### PR TITLE
Allow initialBindings to be passed to query context

### DIFF
--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -61,9 +61,9 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
         copiedOperation[key] = operation[key];
       }
 
-      if (operation.type === 'pattern' || operation.type === 'path') {
+      if (operation.type === Algebra.types.PATTERN || operation.type === Algebra.types.PATH) {
         for (const quadTerm of QUAD_TERM_NAMES) {
-          if (!(operation.type === 'path' && quadTerm === 'predicate')) {
+          if (!(operation.type === Algebra.types.PATH && quadTerm === 'predicate')) {
             const term: RDF.Term = operation[quadTerm];
             if (term.termType === 'Variable') {
               const termString: string = termToString(term);

--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -1,17 +1,22 @@
 import {IActionContextPreprocess, IActorContextPreprocessOutput} from "@comunica/bus-context-preprocess";
 import {ActorInit, IActionInit, IActorOutputInit} from "@comunica/bus-init";
-import {IActionQueryOperation, IActorQueryOperationOutput} from "@comunica/bus-query-operation";
+import {Bindings, IActionQueryOperation, IActorQueryOperationOutput} from "@comunica/bus-query-operation";
 import {IActionSparqlParse, IActorSparqlParseOutput} from "@comunica/bus-sparql-parse";
 import {IActionRootSparqlParse, IActorOutputRootSparqlParse,
   IActorTestRootSparqlParse} from "@comunica/bus-sparql-serialize";
 import {IActorSparqlSerializeOutput} from "@comunica/bus-sparql-serialize";
 import {Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import * as RDF from "rdf-js";
+import {termToString} from "rdf-string";
+import {QUAD_TERM_NAMES} from "rdf-terms";
 import {Algebra} from "sparqlalgebrajs";
 
 /**
  * A browser-safe comunica SPARQL Init Actor.
  */
 export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
+
+  private static ALGEBRA_TYPES: string[] = Object.keys(Algebra.types).map((key) => (<any> Algebra.types)[key]);
 
   public readonly mediatorQueryOperation: Mediator<Actor<IActionQueryOperation, IActorTest, IActorQueryOperationOutput>,
     IActionQueryOperation, IActorTest, IActorQueryOperationOutput>;
@@ -31,6 +36,49 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
     super(args);
   }
 
+  /**
+   * Create a copy of the given operation in which all given bindings are applied.
+   * The bindings are applied to all quad patterns and path expressions.
+   *
+   * @param {Operation} operation An operation.
+   * @param {Bindings} initialBindings Bindings to apply.
+   * @return {Operation} A copy of the given operation where all given bindings are applied.
+   */
+  public static applyInitialBindings(operation: Algebra.Operation, initialBindings: Bindings): Algebra.Operation {
+    const copiedOperation: Algebra.Operation = <any> {};
+    for (const key of Object.keys(operation)) {
+      if (Array.isArray(operation[key])) {
+        if (key === 'variables') {
+          copiedOperation[key] = operation[key].filter(
+            (variable: RDF.Variable) => initialBindings.keySeq().indexOf(termToString(variable)) < 0);
+        } else {
+          copiedOperation[key] = operation[key].map(
+            (subOperation: Algebra.Operation) => ActorInitSparql.applyInitialBindings(subOperation, initialBindings));
+        }
+      } else if (ActorInitSparql.ALGEBRA_TYPES.indexOf(operation[key].type) >= 0) {
+        copiedOperation[key] = ActorInitSparql.applyInitialBindings(operation[key], initialBindings);
+      } else {
+        copiedOperation[key] = operation[key];
+      }
+
+      if (operation.type === 'pattern' || operation.type === 'path') {
+        for (const quadTerm of QUAD_TERM_NAMES) {
+          if (!(operation.type === 'path' && quadTerm === 'predicate')) {
+            const term: RDF.Term = operation[quadTerm];
+            if (term.termType === 'Variable') {
+              const termString: string = termToString(term);
+              const binding: RDF.Term = initialBindings.get(termString);
+              if (binding) {
+                copiedOperation[quadTerm] = binding;
+              }
+            }
+          }
+        }
+      }
+    }
+    return copiedOperation;
+  }
+
   public async test(action: IActionInit): Promise<IActorTest> {
     return true;
   }
@@ -46,10 +94,15 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
     const combinationPromise = this.mediatorContextPreprocess.mediate({ context });
 
     // Parse query
-    const operation: Algebra.Operation = (await this.mediatorSparqlParse.mediate({ query })).operation;
+    let operation: Algebra.Operation = (await this.mediatorSparqlParse.mediate({ query })).operation;
 
     // Block until context has been processed
     context = (await combinationPromise).context;
+
+    // Apply initial bindings in context
+    if (context.initialBindings) {
+      operation = ActorInitSparql.applyInitialBindings(operation, context.initialBindings);
+    }
 
     // Execute query
     const resolve: IActionQueryOperation = { context, operation };

--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -114,6 +114,8 @@
     "componentsjs": "2.2.0",
     "minimist": "^1.2.0",
     "negotiate": "^1.0.1",
+    "rdf-string": "^1.1.1",
+    "rdf-terms": "^1.1.0",
     "streamify-string": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/actor-init-sparql/test/ActorInitSparql-test.ts
+++ b/packages/actor-init-sparql/test/ActorInitSparql-test.ts
@@ -118,6 +118,18 @@ describe('ActorInitSparql', () => {
       }))).toEqual(FACTORY.createPath(literal('sl'), FACTORY.createNps([namedNode('p')]),
         literal('ol'), literal('gl')));
     });
+
+    it('should correctly map describe operations', () => {
+      const input = FACTORY.createDescribe(FACTORY.createBgp([
+        FACTORY.createPattern(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')),
+      ]), [ namedNode('a'), namedNode('b') ]);
+      expect(ActorInitSparql.applyInitialBindings(input, Bindings({}))).toEqual(input);
+    });
+
+    it('should correctly map values operations', () => {
+      const input = FACTORY.createValues([ variable('a') ], [{ '?a': namedNode('b') }]);
+      expect(ActorInitSparql.applyInitialBindings(input, Bindings({}))).toEqual(input);
+    });
   });
 
   describe('An ActorInitSparql instance', () => {


### PR DESCRIPTION
This adds support for prepared statements (#161).