### PR TITLE
Add BGP left-deep-smallest-sort Query Operation Actor

### DIFF
--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -106,6 +106,7 @@
     "streamify-string": "^1.0.1"
   },
   "devDependencies": {
+    "@comunica/actor-query-operation-bgp-left-deep-smallest-sort": "^0.0.1",
     "@comunica/actor-rdf-resolve-quad-pattern-file": "^0.0.1",
     "@comunica/actor-rdf-resolve-quad-pattern-hdt": "^0.0.1",
     "lodash.assign": "^4.2.0",

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/README.md
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/README.md
@@ -1,0 +1,3 @@
+# Comunica BGP left-deep-smallest-sort Query Operation Actor
+
+A comunica Query Operation Actor that resolves BGPs in a left-deep manner based on the pattern with the smallest item count and sorts the remaining patterns by increasing count.

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/components/Actor/QueryOperation/BgpLeftDeepSmallestSort.jsonld
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/components/Actor/QueryOperation/BgpLeftDeepSmallestSort.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/contexts/comunica-actor-query-operation-bgp-left-deep-smallest-sort.jsonld",
+    "https://linkedsoftwaredependencies.org/contexts/comunica-bus-query-operation.jsonld"
+  ],
+  "@id": "npmd:@comunica/actor-query-operation-bgp-left-deep-smallest-sort",
+  "components": [
+    {
+      "@id": "caqobldss:Actor/QueryOperation/BgpLeftDeepSmallestSort",
+      "@type": "Class",
+      "extends": "cbqo:Actor/QueryOperationTypedMediated",
+      "requireElement": "ActorQueryOperationBgpLeftDeepSmallestSort",
+      "comment": "A comunica Query Operation Actor that resolves BGPs in a left-deep manner based on the pattern with the smallest item count and sorts the remaining patterns by increasing count.",
+      "constructorArguments": [
+        {
+          "extends": "cbqo:Actor/QueryOperationTypedMediated/constructorArgumentsObject"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/components/components.jsonld
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/components/components.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/contexts/comunica-actor-query-operation-bgp-left-deep-smallest-sort.jsonld",
+  "@id": "npmd:@comunica/actor-query-operation-bgp-left-deep-smallest-sort",
+  "@type": "Module",
+  "requireName": "@comunica/actor-query-operation-bgp-left-deep-smallest-sort",
+  "import": [
+    "Actor/QueryOperation/BgpLeftDeepSmallestSort.jsonld"
+  ]
+}

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/components/context.jsonld
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/components/context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/contexts/components.jsonld",
+    {
+      "npmd": "https://linkedsoftwaredependencies.org/bundles/npm/",
+      "caqobldss": "npmd:@comunica/actor-query-operation-bgp-left-deep-smallest-sort/",
+
+      "ActorQueryOperationBgpLeftDeepSmallestSort": "caqobldss:Actor/QueryOperation/BgpLeftDeepSmallestSort"
+    }
+  ]
+}

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/index.ts
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ActorQueryOperationBgpLeftDeepSmallestSort';

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/lib/ActorQueryOperationBgpLeftDeepSmallestSort.ts
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/lib/ActorQueryOperationBgpLeftDeepSmallestSort.ts
@@ -1,0 +1,230 @@
+import {
+  ActorQueryOperation,
+  ActorQueryOperationTypedMediated,
+  Bindings,
+  BindingsStream,
+  IActorQueryOperationOutput,
+  IActorQueryOperationOutputBindings,
+  IActorQueryOperationTypedMediatedArgs,
+} from "@comunica/bus-query-operation";
+import {IActorTest} from "@comunica/core";
+import {EmptyIterator, MultiTransformIterator} from "asynciterator";
+import {PromiseProxyIterator} from "asynciterator-promiseproxy";
+import * as RDF from "rdf-js";
+import {termToString} from "rdf-string";
+import {mapTerms} from "rdf-terms";
+import {Algebra} from "sparqlalgebrajs";
+
+/**
+ * A comunica Query Operation Actor that resolves BGPs in a left-deep manner
+ * based on the pattern with the smallest item count and sorts the remaining patterns by increasing count.
+ */
+export class ActorQueryOperationBgpLeftDeepSmallestSort extends ActorQueryOperationTypedMediated<Algebra.Bgp> {
+
+  constructor(args: IActorQueryOperationTypedMediatedArgs) {
+    super(args, 'bgp');
+  }
+
+  /**
+   * Create a new bindings stream
+   * that takes every binding of the base stream,
+   * materializes the remaining patterns with it,
+   * and emits all bindings from this new set of patterns.
+   * @param {BindingsStream} baseStream The base stream.
+   * @param {Algebra.Pattern[]} patterns The patterns to materialize with each binding of the base stream.
+   * @param {(patterns: Algebra.Pattern[]) => Promise<IActorQueryOperationOutput>} patternBinder A callback
+   * to retrieve the bindings stream of an array of patterns.
+   * @return {BindingsStream}
+   */
+  public static createLeftDeepStream(baseStream: BindingsStream, patterns: Algebra.Pattern[],
+                                     patternBinder: (patterns: Algebra.Pattern[]) =>
+                                       Promise<BindingsStream>): BindingsStream {
+    const bindingsStream: MultiTransformIterator<Bindings, Bindings> = new MultiTransformIterator(baseStream);
+    bindingsStream._createTransformer = (bindings: Bindings) => {
+      const bindingsMerger = (subBindings: Bindings) => subBindings.merge(bindings);
+      return new PromiseProxyIterator(
+        async () => (await patternBinder(ActorQueryOperationBgpLeftDeepSmallestSort.materializePatterns(patterns,
+          bindings))).map(bindingsMerger), { autoStart: true, maxBufferSize: 128 });
+    };
+    return bindingsStream;
+  }
+
+  /**
+   * Get the combined list of variables of the given pattern outputs.
+   * @param {IActorQueryOperationOutput[]} patternOutputs An array of query operation outputs
+   * @return {string[]} The array of variable names.
+   */
+  public static getCombinedVariables(patternOutputs: IActorQueryOperationOutputBindings[]): string[] {
+    return require('lodash.uniq')([].concat.apply([],
+      patternOutputs.map((patternOutput) => patternOutput.variables)));
+  }
+
+  /**
+   * Sort the given patterns and metadata by increasing estimated count.
+   * @param {IOutputMetaTuple[]} patternOutputsMeta An array of pattern output and metadata tuples.
+   * @return {IOutputMetaTuple[]} The sorted array.
+   */
+  public static sortPatterns(patternOutputsMeta: IOutputMetaTuple[]): IOutputMetaTuple[] {
+    return require('lodash.sortby')(patternOutputsMeta, [(e: IOutputMetaTuple) => {
+      return ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems(e.meta);
+    }]);
+  }
+
+  /**
+   * Estimate an upper bound for the total number of items from the given metadata.
+   * @param {{[p: string]: any}} smallestPattern The optional metadata for the pattern
+   *                                             with the smallest number of elements.
+   * @param {{[p: string]: any}[]} otherPatterns The array of optional metadata for the other patterns.
+   * @return {number} The estimated number of total items.
+   */
+  public static estimateCombinedTotalItems(smallestPattern: {[id: string]: any},
+                                           otherPatterns: {[id: string]: any}[]): number {
+    const smallestCount: number = ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems(smallestPattern);
+    return otherPatterns
+      .map((otherPattern) => smallestCount * ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems(
+        otherPattern))
+      .reduce((sum, element) => sum + element, 0);
+  }
+
+  /**
+   * Get the estimated number of items from the given metadata.
+   * @param {{[p: string]: any}} metadata An optional metadata object.
+   * @return {number} The estimated number of items, or `Infinity` if metadata is falsy.
+   */
+  public static getTotalItems(metadata?: {[id: string]: any}): number {
+    const totalItems: number = (metadata || {}).totalItems;
+    return totalItems || totalItems === 0 ? totalItems : Infinity;
+  }
+
+  /**
+   * Materialize all patterns in the given pattern array with the given bindings.
+   * @param {Pattern[]} patterns SPARQL algebra patterns.
+   * @param {Bindings} bindings A bindings object.
+   * @return {Pattern[]} A new array where each input pattern is materialized.
+   */
+  public static materializePatterns(patterns: Algebra.Pattern[], bindings: Bindings): Algebra.Pattern[] {
+    return patterns.map((pattern) => ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(
+      pattern, bindings));
+  }
+
+  /**
+   * Materialize a pattern with the given bindings.
+   * @param {Pattern} pattern A SPARQL algebra pattern.
+   * @param {Bindings} bindings A bindings object.
+   * @return {Pattern} A new materialized pattern.
+   */
+  public static materializePattern(pattern: Algebra.Pattern, bindings: Bindings): Algebra.Pattern {
+    return <Algebra.Pattern> Object.assign(mapTerms(pattern,
+      (term: RDF.Term) => ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(term, bindings)),
+      { type: 'pattern' });
+  }
+
+  /**
+   * Materialize a term with the given binding.
+   *
+   * If the given term is a variable (or blank node)
+   * and that variable exist in the given bindings object,
+   * the value of that binding is returned.
+   * In all other cases, the term itself is returned.
+   *
+   * @param {RDF.Term} term A term.
+   * @param {Bindings} bindings A bindings object.
+   * @return {RDF.Term} The materialized term.
+   */
+  public static materializeTerm(term: RDF.Term, bindings: Bindings): RDF.Term {
+    if (term.termType === 'Variable' || term.termType === 'BlankNode') {
+      const value: RDF.Term = bindings.get(termToString(term));
+      if (value) {
+        return value;
+      }
+    }
+    return term;
+  }
+
+  /**
+   * Check if at least one of the given outputs has an empty output, i.e., when the estimated count is zero.
+   * @param {IActorQueryOperationOutputBindings[]} patternOutputs Pattern outputs.
+   * @return {Promise<boolean>} A promise for indicating whether or not at least one of the outputs is empty.
+   */
+  public static async hasOneEmptyPatternOutput(patternOutputs: IActorQueryOperationOutputBindings[]): Promise<boolean> {
+    for (const patternOutput of patternOutputs) {
+      if (patternOutput.metadata) {
+        const metadata: {[id: string]: any} = await patternOutput.metadata();
+        if (!ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems(metadata)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  public async testOperation(pattern: Algebra.Bgp, context?: {[id: string]: any}): Promise<IActorTest> {
+    if (pattern.patterns.length < 2) {
+      throw new Error('Actor ' + this.name + ' can only operate on BGPs with at least two patterns.');
+    }
+    return true;
+  }
+
+  public async runOperation(pattern: Algebra.Bgp, context?: {[id: string]: any})
+  : Promise<IActorQueryOperationOutputBindings> {
+    // Get the total number of items for all patterns by resolving the quad patterns
+    const patternOutputs: IActorQueryOperationOutputBindings[] = (await Promise.all(pattern.patterns
+      .map((subPattern: Algebra.Pattern) => this.mediatorQueryOperation.mediate(
+        { operation: subPattern, context }))))
+      .map(ActorQueryOperation.getSafeBindings);
+
+    // If a triple pattern has no matches, the entire graph pattern has no matches.
+    if (await ActorQueryOperationBgpLeftDeepSmallestSort.hasOneEmptyPatternOutput(patternOutputs)) {
+      return {
+        bindingsStream: new EmptyIterator(),
+        metadata: () => Promise.resolve({ totalItems: 0 }),
+        type: 'bindings',
+        variables: [],
+      };
+    }
+
+    // Resolve the metadata for all patterns
+    const metadatas: {[id: string]: any}[] = await Promise.all(patternOutputs.map(
+      async (patternOutput) => patternOutput.metadata ? await patternOutput.metadata() : {}));
+
+    // Sort patterns by increasing total items
+    const outputMetaTuples: IOutputMetaTuple[] = ActorQueryOperationBgpLeftDeepSmallestSort.sortPatterns(
+      patternOutputs.map((output: IActorQueryOperationOutputBindings, i: number) =>
+        ({ input: pattern.patterns[i], output, meta: metadatas[i] })));
+
+    // Close the non-smallest streams
+    for (let i: number = 1; i < outputMetaTuples.length; i++) {
+      outputMetaTuples[i].output.bindingsStream.close();
+    }
+
+    // Take the pattern with the smallest number of items
+    const smallestPattern: IOutputMetaTuple = outputMetaTuples.slice(0)[0];
+    outputMetaTuples.splice(0, 1);
+
+    // Materialize the remaining patterns for each binding in the stream.
+    const bindingsStream: BindingsStream = ActorQueryOperationBgpLeftDeepSmallestSort.createLeftDeepStream(
+      smallestPattern.output.bindingsStream, outputMetaTuples.map((p) => p.input),
+      async (patterns: Algebra.Pattern[]) => {
+        // Send the materialized patterns to the mediator for recursive BGP evaluation.
+        const operation: Algebra.Bgp = { type: 'bgp', patterns };
+        return ActorQueryOperation.getSafeBindings(await this.mediatorQueryOperation.mediate({ operation, context }))
+          .bindingsStream;
+      });
+
+    // Prepare variables and metadata
+    const variables: string[] = ActorQueryOperationBgpLeftDeepSmallestSort.getCombinedVariables(patternOutputs);
+    const metadata = () => Promise.resolve({
+      totalItems: ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(smallestPattern.meta,
+        outputMetaTuples.map((p) => p.meta)),
+    });
+
+    return { type: 'bindings', bindingsStream, variables, metadata };
+  }
+
+}
+
+export interface IOutputMetaTuple {
+  input: Algebra.Pattern;
+  output: IActorQueryOperationOutputBindings;
+  meta: {[id: string]: any};
+}

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/package.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@comunica/actor-query-operation-bgp-left-deep-smallest-sort",
+  "version": "0.0.1",
+  "description": "A bgp-left-deep-smallest-sort query-operation actor",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-bgp-left-deep-smallest-sort",
+  "lsd:components": "components/components.jsonld",
+  "lsd:contexts": {
+    "https://linkedsoftwaredependencies.org/contexts/comunica-actor-query-operation-bgp-left-deep-smallest-sort.jsonld": "components/context.jsonld"
+  },
+  "main": "index.js",
+  "typings": "index",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/comunica/actor-query-operation-bgp-left-deep-smallest-sort.git"
+  },
+  "keywords": [
+    "comunica",
+    "actor",
+    "query-operation",
+    "bgp-left-deep-smallest-sort"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/actor-query-operation-bgp-left-deep-smallest-sort/issues"
+  },
+  "homepage": "https://github.com/comunica/actor-query-operation-bgp-left-deep-smallest-sort#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "dependencies": {
+    "asynciterator-promiseproxy": "^1.1.0",
+    "lodash.uniq": "^4.5.0",
+    "lodash.sortby": "^4.7.0",
+    "rdf-string": "^1.0.1",
+    "rdf-terms":"^1.0.1"
+  },
+  "peerDependencies": {
+    "@comunica/core": "^0.0.1",
+    "@comunica/bus-query-operation": "^0.0.1"
+  },
+  "devDependencies": {
+    "@comunica/core": "^0.0.1",
+    "@comunica/bus-query-operation": "^0.0.1"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+    },
+    "transformIgnorePatterns": [
+      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
+    ],
+    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true
+  },
+  "scripts": {
+    "test": "node \"../../node_modules/jest/bin/jest.js\" ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/test/ActorQueryOperationBgpLeftDeepSmallestSort-test.ts
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/test/ActorQueryOperationBgpLeftDeepSmallestSort-test.ts
@@ -1,0 +1,542 @@
+import {ActorQueryOperation, Bindings, IActorQueryOperationOutputBindings} from "@comunica/bus-query-operation";
+import {Bus} from "@comunica/core";
+import {ArrayIterator, EmptyIterator, SingletonIterator} from "asynciterator";
+import {blankNode, defaultGraph, literal, namedNode, quad, variable} from "rdf-data-model";
+import {Algebra} from "sparqlalgebrajs";
+import {ActorQueryOperationBgpLeftDeepSmallestSort} from "../lib/ActorQueryOperationBgpLeftDeepSmallestSort";
+const arrayifyStream = require('arrayify-stream');
+
+describe('ActorQueryOperationBgpLeftDeepSmallestSort', () => {
+  let bus;
+  let mediatorQueryOperation;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+    mediatorQueryOperation = {
+      mediate: (arg) => Promise.resolve({
+        bindingsStream: new SingletonIterator(Bindings({
+          graph: arg.operation.graph,
+          object: arg.operation.object,
+          predicate: arg.operation.predicate,
+          subject: arg.operation.subject,
+        })),
+        metadata: () => Promise.resolve({ totalItems: (arg.context || {}).totalItems }),
+        type: 'bindings',
+        variables: (arg.context || {}).variables || [],
+      }),
+    };
+  });
+
+  describe('The ActorQueryOperationBgpLeftDeepSmallestSort module', () => {
+    it('should be a function', () => {
+      expect(ActorQueryOperationBgpLeftDeepSmallestSort).toBeInstanceOf(Function);
+    });
+
+    it('should be a ActorQueryOperationBgpLeftDeepSmallestSort constructor', () => {
+      expect(new (<any> ActorQueryOperationBgpLeftDeepSmallestSort)({ name: 'actor', bus, mediatorQueryOperation }))
+        .toBeInstanceOf(ActorQueryOperationBgpLeftDeepSmallestSort);
+      expect(new (<any> ActorQueryOperationBgpLeftDeepSmallestSort)({ name: 'actor', bus, mediatorQueryOperation }))
+        .toBeInstanceOf(ActorQueryOperation);
+    });
+
+    it('should not be able to create new ActorQueryOperationBgpLeftDeepSmallestSort objects without \'new\'', () => {
+      expect(() => { (<any> ActorQueryOperationBgpLeftDeepSmallestSort)(); }).toThrow();
+    });
+  });
+
+  describe('Static ActorQueryOperationBgpLeftDeepSmallestSort', () => {
+    const termNamedNode = namedNode('a');
+    const termLiteral = literal('b');
+    const termVariableA = variable('a');
+    const termVariableB = variable('b');
+    const termVariableC = blankNode('c');
+    const termVariableD = blankNode('d');
+    const termDefaultGraph = defaultGraph();
+
+    const patternMaterialized: any = Object.assign(quad(termNamedNode, termNamedNode, termNamedNode, termNamedNode),
+      { type: "pattern" });
+    const patternVarS: any = Object.assign(quad(termVariableC, termNamedNode, termNamedNode, termNamedNode),
+      { type: "pattern" });
+    const patternVarP: any = Object.assign(quad(termNamedNode, termVariableC, termNamedNode, termNamedNode),
+      { type: "pattern" });
+    const patternVarO: any = Object.assign(quad(termNamedNode, termNamedNode, termVariableC, termNamedNode),
+      { type: "pattern" });
+    const patternVarG: any = Object.assign(quad(termNamedNode, termNamedNode, termNamedNode, termVariableC),
+      { type: "pattern" });
+    const patternVarAll: any = Object.assign(quad(termVariableC, termVariableC, termVariableC, termVariableC),
+      { type: "pattern" });
+    const patternVarMixed: any = Object.assign(quad(termVariableA, termVariableB, termVariableC, termVariableD),
+      { type: "pattern" });
+
+    const valueA = literal('A');
+    const valueC = literal('C');
+
+    const bindingsEmpty = Bindings({});
+    const bindingsA = Bindings({ '?a': literal('A') });
+    const bindingsC = Bindings({ '_:c': literal('C') });
+    const bindingsAC = Bindings({ '?a': valueA, '_:c': valueC });
+
+    describe('materializeTerm', () => {
+      it('should not materialize a named node with empty bindings', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termNamedNode, bindingsEmpty))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a named node with bindings for a', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termNamedNode, bindingsA))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a named node with bindings for c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termNamedNode, bindingsC))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a named node with bindings for a and c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termNamedNode, bindingsAC))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a literal with empty bindings', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termLiteral, bindingsEmpty))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a literal with bindings for a', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termLiteral, bindingsA))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a literal with bindings for c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termLiteral, bindingsC))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a literal with bindings for a and c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termLiteral, bindingsAC))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a variable with empty bindings', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termVariableC, bindingsEmpty))
+          .toEqual(termVariableC);
+      });
+
+      it('should not materialize a variable with bindings for a', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termVariableC, bindingsA))
+          .toEqual(termVariableC);
+      });
+
+      it('should materialize a variable with bindings for c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termVariableC, bindingsC))
+          .toEqual(valueC);
+      });
+
+      it('should materialize a variable with bindings for a and c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termVariableC, bindingsAC))
+          .toEqual(valueC);
+      });
+
+      it('should not materialize a default graph with empty bindings', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termDefaultGraph, bindingsEmpty))
+          .toEqual(termDefaultGraph);
+      });
+
+      it('should not materialize a default graph with bindings for a', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termDefaultGraph, bindingsA))
+          .toEqual(termDefaultGraph);
+      });
+
+      it('should not materialize a default graph with bindings for c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termDefaultGraph, bindingsC))
+          .toEqual(termDefaultGraph);
+      });
+
+      it('should not materialize a default graph with bindings for a and c', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializeTerm(termDefaultGraph, bindingsAC))
+          .toEqual(termDefaultGraph);
+      });
+    });
+
+    describe('materializePattern', () => {
+      it('should not materialize a pattern without variables', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(patternMaterialized, bindingsAC))
+          .toEqual(patternMaterialized);
+      });
+
+      it('should materialize a pattern with variable subject', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(patternVarS, bindingsAC))
+          .toEqual(Object.assign(quad(valueC, termNamedNode, termNamedNode, termNamedNode),
+            { type: "pattern" }));
+      });
+
+      it('should materialize a pattern with variable predicate', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(patternVarP, bindingsAC))
+          .toEqual(Object.assign(quad(termNamedNode, valueC, termNamedNode, termNamedNode),
+            { type: "pattern" }));
+      });
+
+      it('should materialize a pattern with variable object', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(patternVarO, bindingsAC))
+          .toEqual(Object.assign(quad(termNamedNode, termNamedNode, valueC, termNamedNode),
+            { type: "pattern" }));
+      });
+
+      it('should materialize a pattern with variable graph', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(patternVarG, bindingsAC))
+          .toEqual(Object.assign(quad(termNamedNode, termNamedNode, termNamedNode, valueC),
+            { type: "pattern" }));
+      });
+
+      it('should materialize a pattern with all variables', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(patternVarAll, bindingsAC))
+          .toEqual(Object.assign(quad(valueC, valueC, valueC, valueC),
+            { type: "pattern" }));
+      });
+
+      it('should partially materialize a pattern with mixed variables', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePattern(patternVarMixed, bindingsAC))
+          .toEqual(Object.assign(quad(valueA, termVariableB, valueC, termVariableD),
+            { type: "pattern" }));
+      });
+    });
+
+    describe('materializePatterns', () => {
+      it('should materialize no patterns in an empty array', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePatterns([], bindingsAC)).toEqual([]);
+      });
+
+      it('should materialize all patterns in a non-empty array', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.materializePatterns([patternVarS, patternVarP],
+          bindingsAC)).toEqual([
+            Object.assign(quad(valueC, termNamedNode, termNamedNode, termNamedNode),
+            { type: "pattern" }),
+            Object.assign(quad(termNamedNode, valueC, termNamedNode, termNamedNode),
+            { type: "pattern" }),
+          ]);
+      });
+    });
+
+    describe('getTotalItems', () => {
+      it('should return Infinity when no metadata is given', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems()).toBe(Infinity);
+      });
+
+      it('should return Infinity when a falsy metadata is given', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems(null)).toBe(Infinity);
+      });
+
+      it('should return Infinity when an empty metadata is given', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems({})).toBe(Infinity);
+      });
+
+      it('should return Infinity when a metadata with value Infinity is given', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems({ totalItems: Infinity }))
+          .toBe(Infinity);
+      });
+
+      it('should return 10 when a metadata with value 10 is given', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getTotalItems({ totalItems: 10 }))
+          .toBe(10);
+      });
+    });
+
+    describe('estimateCombinedTotalItems', () => {
+      it('should return Infinity when no metadata is present', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          null, [null])).toBe(Infinity);
+      });
+
+      it('should return Infinity when no smallest metadata is present', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          null, [{ totalItems: 10 }])).toBe(Infinity);
+      });
+
+      it('should return Infinity when no other metadata is present', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 10 }, [null])).toBe(Infinity);
+      });
+
+      it('should return Infinity when smallest metadata is has infinity', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: Infinity }, [{ totalItems: 10 }])).toBe(Infinity);
+      });
+
+      it('should return Infinity when other metadata is has infinity', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 10 }, [{ totalItems: Infinity }])).toBe(Infinity);
+      });
+
+      it('should return Infinity when other one metadata is has infinity', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 10 }, [{ totalItems: 10 }, { totalItems: Infinity }, { totalItems: 20 }])).toBe(Infinity);
+      });
+
+      it('should return 10 when with smallest metadata 2 and other metadata 5', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 2 }, [{ totalItems: 5 }])).toBe(10);
+      });
+
+      it('should return 30 when with smallest metadata 2 and other metadata 5 and 10', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 2 }, [{ totalItems: 5 }, { totalItems: 10 }])).toBe(30);
+      });
+
+      it('should return 30 when with smallest metadata 2 and other metadata 10 and 5', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 2 }, [{ totalItems: 10 }, { totalItems: 5 }])).toBe(30);
+      });
+
+      it('should return 0 when with smallest metadata 0 and other metadata 10 and 5', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 0 }, [{ totalItems: 10 }, { totalItems: 5 }])).toBe(0);
+      });
+
+      it('should return 50 when with smallest metadata 2 and other metadata 0 and 5', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.estimateCombinedTotalItems(
+          { totalItems: 10 }, [{ totalItems: 0 }, { totalItems: 5 }])).toBe(50);
+      });
+    });
+
+    describe('sortPatterns', () => {
+      it('should return an empty array for no patterns', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.sortPatterns(
+          [])).toEqual([]);
+      });
+
+      it('should sort an unsorted by increasing totalItems', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.sortPatterns([
+          {
+            input: <any> 'I1',
+            meta: null,
+            output: <any> 'O1',
+          },
+          {
+            input: <any> 'I1',
+            meta: { totalItems: 10 },
+            output: <any> 'O1',
+          },
+          {
+            input: <any> 'I1',
+            meta: { totalItems: 0 },
+            output: <any> 'O1',
+          },
+          {
+            input: <any> 'I1',
+            meta: { totalItems: Infinity },
+            output: <any> 'O1',
+          },
+        ])).toEqual([
+          {
+            input: <any> 'I1',
+            meta: { totalItems: 0 },
+            output: <any> 'O1',
+          },
+          {
+            input: <any> 'I1',
+            meta: { totalItems: 10 },
+            output: <any> 'O1',
+          },
+          {
+            input: <any> 'I1',
+            meta: null,
+            output: <any> 'O1',
+          },
+          {
+            input: <any> 'I1',
+            meta: { totalItems: Infinity },
+            output: <any> 'O1',
+          },
+        ]);
+      });
+    });
+
+    describe('getCombinedVariables', () => {
+      it('should return an empty array for no variables', () => {
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getCombinedVariables(
+          [])).toEqual([]);
+      });
+
+      it('should return an empty array for outputs without variables', () => {
+        const data: any = [{ variables: [] }, { variables: [] }];
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getCombinedVariables(
+          data)).toEqual([]);
+      });
+
+      it('should return [a] for one output with one variable a', () => {
+        const data: any = [{ variables: ['a'] }];
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getCombinedVariables(
+          data)).toEqual(['a']);
+      });
+
+      it('should return [a, b, c] for output with variables a, b and b, c', () => {
+        const data: any = [{ variables: ['a', 'b'] }, { variables: ['b', 'c'] }];
+        return expect(ActorQueryOperationBgpLeftDeepSmallestSort.getCombinedVariables(
+          data)).toEqual(['a', 'b', 'c']);
+      });
+    });
+
+    describe('createLeftDeepStream', () => {
+      const binder: any = (patterns) => new SingletonIterator(Bindings({
+        graph: patterns[0].graph,
+        object: patterns[1].object,
+        predicate: patterns[2].predicate,
+        subject: patterns[3].subject,
+      }));
+      const pattern1 = <Algebra.Pattern> quad(namedNode('1'), namedNode('1'), namedNode('1'), variable('a'));
+      const pattern2 = <Algebra.Pattern> quad(namedNode('2'), namedNode('2'), variable('b'), namedNode('2'));
+      const pattern3 = <Algebra.Pattern> quad(namedNode('3'), blankNode('c'), namedNode('3'), namedNode('3'));
+      const pattern4 = <Algebra.Pattern> quad(blankNode('d'), namedNode('4'), namedNode('4'), namedNode('4'));
+      const binding1 = Bindings({ '?a': namedNode('A') });
+      const binding2 = Bindings({ '?b': namedNode('B') });
+      const binding3 = Bindings({ '_:c': namedNode('C') });
+      it('should return an empty stream for an empty base stream', async () => {
+        expect(await arrayifyStream(ActorQueryOperationBgpLeftDeepSmallestSort.createLeftDeepStream(
+          new EmptyIterator(), [], binder))).toEqual([]);
+      });
+
+      it('should return a stream with one binding for an input stream with one element and four patterns', async () => {
+        expect(await arrayifyStream(ActorQueryOperationBgpLeftDeepSmallestSort.createLeftDeepStream(
+          new SingletonIterator(binding1), [pattern1, pattern2, pattern3, pattern4], binder))).toEqual([
+            Bindings({
+              'graph': namedNode('A'),
+              'object': namedNode('b'),
+              'predicate': namedNode('c'),
+              'subject': namedNode('d'),
+              '?a': namedNode('A'), // tslint:disable-line:object-literal-sort-keys
+            }),
+          ]);
+      });
+
+      it('should return a stream with 3 bindings for an input stream with 3 elements and four patterns', async () => {
+        expect(await arrayifyStream(ActorQueryOperationBgpLeftDeepSmallestSort.createLeftDeepStream(
+          new ArrayIterator([binding1, binding2, binding3]), [pattern1, pattern2, pattern3, pattern4], binder),
+        )).toEqual([
+          Bindings({
+            'graph': namedNode('A'),
+            'object': namedNode('b'),
+            'predicate': namedNode('c'),
+            'subject': namedNode('d'),
+            '?a': namedNode('A'), // tslint:disable-line:object-literal-sort-keys
+          }),
+          Bindings({
+            'graph': namedNode('a'),
+            'object': namedNode('B'),
+            'predicate': namedNode('c'),
+            'subject': namedNode('d'),
+            '?b': namedNode('B'), // tslint:disable-line:object-literal-sort-keys
+          }),
+          Bindings({
+            'graph': namedNode('a'),
+            'object': namedNode('b'),
+            'predicate': namedNode('C'),
+            'subject': namedNode('d'),
+            '_:c': namedNode('C'), // tslint:disable-line:object-literal-sort-keys
+          }),
+        ]);
+      });
+    });
+
+  });
+
+  describe('An ActorQueryOperationBgpLeftDeepSmallestSort instance', () => {
+    let actor: ActorQueryOperationBgpLeftDeepSmallestSort;
+
+    beforeEach(() => {
+      actor = new ActorQueryOperationBgpLeftDeepSmallestSort({ name: 'actor', bus, mediatorQueryOperation });
+    });
+
+    it('should not test on empty BGPs', () => {
+      const op = { operation: { type: 'bgp', patterns: [] } };
+      return expect(actor.test(op)).rejects.toBeTruthy();
+    });
+
+    it('should not test on BGPs with a single pattern', () => {
+      const op = { operation: { type: 'bgp', patterns: [ 'abc' ] } };
+      return expect(actor.test(op)).rejects.toBeTruthy();
+    });
+
+    it('should test on BGPs with more than one pattern', () => {
+      const op = { operation: { type: 'bgp', patterns: [ 'abc', 'def' ] } };
+      return expect(actor.test(op)).resolves.toBeTruthy();
+    });
+
+    const pattern1 = quad(namedNode('1'), namedNode('1'), namedNode('1'), variable('a'));
+    const pattern2 = quad(variable('d'), namedNode('4'), namedNode('4'), namedNode('4'));
+    const patterns = [ pattern1, pattern2 ];
+
+    it('should run with a context and delegate the pattern to the mediator', () => {
+      const op = { operation: { type: 'bgp', patterns }, context: { totalItems: 10, variables: ['a'] } };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            graph: namedNode('a'),
+            object: namedNode('1'),
+            predicate: namedNode('1'),
+            subject: namedNode('1'),
+          }),
+        ]);
+      });
+    });
+
+    it('should run without a context and delegate the pattern to the mediator', () => {
+      const op = { operation: { type: 'bgp', patterns } };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual([]);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: Infinity });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            graph: namedNode('a'),
+            object: namedNode('1'),
+            predicate: namedNode('1'),
+            subject: namedNode('1'),
+          }),
+        ]);
+      });
+    });
+
+    it('should run for an empty pattern response', () => {
+      const thisMediatorQueryOperation: any = {
+        mediate: (arg) => Promise.resolve({
+          bindingsStream: new EmptyIterator(),
+          metadata: () => Promise.resolve({ totalItems: 0 }),
+          type: 'bindings',
+          variables: (arg.context || {}).variables || [],
+        }),
+      };
+      const thisActor = new ActorQueryOperationBgpLeftDeepSmallestSort(
+        { name: 'actor', bus, mediatorQueryOperation: thisMediatorQueryOperation });
+      const op = { operation: { type: 'bgp', patterns } };
+      return thisActor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual([]);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 0 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([]);
+      });
+    });
+
+    it('should run for responses with unknown metadata', () => {
+      const thisMediatorQueryOperation: any = {
+        mediate: (arg) => Promise.resolve({
+          bindingsStream: new EmptyIterator(),
+          metadata: null,
+          type: 'bindings',
+          variables: (arg.context || {}).variables || [],
+        }),
+      };
+      const thisActor = new ActorQueryOperationBgpLeftDeepSmallestSort(
+        { name: 'actor', bus, mediatorQueryOperation: thisMediatorQueryOperation });
+      const op = { operation: { type: 'bgp', patterns } };
+      return thisActor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual([]);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: Infinity });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([]);
+      });
+    });
+  });
+});

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/test/tsconfig.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ]
+  }
+}
+

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/test/tslint.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/test/tslint.json
@@ -1,0 +1,11 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "../tslint.json"
+  ],
+  "rules": {
+    "no-var-requires": false,
+    "no-unused-expression": false
+  }
+}
+

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/tsconfig.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/tslint.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}


### PR DESCRIPTION
As originally introduced in #106, and similar to #102, this is a variant of the left-deep-smallest actor with the only difference that it also sorts the remaining patterns by increasing count.

Results show that this actor only in some cases outperforms the default actor, so we should keep the other actor as default. In future work, we should add a mediator that intelligently identifies the cases in which the other actor is sub-optimal, and chooses another actor.