### PR TITLE
Remove transformIgnorePatterns from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-abstract-mediatyped/package.json
+++ b/packages/actor-abstract-mediatyped/package.json
@@ -44,9 +44,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-context-preprocess-rdf-source-identifier/package.json
+++ b/packages/actor-context-preprocess-rdf-source-identifier/package.json
@@ -45,9 +45,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-http-native/package.json
+++ b/packages/actor-http-native/package.json
@@ -51,9 +51,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-http-node-fetch/package.json
+++ b/packages/actor-http-node-fetch/package.json
@@ -45,9 +45,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-hello-world/package.json
+++ b/packages/actor-init-hello-world/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-http/package.json
+++ b/packages/actor-init-http/package.json
@@ -56,9 +56,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-rdf-dereference-paged/package.json
+++ b/packages/actor-init-rdf-dereference-paged/package.json
@@ -67,9 +67,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-rdf-dereference/package.json
+++ b/packages/actor-init-rdf-dereference/package.json
@@ -56,9 +56,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-rdf-parse/package.json
+++ b/packages/actor-init-rdf-parse/package.json
@@ -51,9 +51,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-sparql-file/package.json
+++ b/packages/actor-init-sparql-file/package.json
@@ -91,9 +91,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-sparql-hdt/package.json
+++ b/packages/actor-init-sparql-hdt/package.json
@@ -83,9 +83,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -128,9 +128,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-ask/package.json
+++ b/packages/actor-query-operation-ask/package.json
@@ -44,9 +44,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-bgp-empty/package.json
+++ b/packages/actor-query-operation-bgp-empty/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/package.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/package.json
@@ -50,9 +50,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-bgp-left-deep-smallest/package.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest/package.json
@@ -49,9 +49,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-bgp-single/package.json
+++ b/packages/actor-query-operation-bgp-single/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-construct/package.json
+++ b/packages/actor-query-operation-construct/package.json
@@ -48,9 +48,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-describe-subject/package.json
+++ b/packages/actor-query-operation-describe-subject/package.json
@@ -48,9 +48,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-distinct-hash/package.json
+++ b/packages/actor-query-operation-distinct-hash/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-filter-direct/package.json
+++ b/packages/actor-query-operation-filter-direct/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-from-quad/package.json
+++ b/packages/actor-query-operation-from-quad/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-join/package.json
+++ b/packages/actor-query-operation-join/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-leftjoin-nestedloop/package.json
+++ b/packages/actor-query-operation-leftjoin-nestedloop/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-orderby-direct/package.json
+++ b/packages/actor-query-operation-orderby-direct/package.json
@@ -48,9 +48,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-project/package.json
+++ b/packages/actor-query-operation-project/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-quadpattern/package.json
+++ b/packages/actor-query-operation-quadpattern/package.json
@@ -50,9 +50,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-slice/package.json
+++ b/packages/actor-query-operation-slice/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-union/package.json
+++ b/packages/actor-query-operation-union/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-query-operation-values/package.json
+++ b/packages/actor-query-operation-values/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-dereference-file/package.json
+++ b/packages/actor-rdf-dereference-file/package.json
@@ -45,9 +45,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-dereference-http-parse/package.json
+++ b/packages/actor-rdf-dereference-http-parse/package.json
@@ -49,9 +49,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-dereference-paged-next/package.json
+++ b/packages/actor-rdf-dereference-paged-next/package.json
@@ -53,9 +53,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-join-hash/package.json
+++ b/packages/actor-rdf-join-hash/package.json
@@ -48,9 +48,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-join-nestedloop/package.json
+++ b/packages/actor-rdf-join-nestedloop/package.json
@@ -48,9 +48,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-join-symmetrichash/package.json
+++ b/packages/actor-rdf-join-symmetrichash/package.json
@@ -48,9 +48,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-metadata-extract-hydra-controls/package.json
+++ b/packages/actor-rdf-metadata-extract-hydra-controls/package.json
@@ -50,9 +50,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-metadata-extract-hydra-count/package.json
+++ b/packages/actor-rdf-metadata-extract-hydra-count/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-metadata-primary-topic/package.json
+++ b/packages/actor-rdf-metadata-primary-topic/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-metadata-triple-predicate/package.json
+++ b/packages/actor-rdf-metadata-triple-predicate/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-parse-jsonld/package.json
+++ b/packages/actor-rdf-parse-jsonld/package.json
@@ -45,9 +45,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-parse-n3/package.json
+++ b/packages/actor-rdf-parse-n3/package.json
@@ -45,9 +45,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-resolve-quad-pattern-federated/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/package.json
@@ -50,9 +50,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-resolve-quad-pattern-file/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-file/package.json
@@ -50,9 +50,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-resolve-quad-pattern-hdt/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-hdt/package.json
@@ -48,9 +48,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-resolve-quad-pattern-qpf/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-qpf/package.json
@@ -51,9 +51,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
@@ -55,9 +55,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-serialize-jsonld/package.json
+++ b/packages/actor-rdf-serialize-jsonld/package.json
@@ -50,9 +50,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-serialize-n3/package.json
+++ b/packages/actor-rdf-serialize-n3/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-source-identifier-file-content-type/package.json
+++ b/packages/actor-rdf-source-identifier-file-content-type/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-source-identifier-hypermedia-qpf/package.json
+++ b/packages/actor-rdf-source-identifier-hypermedia-qpf/package.json
@@ -49,9 +49,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-rdf-source-identifier-sparql/package.json
+++ b/packages/actor-rdf-source-identifier-sparql/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-parse-algebra/package.json
+++ b/packages/actor-sparql-parse-algebra/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-serialize-json/package.json
+++ b/packages/actor-sparql-serialize-json/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-serialize-rdf/package.json
+++ b/packages/actor-sparql-serialize-rdf/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-serialize-simple/package.json
+++ b/packages/actor-sparql-serialize-simple/package.json
@@ -44,9 +44,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-serialize-sparql-json/package.json
+++ b/packages/actor-sparql-serialize-sparql-json/package.json
@@ -44,9 +44,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-serialize-sparql-xml/package.json
+++ b/packages/actor-sparql-serialize-sparql-xml/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-serialize-stats/package.json
+++ b/packages/actor-sparql-serialize-stats/package.json
@@ -44,9 +44,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/actor-sparql-serialize-table/package.json
+++ b/packages/actor-sparql-serialize-table/package.json
@@ -47,9 +47,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/bus-query-operation/package.json
+++ b/packages/bus-query-operation/package.json
@@ -44,9 +44,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/bus-rdf-parse/package.json
+++ b/packages/bus-rdf-parse/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/bus-rdf-resolve-quad-pattern/package.json
+++ b/packages/bus-rdf-resolve-quad-pattern/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/bus-rdf-serialize/package.json
+++ b/packages/bus-rdf-serialize/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/bus-sparql-serialize/package.json
+++ b/packages/bus-sparql-serialize/package.json
@@ -44,9 +44,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,9 +42,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/mediator-combine-pipeline/package.json
+++ b/packages/mediator-combine-pipeline/package.json
@@ -42,9 +42,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/mediator-combine-union/package.json
+++ b/packages/mediator-combine-union/package.json
@@ -43,9 +43,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/mediator-number/package.json
+++ b/packages/mediator-number/package.json
@@ -42,9 +42,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/mediator-race/package.json
+++ b/packages/mediator-race/package.json
@@ -39,9 +39,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -46,9 +46,6 @@
     "transform": {
       "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
     },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
     "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
     "moduleFileExtensions": [
       "ts",


### PR DESCRIPTION
The regex was causing some problems
and this doesn't seem to be required anymore.

Will also have to update the templates here if all tests pass https://github.com/comunica/generate-comunica/tree/master/generators