### PR TITLE
Makes native http calls cancellable

### DIFF
--- a/packages/actor-http-native/package.json
+++ b/packages/actor-http-native/package.json
@@ -44,6 +44,7 @@
     "@comunica/core": "^0.0.1",
     "@comunica/bus-http": "^0.0.1",
     "@comunica/mediatortype-time": "^0.0.1",
+    "@comunica/runner": "^0.0.1",
     "@types/parse-link-header": "^1.0.0"
   },
   "jest": {

--- a/packages/actor-http-native/test/__mocks__/follow-redirects.js
+++ b/packages/actor-http-native/test/__mocks__/follow-redirects.js
@@ -1,4 +1,6 @@
 
+const IncomingMessage = require('http').IncomingMessage;
+
 let options = {
   statusCode: 200
 };
@@ -8,8 +10,8 @@ function mockSetup(mock) {
 }
 
 function request(settings, func) {
-  let body = options.body || {};
-  Object.assign(body, {
+  let body = new IncomingMessage();
+  Object.assign(body, options.body || {}, {
     input: settings,
     setEncoding: () => {},
     headers: options.headers || {},
@@ -18,7 +20,9 @@ function request(settings, func) {
     responseUrl: settings.url,
   });
   setImmediate(() => func(body));
+
   return {
+    abort: () => { },
     end: () => {}
   }
 }

--- a/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
@@ -31,10 +31,10 @@ export class ActorQueryOperationLeftJoinNestedLoop extends ActorQueryOperationTy
         rightStream.on('data', (rightItem) => {
           const join = ActorRdfJoin.join(leftItem, rightItem);
           if (join) {
-            if (pattern.expression) {
-              // TODO: do this once expressions are implemented
-              // Values of both streams can be used for this expression
-            }
+            // if (pattern.expression) {
+            //   // TODO: do this once expressions are implemented
+            //   // Values of both streams can be used for this expression
+            // }
 
             bindingsStream._push(join);
           }


### PR DESCRIPTION
@rubensworks look, more tests!

While I was doing this I also integrated the abort function into the Bluebird cancel, so this should make these requests cancellable. Although I'm not sure if there was a cleaner way to create that promise.