### PR TITLE
Use order for source identifiers

### DIFF
--- a/packages/actor-init-sparql/config/config-default.json
+++ b/packages/actor-init-sparql/config/config-default.json
@@ -331,8 +331,8 @@
           "@type": "ActorContextPreprocessRdfSourceIdentifier",
           "cacprsi:Actor/ContextPreprocess/RdfSourceIdentifier/mediatorRdfSourceIdentifier": {
             "@id": "ex:mediatorRdfSourceIdentifier",
-            "@type": "MediatorNumberMin",
-            "field": "order",
+            "@type": "MediatorNumberMax",
+            "field": "priority",
             "ignoreErrors": true,
             "cc:Mediator/bus": { "@id": "cbrsi:Bus/RdfSourceIdentifier" }
           }

--- a/packages/actor-init-sparql/config/config-default.json
+++ b/packages/actor-init-sparql/config/config-default.json
@@ -331,7 +331,9 @@
           "@type": "ActorContextPreprocessRdfSourceIdentifier",
           "cacprsi:Actor/ContextPreprocess/RdfSourceIdentifier/mediatorRdfSourceIdentifier": {
             "@id": "ex:mediatorRdfSourceIdentifier",
-            "@type": "MediatorRace",
+            "@type": "MediatorNumberMin",
+            "field": "order",
+            "ignoreErrors": true,
             "cc:Mediator/bus": { "@id": "cbrsi:Bus/RdfSourceIdentifier" }
           }
         },

--- a/packages/actor-rdf-source-identifier-file-content-type/components/Actor/RdfSourceIdentifier/FileContentType.jsonld
+++ b/packages/actor-rdf-source-identifier-file-content-type/components/Actor/RdfSourceIdentifier/FileContentType.jsonld
@@ -31,6 +31,13 @@
             "text/n3",
             "application/ld+json"
           ]
+        },
+        {
+          "@id": "cbrsi:Actor/RdfSourceIdentifier/priority",
+          "defaultScoped": {
+            "defaultScope": "carsifct:Actor/RdfSourceIdentifier/FileContentType",
+            "defaultScopedValue": 0.1
+          }
         }
       ],
       "constructorArguments": [

--- a/packages/actor-rdf-source-identifier-file-content-type/lib/ActorRdfSourceIdentifierFileContentType.ts
+++ b/packages/actor-rdf-source-identifier-file-content-type/lib/ActorRdfSourceIdentifierFileContentType.ts
@@ -28,7 +28,7 @@ export class ActorRdfSourceIdentifierFileContentType extends ActorRdfSourceIdent
         .get('Content-Type').indexOf(mediaType) >= 0)) {
       throw new Error(`${action.sourceValue} is not an RDF file of valid content type: ${this.allowedMediaTypes}`);
     }
-    return true;
+    return { order: 2 };
   }
 
   public async run(action: IActionRdfSourceIdentifier): Promise<IActorRdfSourceIdentifierOutput> {

--- a/packages/actor-rdf-source-identifier-file-content-type/lib/ActorRdfSourceIdentifierFileContentType.ts
+++ b/packages/actor-rdf-source-identifier-file-content-type/lib/ActorRdfSourceIdentifierFileContentType.ts
@@ -1,7 +1,10 @@
 import {IActionHttp, IActorHttpOutput} from "@comunica/bus-http";
-import {ActorRdfSourceIdentifier, IActionRdfSourceIdentifier,
-  IActorRdfSourceIdentifierOutput} from "@comunica/bus-rdf-source-identifier";
+import {
+  ActorRdfSourceIdentifier, IActionRdfSourceIdentifier, IActorRdfSourceIdentifierArgs,
+  IActorRdfSourceIdentifierOutput,
+} from "@comunica/bus-rdf-source-identifier";
 import {Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {IMediatorTypePriority} from "@comunica/mediatortype-priority";
 
 /**
  * A comunica File Content Type RDF Source Identifier Actor.
@@ -16,7 +19,7 @@ export class ActorRdfSourceIdentifierFileContentType extends ActorRdfSourceIdent
     super(args);
   }
 
-  public async test(action: IActionRdfSourceIdentifier): Promise<IActorTest> {
+  public async test(action: IActionRdfSourceIdentifier): Promise<IMediatorTypePriority> {
     if (!action.sourceValue.startsWith('http')) {
       throw new Error(`Actor ${this.name} can only detect files hosted via HTTP(S).`);
     }
@@ -28,7 +31,7 @@ export class ActorRdfSourceIdentifierFileContentType extends ActorRdfSourceIdent
         .get('Content-Type').indexOf(mediaType) >= 0)) {
       throw new Error(`${action.sourceValue} is not an RDF file of valid content type: ${this.allowedMediaTypes}`);
     }
-    return { order: 2 };
+    return { priority: this.priority };
   }
 
   public async run(action: IActionRdfSourceIdentifier): Promise<IActorRdfSourceIdentifierOutput> {
@@ -38,7 +41,7 @@ export class ActorRdfSourceIdentifierFileContentType extends ActorRdfSourceIdent
 }
 
 export interface IActorRdfSourceIdentifierFileContentTypeArgs
-  extends IActorArgs<IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput> {
+  extends IActorRdfSourceIdentifierArgs {
   allowedMediaTypes: string[];
   mediatorHttp: Mediator<Actor<IActionHttp, IActorTest, IActorHttpOutput>,
     IActionHttp, IActorTest, IActorHttpOutput>;

--- a/packages/actor-rdf-source-identifier-file-content-type/package.json
+++ b/packages/actor-rdf-source-identifier-file-content-type/package.json
@@ -39,7 +39,8 @@
   "devDependencies": {
     "@comunica/core": "^1.0.0",
     "@comunica/bus-http": "^1.0.0",
-    "@comunica/bus-rdf-source-identifier": "^1.0.0"
+    "@comunica/bus-rdf-source-identifier": "^1.0.0",
+    "@comunica/mediatortype-priority": "^1.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/actor-rdf-source-identifier-hypermedia-qpf/components/Actor/RdfSourceIdentifier/HypermediaQpf.jsonld
+++ b/packages/actor-rdf-source-identifier-hypermedia-qpf/components/Actor/RdfSourceIdentifier/HypermediaQpf.jsonld
@@ -39,6 +39,13 @@
             "variable",
             "property"
           ]
+        },
+        {
+          "@id": "cbrsi:Actor/RdfSourceIdentifier/priority",
+          "defaultScoped": {
+            "defaultScope": "carsihq:Actor/RdfSourceIdentifier/HypermediaQpf",
+            "defaultScopedValue": 0.9
+          }
         }
       ],
       "constructorArguments": [

--- a/packages/actor-rdf-source-identifier-hypermedia-qpf/lib/ActorRdfSourceIdentifierHypermediaQpf.ts
+++ b/packages/actor-rdf-source-identifier-hypermedia-qpf/lib/ActorRdfSourceIdentifierHypermediaQpf.ts
@@ -39,7 +39,7 @@ export class ActorRdfSourceIdentifierHypermediaQpf extends ActorRdfSourceIdentif
         }
       }
       if (valid) {
-        return true;
+        return { order: 0 };
       }
     }
 

--- a/packages/actor-rdf-source-identifier-hypermedia-qpf/lib/ActorRdfSourceIdentifierHypermediaQpf.ts
+++ b/packages/actor-rdf-source-identifier-hypermedia-qpf/lib/ActorRdfSourceIdentifierHypermediaQpf.ts
@@ -1,7 +1,10 @@
 import {IActionHttp, IActorHttpOutput} from "@comunica/bus-http";
-import {ActorRdfSourceIdentifier, IActionRdfSourceIdentifier,
-  IActorRdfSourceIdentifierOutput} from "@comunica/bus-rdf-source-identifier";
-import {Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {
+  ActorRdfSourceIdentifier, IActionRdfSourceIdentifier, IActorRdfSourceIdentifierArgs,
+  IActorRdfSourceIdentifierOutput,
+} from "@comunica/bus-rdf-source-identifier";
+import {Actor, IActorTest, Mediator} from "@comunica/core";
+import {IMediatorTypePriority} from "@comunica/mediatortype-priority";
 import "isomorphic-fetch";
 
 /**
@@ -18,7 +21,7 @@ export class ActorRdfSourceIdentifierHypermediaQpf extends ActorRdfSourceIdentif
     super(args);
   }
 
-  public async test(action: IActionRdfSourceIdentifier): Promise<IActorTest> {
+  public async test(action: IActionRdfSourceIdentifier): Promise<IMediatorTypePriority> {
     if (!action.sourceValue.startsWith('http')) {
       throw new Error(`Actor ${this.name} can only detect hypermedia interfaces hosted via HTTP(S).`);
     }
@@ -39,7 +42,7 @@ export class ActorRdfSourceIdentifierHypermediaQpf extends ActorRdfSourceIdentif
         }
       }
       if (valid) {
-        return { order: 0 };
+        return { priority: this.priority };
       }
     }
 
@@ -58,7 +61,7 @@ export class ActorRdfSourceIdentifierHypermediaQpf extends ActorRdfSourceIdentif
 }
 
 export interface IActorRdfSourceIdentifierHypermediaQpfArgs
-  extends IActorArgs<IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput> {
+  extends IActorRdfSourceIdentifierArgs {
   mediatorHttp: Mediator<Actor<IActionHttp, IActorTest, IActorHttpOutput>,
     IActionHttp, IActorTest, IActorHttpOutput>;
   acceptHeader: string;

--- a/packages/actor-rdf-source-identifier-hypermedia-qpf/package.json
+++ b/packages/actor-rdf-source-identifier-hypermedia-qpf/package.json
@@ -42,7 +42,8 @@
   "devDependencies": {
     "@comunica/core": "^1.0.0",
     "@comunica/bus-http": "^1.0.0",
-    "@comunica/bus-rdf-source-identifier": "^1.0.0"
+    "@comunica/bus-rdf-source-identifier": "^1.0.0",
+    "@comunica/mediatortype-priority": "^1.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/actor-rdf-source-identifier-sparql/components/Actor/RdfSourceIdentifier/Sparql.jsonld
+++ b/packages/actor-rdf-source-identifier-sparql/components/Actor/RdfSourceIdentifier/Sparql.jsonld
@@ -18,6 +18,13 @@
           "comment": "The HTTP mediator",
           "required": true,
           "unique": true
+        },
+        {
+          "@id": "cbrsi:Actor/RdfSourceIdentifier/priority",
+          "defaultScoped": {
+            "defaultScope": "carsis:Actor/RdfSourceIdentifier/Sparql",
+            "defaultScopedValue": 0.5
+          }
         }
       ],
       "constructorArguments": [

--- a/packages/actor-rdf-source-identifier-sparql/lib/ActorRdfSourceIdentifierSparql.ts
+++ b/packages/actor-rdf-source-identifier-sparql/lib/ActorRdfSourceIdentifierSparql.ts
@@ -27,7 +27,7 @@ export class ActorRdfSourceIdentifierSparql extends ActorRdfSourceIdentifier {
     if (!httpResponse.ok || httpResponse.headers.get('Content-Type').indexOf('application/sparql-results+json') < 0) {
       throw new Error(`${action.sourceValue} is not a SPARQL endpoint`);
     }
-    return true;
+    return { order: 1 };
   }
 
   public async run(action: IActionRdfSourceIdentifier): Promise<IActorRdfSourceIdentifierOutput> {

--- a/packages/actor-rdf-source-identifier-sparql/lib/ActorRdfSourceIdentifierSparql.ts
+++ b/packages/actor-rdf-source-identifier-sparql/lib/ActorRdfSourceIdentifierSparql.ts
@@ -1,7 +1,10 @@
 import {IActionHttp, IActorHttpOutput} from "@comunica/bus-http";
-import {ActorRdfSourceIdentifier, IActionRdfSourceIdentifier,
-  IActorRdfSourceIdentifierOutput} from "@comunica/bus-rdf-source-identifier";
+import {
+  ActorRdfSourceIdentifier, IActionRdfSourceIdentifier, IActorRdfSourceIdentifierArgs,
+  IActorRdfSourceIdentifierOutput,
+} from "@comunica/bus-rdf-source-identifier";
 import {Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {IMediatorTypePriority} from "@comunica/mediatortype-priority";
 
 /**
  * A comunica SPARQL RDF Source Identifier Actor.
@@ -15,7 +18,7 @@ export class ActorRdfSourceIdentifierSparql extends ActorRdfSourceIdentifier {
     super(args);
   }
 
-  public async test(action: IActionRdfSourceIdentifier): Promise<IActorTest> {
+  public async test(action: IActionRdfSourceIdentifier): Promise<IMediatorTypePriority> {
     if (!action.sourceValue.startsWith('http')) {
       throw new Error(`Actor ${this.name} can only detect SPARQL endpoints hosted via HTTP(S).`);
     }
@@ -27,7 +30,7 @@ export class ActorRdfSourceIdentifierSparql extends ActorRdfSourceIdentifier {
     if (!httpResponse.ok || httpResponse.headers.get('Content-Type').indexOf('application/sparql-results+json') < 0) {
       throw new Error(`${action.sourceValue} is not a SPARQL endpoint`);
     }
-    return { order: 1 };
+    return { priority: this.priority};
   }
 
   public async run(action: IActionRdfSourceIdentifier): Promise<IActorRdfSourceIdentifierOutput> {
@@ -37,7 +40,7 @@ export class ActorRdfSourceIdentifierSparql extends ActorRdfSourceIdentifier {
 }
 
 export interface IActorRdfSourceIdentifierSparqlArgs
-  extends IActorArgs<IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput> {
+  extends IActorRdfSourceIdentifierArgs {
   mediatorHttp: Mediator<Actor<IActionHttp, IActorTest, IActorHttpOutput>,
     IActionHttp, IActorTest, IActorHttpOutput>;
 }

--- a/packages/actor-rdf-source-identifier-sparql/package.json
+++ b/packages/actor-rdf-source-identifier-sparql/package.json
@@ -39,7 +39,8 @@
   "devDependencies": {
     "@comunica/core": "^1.0.0",
     "@comunica/bus-http": "^1.0.0",
-    "@comunica/bus-rdf-source-identifier": "^1.0.0"
+    "@comunica/bus-rdf-source-identifier": "^1.0.0",
+    "@comunica/mediatortype-priority": "^1.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/bus-rdf-source-identifier/components/Actor/RdfSourceIdentifier.jsonld
+++ b/packages/bus-rdf-source-identifier/components/Actor/RdfSourceIdentifier.jsonld
@@ -18,13 +18,26 @@
             "defaultScope": "cbrsi:Actor/RdfSourceIdentifier",
             "defaultScopedValue": { "@id": "cbrsi:Bus/RdfSourceIdentifier" }
           }
+        },
+        {
+          "@id": "cbrsi:Actor/RdfSourceIdentifier/priority",
+          "comment": "The priority of this identifier",
+          "range": "xsd:float",
+          "required": true,
+          "unique": true
         }
       ],
       "constructorArguments": [
         {
           "@id": "cbrsi:Actor/RdfSourceIdentifier/constructorArgumentsObject",
           "@type": "https://linkedsoftwaredependencies.org/vocabularies/object-oriented#Object",
-          "extends": "cc:Actor/constructorArgumentsObject"
+          "extends": "cc:Actor/constructorArgumentsObject",
+          "fields": [
+            {
+              "keyRaw": "priority",
+              "value": "cbrsi:Actor/RdfSourceIdentifier/priority"
+            }
+          ]
         }
       ]
     }

--- a/packages/bus-rdf-source-identifier/lib/ActorRdfSourceIdentifier.ts
+++ b/packages/bus-rdf-source-identifier/lib/ActorRdfSourceIdentifier.ts
@@ -1,4 +1,5 @@
 import {Actor, IAction, IActorArgs, IActorOutput, IActorTest} from "@comunica/core";
+import {IMediatorTypePriority} from "@comunica/mediatortype-priority";
 
 /**
  * A comunica actor for rdf-source-identifier events.
@@ -14,9 +15,13 @@ import {Actor, IAction, IActorArgs, IActorOutput, IActorTest} from "@comunica/co
 export abstract class ActorRdfSourceIdentifier
   extends Actor<IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput> {
 
-  constructor(args: IActorArgs<IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput>) {
+  public readonly priority: number;
+
+  constructor(args: IActorRdfSourceIdentifierArgs) {
     super(args);
   }
+
+  public abstract async test(action: IActionRdfSourceIdentifier): Promise<IMediatorTypePriority>;
 
 }
 
@@ -32,4 +37,9 @@ export interface IActorRdfSourceIdentifierOutput extends IActorOutput {
    * The identified source type.
    */
   sourceType: string;
+}
+
+export interface IActorRdfSourceIdentifierArgs
+  extends IActorArgs<IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput> {
+  priority: number;
 }

--- a/packages/bus-rdf-source-identifier/package.json
+++ b/packages/bus-rdf-source-identifier/package.json
@@ -36,7 +36,8 @@
   },
   "devDependencies": {
     "@comunica/core": "^1.0.0",
-    "@comunica/bus-http": "^1.0.0"
+    "@comunica/bus-http": "^1.0.0",
+    "@comunica/mediatortype-priority": "^1.0.0"
   },
   "scripts": {
     "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",

--- a/packages/mediator-number/components/Mediator/Number.jsonld
+++ b/packages/mediator-number/components/Mediator/Number.jsonld
@@ -25,6 +25,14 @@
           "range": "xsd:string",
           "unique": true,
           "required": true
+        },
+        {
+          "@id": "cmn:Mediator/Number/ignoreErrors",
+          "comment": "If actors that throw test errors should be ignored",
+          "range": "xsd:boolean",
+          "unique": true,
+          "required": true,
+          "default": false
         }
       ],
       "constructorArguments": [
@@ -39,6 +47,10 @@
             {
               "keyRaw": "type",
               "valueRawReference": "cmn:Mediator/Number/type"
+            },
+            {
+              "keyRaw": "ignoreErrors",
+              "valueRawReference": "cmn:Mediator/Number/ignoreErrors"
             }
           ]
         }

--- a/packages/mediator-number/components/context.jsonld
+++ b/packages/mediator-number/components/context.jsonld
@@ -8,6 +8,7 @@
       "MediatorNumber": "cmn:Mediator/Number",
       "field": "cmn:Mediator/Number/field",
       "type": "cmn:Mediator/Number/type",
+      "ignoreErrors": "cmn:Mediator/Number/ignoreErrors",
       "Min": "cmn:Mediator/Number/type/TypeMin",
       "Max": "cmn:Mediator/Number/type/TypeMax",
 

--- a/packages/mediator-number/test/MediatorNumber-test.ts
+++ b/packages/mediator-number/test/MediatorNumber-test.ts
@@ -101,6 +101,26 @@ describe('MediatorNumber', () => {
         return expect(mediatorMax.mediate({})).resolves.toEqual({ field: 100 });
       });
     });
+
+    describe('with actors throwing errors', () => {
+      beforeEach(() => {
+        mediatorMin = new MediatorNumber({ bus, field: 'field', ignoreErrors: true,
+          name: 'mediatorMin', type: MediatorNumber.MIN });
+        mediatorMax = new MediatorNumber({ bus, field: 'field', ignoreErrors: true,
+          name: 'mediatorMax', type: MediatorNumber.MAX });
+        bus.subscribe(new ErrorDummyActor(null, bus));
+        bus.subscribe(new DummyActor(100, bus));
+        bus.subscribe(new DummyActor(1, bus));
+      });
+
+      it('should mediate to the minimum value for type MIN', () => {
+        return expect(mediatorMin.mediate({})).resolves.toEqual({ field: 1 });
+      });
+
+      it('should mediate to the maximum value for type MAX', () => {
+        return expect(mediatorMax.mediate({})).resolves.toEqual({ field: 100 });
+      });
+    });
   });
 });
 
@@ -121,6 +141,13 @@ class DummyActor extends Actor<IAction, IDummyTest, IDummyTest> {
     return { field: this.id };
   }
 
+}
+
+// tslint:disable-next-line:max-classes-per-file
+class ErrorDummyActor extends DummyActor {
+  public async test(action: IAction): Promise<IDummyTest> {
+    throw new Error();
+  }
 }
 
 interface IDummyTest extends IActorTest, IActorOutput {

--- a/packages/mediatortype-priority/README.md
+++ b/packages/mediatortype-priority/README.md
@@ -1,0 +1,17 @@
+# Comunica Mediatortype Priority
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Fmediatortype-priority.svg)](https://www.npmjs.com/package/@comunica/mediatortype-priority)
+
+A comunica mediator type for mediation on 'priority'. 
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/mediatortype-priority
+```
+
+## Usage
+
+TODO

--- a/packages/mediatortype-priority/index.ts
+++ b/packages/mediatortype-priority/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/MediatorTypePriority';

--- a/packages/mediatortype-priority/lib/MediatorTypePriority.ts
+++ b/packages/mediatortype-priority/lib/MediatorTypePriority.ts
@@ -1,0 +1,11 @@
+import {IActorTest} from "@comunica/core";
+
+/**
+ * A mediator type that has a priority parameter.
+ */
+export interface IMediatorTypePriority extends IActorTest {
+  /**
+   * A certain amount of priority, going from 0 to 1.
+   */
+  priority?: number;
+}

--- a/packages/mediatortype-priority/package.json
+++ b/packages/mediatortype-priority/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@comunica/mediatortype-priority",
+  "version": "1.0.0",
+  "description": "A comunica mediator type for the 'priority' parameter.",
+  "main": "index.js",
+  "typings": "index",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/mediatortype-priority",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "comunica",
+    "bus",
+    "init"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://github.com/comunica/comunica#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@comunica/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@comunica/core": "^1.0.0"
+  },
+  "scripts": {
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/mediatortype-priority/tsconfig.json
+++ b/packages/mediatortype-priority/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/mediatortype-priority/tslint.json
+++ b/packages/mediatortype-priority/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}


### PR DESCRIPTION
This makes sure that sources that match both files and hypermedia
are always recognized as hypermedia