### PR TITLE
[WIP] Actor Profiling

### DIFF
--- a/packages/actor-init-sparql/lib/ActorInitSparql.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql.ts
@@ -86,7 +86,13 @@ Options:
     const result: IActorQueryOperationOutput = await this.mediatorQueryOperation.mediate(resolve);
 
     result.bindingsStream.on('data', (binding) => readable.push(JSON.stringify(binding) + '\n'));
-    result.bindingsStream.on('end', () => readable.push(null));
+    result.bindingsStream.on('end', () => {
+      readable.push(null);
+
+      console.error(Object.keys(Mediator.PROFILING_DURATIONS)
+        .map((key: string) => ({ key, value: Mediator.PROFILING_DURATIONS[key] }))
+        .sort((a, b) => b.value - a.value));
+    });
     const readable = new Readable();
     readable._read = () => {
       return;


### PR DESCRIPTION
WIP: do not merge.

This adds a simple profiling implementation that measures the total active time of each actor.

The problem is that the _total time_ for each actor is measures, not the _self time_.
For instance, actor1 calling actor2 will also include the time of actor2.
If we want to measure this, we would somehow have to pass the actor stack between all mediator calls, so that we know when each actor is actually active, and when it is not. This would however require us to change the signature the `Mediator.mediate` and `Actor.run` methods to include this stack, not sure if there is a cleaner way...

#53 