### PR TITLE
Reference package names instead

### DIFF
--- a/packages/actor-init-hello-world/lib/ActorInitHelloWorld.ts
+++ b/packages/actor-init-hello-world/lib/ActorInitHelloWorld.ts
@@ -1,5 +1,5 @@
-import {ActorInit, IActionInit, IActorOutputInit} from "@comunica/bus-init/lib/ActorInit";
-import {IActorArgs, IActorTest} from "@comunica/core/lib/Actor";
+import {ActorInit, IActionInit, IActorOutputInit} from "@comunica/bus-init";
+import {IActorArgs, IActorTest} from "@comunica/core";
 import {Duplex, PassThrough, Readable} from "stream";
 
 /**

--- a/packages/actor-init-hello-world/test/ActorInitHelloWorld-test.ts
+++ b/packages/actor-init-hello-world/test/ActorInitHelloWorld-test.ts
@@ -1,5 +1,5 @@
-import {ActorInit, IActorOutputInit} from "@comunica/bus-init/lib/ActorInit";
-import {Bus} from "@comunica/core/lib/Bus";
+import {ActorInit, IActorOutputInit} from "@comunica/bus-init";
+import {Bus} from "@comunica/core";
 import {PassThrough} from "stream";
 import {ActorInitHelloWorld} from "../lib/ActorInitHelloWorld";
 

--- a/packages/bus-init/lib/ActorInit.ts
+++ b/packages/bus-init/lib/ActorInit.ts
@@ -1,5 +1,5 @@
 import {Actor, IAction, IActorOutput, IActorTest} from "@comunica/core";
-import {IActorArgs} from "@comunica/core/lib/Actor";
+import {IActorArgs} from "@comunica/core";
 import {Readable} from "stream";
 
 /**

--- a/packages/runner-cli/bin/run.ts
+++ b/packages/runner-cli/bin/run.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import {IActorOutputInit} from "@comunica/bus-init/lib/ActorInit";
+import {IActorOutputInit} from "@comunica/bus-init";
 import {Setup} from "@comunica/runner";
 
 const argv = process.argv.slice(2);

--- a/packages/runner/lib/Runner.ts
+++ b/packages/runner/lib/Runner.ts
@@ -1,6 +1,6 @@
-import {ActorInit, IActionInit, IActorOutputInit} from "@comunica/bus-init/lib/ActorInit";
-import {Actor, IAction, IActorOutput, IActorTest} from "@comunica/core/lib/Actor";
-import {Bus, IActorReply} from "@comunica/core/lib/Bus";
+import {ActorInit, IActionInit, IActorOutputInit} from "@comunica/bus-init";
+import {Actor, IAction, IActorOutput, IActorTest} from "@comunica/core";
+import {Bus, IActorReply} from "@comunica/core";
 import * as _ from "lodash";
 
 /**

--- a/packages/runner/lib/Setup.ts
+++ b/packages/runner/lib/Setup.ts
@@ -1,9 +1,9 @@
-import {IActionInit} from "@comunica/bus-init/lib/ActorInit";
+import {IActionInit} from "@comunica/bus-init";
 import Bluebird = require("bluebird");
 import cancelableAwaiter = require("cancelable-awaiter");
 import * as _ from "lodash";
 import {Loader} from "lsd-components";
-import {LoaderProperties} from "lsd-components/lib/Loader";
+import {LoaderProperties} from "lsd-components";
 import tslib = require("tslib");
 import {Runner} from "./Runner";
 

--- a/packages/runner/test/Runner-test.ts
+++ b/packages/runner/test/Runner-test.ts
@@ -1,5 +1,5 @@
-import {Actor} from "@comunica/core/lib/Actor";
-import {Bus} from "@comunica/core/lib/Bus";
+import {Actor} from "@comunica/core";
+import {Bus} from "@comunica/core";
 import {Runner} from "../lib/Runner";
 
 describe('Runner', () => {


### PR DESCRIPTION
Some imports were using the internal structure instead of the actual package names.