### PR TITLE
Rewrite script commands to be OS-independent

### DIFF
--- a/packages/actor-init-hello-world/package.json
+++ b/packages/actor-init-hello-world/package.json
@@ -52,10 +52,10 @@
     "mapCoverage": true
   },
   "scripts": {
-    "test": "../../node_modules/.bin/jest --no-cache ${1}",
-    "test-watch": "../../node_modules/.bin/jest ${1} --watch",
-    "lint": "../../node_modules/.bin/tslint lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
-    "build": "../../node_modules/.bin/tsc",
+    "test": "node \"../../node_modules/jest/bin/jest.js\" --no-cache ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
     "validate": "npm ls",
     "prepare": "npm run build"
   }

--- a/packages/bus-init/package.json
+++ b/packages/bus-init/package.json
@@ -34,8 +34,8 @@
     "@comunica/core": "^0.0.1"
   },
   "scripts": {
-    "lint": "../../node_modules/.bin/tslint lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
-    "build": "../../node_modules/.bin/tsc",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
     "validate": "npm ls",
     "prepare": "npm run build"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,10 +48,10 @@
     "mapCoverage": true
   },
   "scripts": {
-    "test": "../../node_modules/.bin/jest --no-cache ${1}",
-    "test-watch": "../../node_modules/.bin/jest ${1} --watch",
-    "lint": "../../node_modules/.bin/tslint lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
-    "build": "../../node_modules/.bin/tsc",
+    "test": "node \"../../node_modules/jest/bin/jest.js\" --no-cache ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
     "validate": "npm ls",
     "prepare": "npm run build"
   }

--- a/packages/runner-cli/package.json
+++ b/packages/runner-cli/package.json
@@ -29,8 +29,8 @@
     "@comunica/core": "^0.0.1"
   },
   "scripts": {
-    "lint": "../../node_modules/.bin/tslint lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
-    "build": "../../node_modules/.bin/tsc",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
     "validate": "npm ls",
     "prepare": "npm run build"
   }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -57,10 +57,10 @@
     "mapCoverage": true
   },
   "scripts": {
-    "test": "../../node_modules/.bin/jest --no-cache ${1}",
-    "test-watch": "../../node_modules/.bin/jest ${1} --watch",
-    "lint": "../../node_modules/.bin/tslint lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
-    "build": "../../node_modules/.bin/tsc",
+    "test": "node \"../../node_modules/jest/bin/jest.js\" --no-cache ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
     "validate": "npm ls",
     "prepare": "npm run build"
   }


### PR DESCRIPTION
By introducing the node command explicity they also work on Windows.