### PR TITLE
Added stats serializer

### DIFF
--- a/packages/actor-init-sparql/config/config-default.json
+++ b/packages/actor-init-sparql/config/config-default.json
@@ -10,6 +10,7 @@
     "https://linkedsoftwaredependencies.org/contexts/comunica-actor-sparql-serialize-sparql-json.jsonld",
     "https://linkedsoftwaredependencies.org/contexts/comunica-actor-sparql-serialize-sparql-xml.jsonld",
     "https://linkedsoftwaredependencies.org/contexts/comunica-actor-sparql-serialize-table.jsonld",
+    "https://linkedsoftwaredependencies.org/contexts/comunica-actor-sparql-serialize-stats.jsonld",
     "https://linkedsoftwaredependencies.org/contexts/comunica-bus-query-operation.jsonld",
     "https://linkedsoftwaredependencies.org/contexts/comunica-actor-query-operation-ask.jsonld",
     "https://linkedsoftwaredependencies.org/contexts/comunica-actor-query-operation-bgp-empty.jsonld",

--- a/packages/actor-sparql-serialize-stats/README.md
+++ b/packages/actor-sparql-serialize-stats/README.md
@@ -1,0 +1,3 @@
+# Comunica Stats Sparql Serialize Actor
+
+Serializes SPARQL results for testing and debugging.

--- a/packages/actor-sparql-serialize-stats/components/Actor/SparqlSerialize/Stats.jsonld
+++ b/packages/actor-sparql-serialize-stats/components/Actor/SparqlSerialize/Stats.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/contexts/comunica-actor-sparql-serialize-stats.jsonld",
+    "https://linkedsoftwaredependencies.org/contexts/comunica-bus-sparql-serialize.jsonld"
+  ],
+  "@id": "npmd:@comunica/actor-sparql-serialize-stats",
+  "components": [
+    {
+      "@id": "casss:Actor/SparqlSerialize/Stats",
+      "@type": "Class",
+      "extends": "cbss:Actor/SparqlSerialize",
+      "requireElement": "ActorSparqlSerializeStats",
+      "comment": "Serializes SPARQL results for testing and debugging.",
+      "constructorArguments": [
+        {
+          "extends": "cbss:Actor/SparqlSerialize/constructorArgumentsObject"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/actor-sparql-serialize-stats/components/components.jsonld
+++ b/packages/actor-sparql-serialize-stats/components/components.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/contexts/comunica-actor-sparql-serialize-stats.jsonld",
+  "@id": "npmd:@comunica/actor-sparql-serialize-stats",
+  "@type": "Module",
+  "requireName": "@comunica/actor-sparql-serialize-stats",
+  "import": [
+    "Actor/SparqlSerialize/Stats.jsonld"
+  ]
+}

--- a/packages/actor-sparql-serialize-stats/components/context.jsonld
+++ b/packages/actor-sparql-serialize-stats/components/context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/contexts/components.jsonld",
+    {
+      "npmd": "https://linkedsoftwaredependencies.org/bundles/npm/",
+      "casss": "npmd:@comunica/actor-sparql-serialize-stats/",
+
+      "ActorSparqlSerializeStats": "casss:Actor/SparqlSerialize/Stats"
+    }
+  ]
+}

--- a/packages/actor-sparql-serialize-stats/index.ts
+++ b/packages/actor-sparql-serialize-stats/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ActorSparqlSerializeStats';

--- a/packages/actor-sparql-serialize-stats/lib/ActorSparqlSerializeStats.ts
+++ b/packages/actor-sparql-serialize-stats/lib/ActorSparqlSerializeStats.ts
@@ -1,0 +1,73 @@
+import {IActorQueryOperationOutputBindings,
+  IActorQueryOperationOutputQuads} from "@comunica/bus-query-operation";
+import {ActorSparqlSerializeFixedMediaTypes, IActionSparqlSerialize,
+  IActorSparqlSerializeFixedMediaTypesArgs, IActorSparqlSerializeOutput} from "@comunica/bus-sparql-serialize";
+import {Readable} from "stream";
+
+/**
+ * Serializes SPARQL results for testing and debugging.
+ */
+export class ActorSparqlSerializeStats extends ActorSparqlSerializeFixedMediaTypes {
+
+  private startTime: [number, number] = process.hrtime();
+  private result: number = 1;
+
+  constructor(args: IActorSparqlSerializeStatsArgs) {
+    super(args);
+    if (args.delay) {
+      this.delay = args.delay;
+    }
+  }
+
+  public async testHandleChecked(action: IActionSparqlSerialize) {
+    if (['bindings', 'quads'].indexOf(action.type) < 0) {
+      throw new Error('This actor can only handle bindings streams or quad streams.');
+    }
+    return true;
+  }
+
+  public pushHeader(data: Readable) {
+    const header: string = ['Result', 'Delay (ms)', // 'Requests (#)'
+    ].join(',');
+    data.push(header + '\n');
+  }
+
+  public pushStat(data: Readable) {
+    const row: string = [this.result++, this.delay(), // this._fragmentsClient.getRequestCount()
+    ].join(',');
+    data.push(row + '\n');
+  }
+
+  public pushFooter(data: Readable) {
+    const footer: string = ['TOTAL', this.delay(), // this._fragmentsClient.getRequestCount()
+    ].join(',');
+    data.push(footer + '\n');
+    data.push(null);
+  }
+
+  public async runHandle(action: IActionSparqlSerialize, mediaType: string): Promise<IActorSparqlSerializeOutput> {
+    const data = new Readable();
+    data._read = () => {
+      return;
+    };
+
+    const resultStream: NodeJS.EventEmitter = action.type === 'bindings' ?
+    (<IActorQueryOperationOutputBindings> action).bindingsStream :
+    (<IActorQueryOperationOutputQuads> action).quadStream;
+    this.pushHeader(data);
+    resultStream.on('data', () => this.pushStat(data));
+    resultStream.on('end', () => this.pushFooter(data));
+
+    return { data };
+  }
+
+  private delay = function()  {
+    const time: [number, number] = process.hrtime(this.startTime);
+    return time[0] * 1000 + (time[1] / 1000000);
+  };
+
+}
+
+export interface IActorSparqlSerializeStatsArgs extends IActorSparqlSerializeFixedMediaTypesArgs {
+  delay(): number;
+}

--- a/packages/actor-sparql-serialize-stats/package.json
+++ b/packages/actor-sparql-serialize-stats/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@comunica/actor-sparql-serialize-stats",
+  "version": "0.0.1",
+  "description": "A stats sparql-serialize actor",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-sparql-serialize-stats",
+  "lsd:components": "components/components.jsonld",
+  "lsd:contexts": {
+    "https://linkedsoftwaredependencies.org/contexts/comunica-actor-sparql-serialize-stats.jsonld": "components/context.jsonld"
+  },
+  "main": "index.js",
+  "typings": "index",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/comunica/actor-sparql-serialize-stats.git"
+  },
+  "keywords": [
+    "comunica",
+    "actor",
+    "sparql-serialize",
+    "stats"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/actor-sparql-serialize-stats/issues"
+  },
+  "homepage": "https://github.com/comunica/actor-sparql-serialize-stats#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@comunica/core": "^0.0.1",
+    "@comunica/bus-sparql-serialize": "^0.0.1"
+  },
+  "devDependencies": {
+    "@comunica/core": "^0.0.1",
+    "@comunica/bus-query-operation": "^0.0.1",
+    "@comunica/bus-sparql-serialize": "^0.0.1"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+    },
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
+    ],
+    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true,
+    "mapCoverage": true
+  },
+  "scripts": {
+    "test": "node \"../../node_modules/jest/bin/jest.js\" ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls",
+    "prepare": "npm run build"
+  }
+}

--- a/packages/actor-sparql-serialize-stats/test/ActorSparqlSerializeStats-test.ts
+++ b/packages/actor-sparql-serialize-stats/test/ActorSparqlSerializeStats-test.ts
@@ -20,7 +20,6 @@ describe('ActorSparqlSerializeStats', () => {
 
     it('should be a ActorSparqlSerializeStats constructor', () => {
       expect(new (<any> ActorSparqlSerializeStats)({ name: 'actor', bus })).toBeInstanceOf(ActorSparqlSerializeStats);
-      // expect(new (<any> ActorSparqlSerializeStats)({ name: 'actor', bus })).toBeInstanceOf(ActorSparqlSerialize);
     });
 
     it('should not be able to create new ActorSparqlSerializeStats objects without \'new\'', () => {
@@ -34,9 +33,12 @@ describe('ActorSparqlSerializeStats', () => {
     let quadStream;
 
     beforeEach(() => {
-      actor = new ActorSparqlSerializeStats({ bus, delay: () => 3.14, mediaTypes: {
+      actor = new ActorSparqlSerializeStats({ bus, mediaTypes: {
         debug: 1.0,
       }, name: 'actor'});
+
+      actor.delay = () => 3.14;
+
       bindingsStream = new ArrayIterator([
         Bindings({ k1: namedNode('v1'), k2: null }),
         Bindings({ k1: null, k2: namedNode('v2') }),

--- a/packages/actor-sparql-serialize-stats/test/ActorSparqlSerializeStats-test.ts
+++ b/packages/actor-sparql-serialize-stats/test/ActorSparqlSerializeStats-test.ts
@@ -37,8 +37,6 @@ describe('ActorSparqlSerializeStats', () => {
         debug: 1.0,
       }, name: 'actor'});
 
-      actor.delay = () => 3.14;
-
       bindingsStream = new ArrayIterator([
         Bindings({ k1: namedNode('v1'), k2: null }),
         Bindings({ k1: null, k2: namedNode('v2') }),
@@ -60,7 +58,17 @@ describe('ActorSparqlSerializeStats', () => {
       });
     });
 
+    describe('for calculating delay', () => {
+      it('should return number greater than 0', () => {
+        return expect(actor.delay(process.hrtime())).toBeGreaterThan(0);
+      });
+    });
+
     describe('for serializing', () => {
+      beforeEach(() => {
+        actor.delay = () => 3.14;
+      });
+
       it('should test on table', () => {
         return expect(actor.test({ handle: <any> { type: 'quads', quadStream },
           handleMediaType: 'debug' })).resolves.toBeTruthy();

--- a/packages/actor-sparql-serialize-stats/test/ActorSparqlSerializeStats-test.ts
+++ b/packages/actor-sparql-serialize-stats/test/ActorSparqlSerializeStats-test.ts
@@ -1,0 +1,103 @@
+import {Bindings, BindingsStream} from "@comunica/bus-query-operation";
+import {Bus} from "@comunica/core";
+import {ArrayIterator} from "asynciterator";
+import {namedNode} from "rdf-data-model";
+import {ActorSparqlSerializeStats} from "../lib/ActorSparqlSerializeStats";
+const quad = require('rdf-quad');
+const stringifyStream = require('stream-to-string');
+
+describe('ActorSparqlSerializeStats', () => {
+  let bus;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+  });
+
+  describe('The ActorSparqlSerializeStats module', () => {
+    it('should be a function', () => {
+      expect(ActorSparqlSerializeStats).toBeInstanceOf(Function);
+    });
+
+    it('should be a ActorSparqlSerializeStats constructor', () => {
+      expect(new (<any> ActorSparqlSerializeStats)({ name: 'actor', bus })).toBeInstanceOf(ActorSparqlSerializeStats);
+      // expect(new (<any> ActorSparqlSerializeStats)({ name: 'actor', bus })).toBeInstanceOf(ActorSparqlSerialize);
+    });
+
+    it('should not be able to create new ActorSparqlSerializeStats objects without \'new\'', () => {
+      expect(() => { (<any> ActorSparqlSerializeStats)(); }).toThrow();
+    });
+  });
+
+  describe('An ActorSparqlSerializeStats instance', () => {
+    let actor: ActorSparqlSerializeStats;
+    let bindingsStream: BindingsStream;
+    let quadStream;
+
+    beforeEach(() => {
+      actor = new ActorSparqlSerializeStats({ bus, delay: () => 3.14, mediaTypes: {
+        debug: 1.0,
+      }, name: 'actor'});
+      bindingsStream = new ArrayIterator([
+        Bindings({ k1: namedNode('v1'), k2: null }),
+        Bindings({ k1: null, k2: namedNode('v2') }),
+      ]);
+      quadStream = new ArrayIterator([
+        quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
+        quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
+      ]);
+    });
+    describe('for getting media types', () => {
+      it('should test', () => {
+        return expect(actor.test({ mediaTypes: true })).resolves.toBeTruthy();
+      });
+
+      it('should run', () => {
+        return expect(actor.run({ mediaTypes: true })).resolves.toEqual({ mediaTypes: {
+          debug: 1.0,
+        }});
+      });
+    });
+
+    describe('for serializing', () => {
+      it('should test on table', () => {
+        return expect(actor.test({ handle: <any> { type: 'quads', quadStream },
+          handleMediaType: 'debug' })).resolves.toBeTruthy();
+      });
+
+      it('should not test on N-Triples', () => {
+        return expect(actor.test({ handle: <any> { type: 'quads', quadStream },
+          handleMediaType: 'application/n-triples' }))
+        .rejects.toBeTruthy();
+      });
+
+      it('should not test on unknown types', () => {
+        return expect(actor.test(
+        { handle: <any> { type: 'unknown' }, handleMediaType: 'debug' }))
+        .rejects.toBeTruthy();
+      });
+
+      // tslint:disable:no-trailing-whitespace
+      it('should run on a bindings stream', async () => {
+        return expect((await stringifyStream((await actor.run(
+        {handle: <any> { type: 'bindings', bindingsStream }, handleMediaType: 'debug'})
+        ).handle.data))).toEqual(
+        `Result,Delay (ms)
+1,3.14
+2,3.14
+TOTAL,3.14
+`);
+      });
+
+      it('should run on a quad stream', async () => {
+        return expect((await stringifyStream((await actor.run(
+          { handle: <any> { type: 'quads', quadStream },
+            handleMediaType: 'debug' })).handle.data))).toEqual(
+        `Result,Delay (ms)
+1,3.14
+2,3.14
+TOTAL,3.14
+`);
+      });
+    });
+  });
+});

--- a/packages/actor-sparql-serialize-stats/test/tsconfig.json
+++ b/packages/actor-sparql-serialize-stats/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ]
+  }
+}
+

--- a/packages/actor-sparql-serialize-stats/test/tslint.json
+++ b/packages/actor-sparql-serialize-stats/test/tslint.json
@@ -1,0 +1,11 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "../tslint.json"
+  ],
+  "rules": {
+    "no-var-requires": false,
+    "no-unused-expression": false
+  }
+}
+

--- a/packages/actor-sparql-serialize-stats/tsconfig.json
+++ b/packages/actor-sparql-serialize-stats/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/actor-sparql-serialize-stats/tslint.json
+++ b/packages/actor-sparql-serialize-stats/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}


### PR DESCRIPTION
This PR adds a serializer for evaluation or debugging purposes. 

TODO: implement the per-result request count, when the right method way to obtain that number is found.