### PR TITLE
Feature/sources stream

### DIFF
--- a/packages/actor-context-preprocess-rdf-source-identifier/lib/ActorContextPreprocessRdfSourceIdentifier.ts
+++ b/packages/actor-context-preprocess-rdf-source-identifier/lib/ActorContextPreprocessRdfSourceIdentifier.ts
@@ -26,7 +26,7 @@ export class ActorContextPreprocessRdfSourceIdentifier extends ActorContextPrepr
       const subContext: ActionContext = action.context.delete(KEY_CONTEXT_SOURCES);
 
       const sources: DataSources = action.context.get(KEY_CONTEXT_SOURCES);
-      const newSources: DataSources = AsyncReiterableArray.forInitialEmpty();
+      const newSources: DataSources = AsyncReiterableArray.fromInitialEmpty();
       let remainingSources = 1;
       const it = sources.iterator();
       it.on('data', (source: IDataSource) => {

--- a/packages/actor-context-preprocess-rdf-source-identifier/package.json
+++ b/packages/actor-context-preprocess-rdf-source-identifier/package.json
@@ -34,6 +34,9 @@
     "index.d.ts",
     "index.js"
   ],
+  "dependencies": {
+    "asyncreiterable": "^1.0.0"
+  },
   "peerDependencies": {
     "@comunica/bus-context-preprocess": "^1.0.0",
     "@comunica/bus-rdf-source-identifier": "^1.0.0",

--- a/packages/actor-context-preprocess-rdf-source-identifier/package.json
+++ b/packages/actor-context-preprocess-rdf-source-identifier/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "asyncreiterable": "^1.0.0"
+    "asyncreiterable": "^1.1.0"
   },
   "peerDependencies": {
     "@comunica/bus-context-preprocess": "^1.0.0",

--- a/packages/actor-context-preprocess-rdf-source-identifier/test/ActorContextPreprocessRdfSourceIdentifier-test.ts
+++ b/packages/actor-context-preprocess-rdf-source-identifier/test/ActorContextPreprocessRdfSourceIdentifier-test.ts
@@ -54,7 +54,7 @@ describe('ActorContextPreprocessRdfSourceIdentifier', () => {
     it('should run for a context with zero sources', async () => {
       return expect(await arrayifyStream((await actor.run({
         context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.forFixedData([]) }),
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([]) }),
       })).context.get('@comunica/bus-rdf-resolve-quad-pattern:sources').iterator()))
         .toEqual([]);
     });
@@ -62,7 +62,7 @@ describe('ActorContextPreprocessRdfSourceIdentifier', () => {
     it('should run for a context with two dummy sources', async () => {
       return expect(await arrayifyStream((await actor.run({
         context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.forFixedData([
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([
               { type: 'dummy' },
               { type: 'dummy' },
           ]) }),
@@ -73,7 +73,7 @@ describe('ActorContextPreprocessRdfSourceIdentifier', () => {
     it('should run for a context with two auto sources', async () => {
       return expect(await arrayifyStream((await actor.run({
         context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.forFixedData([
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([
               { type: 'auto', value: 'abc' },
               { type: 'auto', value: 'def' },
           ]) }),
@@ -84,7 +84,7 @@ describe('ActorContextPreprocessRdfSourceIdentifier', () => {
     it('should run for a context with a auto and a dummy source', async () => {
       return expect(await arrayifyStream((await actor.run({
         context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.forFixedData([
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([
               { type: 'auto', value: 'abc' },
               { type: 'dummy' },
           ]) }),
@@ -95,7 +95,7 @@ describe('ActorContextPreprocessRdfSourceIdentifier', () => {
     it('should run and keep the auto type if the mediator fails', async () => {
       return expect(await arrayifyStream((await actor.run({
         context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.forFixedData([
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([
               { type: 'auto' },
           ]) }),
       })).context.get('@comunica/bus-rdf-resolve-quad-pattern:sources').iterator()))

--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -109,7 +109,7 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
       delete context.queryFormat;
     }
     if (Array.isArray(context[KEY_CONTEXT_SOURCES])) {
-      context[KEY_CONTEXT_SOURCES] = AsyncReiterableArray.forFixedData(context[KEY_CONTEXT_SOURCES]);
+      context[KEY_CONTEXT_SOURCES] = AsyncReiterableArray.fromFixedData(context[KEY_CONTEXT_SOURCES]);
     }
 
     context = ActionContext(context);

--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -8,6 +8,7 @@ import {IActionRootSparqlParse, IActorOutputRootSparqlParse,
   IActorTestRootSparqlParse} from "@comunica/bus-sparql-serialize";
 import {IActorSparqlSerializeOutput} from "@comunica/bus-sparql-serialize";
 import {ActionContext, Actor, IAction, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {AsyncReiterableArray} from "asyncreiterable";
 import * as RDF from "rdf-js";
 import {termToString} from "rdf-string";
 import {QUAD_TERM_NAMES} from "rdf-terms";
@@ -106,6 +107,9 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
     if (context.queryFormat) {
       context[KEY_CONTEXT_QUERYFORMAT] = context.queryFormat;
       delete context.queryFormat;
+    }
+    if (Array.isArray(context[KEY_CONTEXT_SOURCES])) {
+      context[KEY_CONTEXT_SOURCES] = AsyncReiterableArray.forFixedData(context[KEY_CONTEXT_SOURCES]);
     }
 
     context = ActionContext(context);

--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -117,7 +117,7 @@
     "@comunica/mediator-race": "^1.1.0",
     "@comunica/runner": "^1.1.0",
     "@comunica/runner-cli": "^1.1.0",
-    "asyncreiterable": "^1.0.0",
+    "asyncreiterable": "^1.1.0",
     "minimist": "^1.2.0",
     "negotiate": "^1.0.1",
     "rdf-string": "^1.1.1",

--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -117,6 +117,7 @@
     "@comunica/mediator-race": "^1.1.0",
     "@comunica/runner": "^1.1.0",
     "@comunica/runner-cli": "^1.1.0",
+    "asyncreiterable": "^1.0.0",
     "minimist": "^1.2.0",
     "negotiate": "^1.0.1",
     "rdf-string": "^1.1.1",

--- a/packages/actor-query-operation-describe-subject/package.json
+++ b/packages/actor-query-operation-describe-subject/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@comunica/actor-query-operation-union": "^1.1.0",
-    "asynciterator-union": "^2.0.0",
+    "asynciterator-union": "^2.1.0",
     "rdf-data-model": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/actor-query-operation-union/package.json
+++ b/packages/actor-query-operation-union/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "asynciterator-union": "^2.0.0",
+    "asynciterator-union": "^2.1.0",
     "lodash.union": "^4.6.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/ActorRdfResolveQuadPatternFederated.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/ActorRdfResolveQuadPatternFederated.ts
@@ -22,8 +22,8 @@ export class ActorRdfResolveQuadPatternFederated extends ActorRdfResolveQuadPatt
 
   public async test(action: IActionRdfResolveQuadPattern): Promise<IActorTest> {
     const sources = this.getContextSources(action.context);
-    if (!sources || sources.length < 2) {
-      throw new Error('Actor ' + this.name + ' can only resolve quad pattern queries against a set of sources.');
+    if (!sources || sources.length < 1) {
+      throw new Error('Actor ' + this.name + ' can only resolve quad pattern queries against a sources array.');
     }
     return true;
   }

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/ActorRdfResolveQuadPatternFederated.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/ActorRdfResolveQuadPatternFederated.ts
@@ -55,8 +55,3 @@ export interface IActorRdfResolveQuadPatternFederatedArgs
     IActorRdfResolveQuadPatternOutput>, IActionRdfResolveQuadPattern, IActorTest, IActorRdfResolveQuadPatternOutput>;
   skipEmptyPatterns?: boolean;
 }
-
-export interface IQuerySource {
-  type: string;
-  value: any;
-}

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -1,6 +1,6 @@
 import {
   IActionRdfResolveQuadPattern, IActorRdfResolveQuadPatternOutput,
-  ILazyQuadSource, KEY_CONTEXT_SOURCES,
+  ILazyQuadSource, KEY_CONTEXT_SOURCE, KEY_CONTEXT_SOURCES,
 } from "@comunica/bus-rdf-resolve-quad-pattern";
 import {ActionContext, Actor, IActorTest, Mediator} from "@comunica/core";
 import {AsyncIterator, EmptyIterator} from "asynciterator";
@@ -139,8 +139,8 @@ export class FederatedQuadSource implements ILazyQuadSource {
       };
 
       // Prepare the context for this specific source
-      const context: ActionContext = this.contextDefault.set(KEY_CONTEXT_SOURCES,
-        [{ type: source.type, value: source.value }]);
+      const context: ActionContext = this.contextDefault.set(KEY_CONTEXT_SOURCE,
+        { type: source.type, value: source.value });
 
       return new PromiseProxyIterator(async () => {
         let output: IActorRdfResolveQuadPatternOutput;

--- a/packages/actor-rdf-resolve-quad-pattern-federated/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "asynciterator": "^2.0.0",
     "asynciterator-promiseproxy": "^2.0.0",
-    "asynciterator-union": "^2.0.0",
+    "asynciterator-union": "^2.1.0",
     "lodash.omit": "^4.5.0",
     "rdf-data-model": "^1.0.0"
   },

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
@@ -52,14 +52,19 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
         { name: 'actor', bus, mediatorResolveQuadPattern, skipEmptyPatterns });
     });
 
-    it('should test with >= 2 sources', () => {
+    it('should test with >= 1 sources', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{}, {}] }) })).resolves.toBeTruthy();
+        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{}] }) })).resolves.toBeTruthy();
     });
 
-    it('should not test with < 2 sources', () => {
+    it('should not test with < 1 sources', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{}] }) })).rejects.toBeTruthy();
+        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [] }) })).rejects.toBeTruthy();
+    });
+
+    it('should not test with a single source', () => {
+      return expect(actor.test({ pattern: null, context: ActionContext(
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': {} }) })).rejects.toBeTruthy();
     });
 
     it('should not test without sources', () => {

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
@@ -80,7 +80,7 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
     it('should run', () => {
       const pattern = squad('?s', 'p', 'o', '?g');
       const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySource', value: 'I will not be empty' },
             { type: 'nonEmptySource', value: 'I will not be empty' },
           ])});
@@ -102,7 +102,7 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
         { name: 'actor', bus, mediatorResolveQuadPattern: thisMediator, skipEmptyPatterns });
       const pattern = squad('?s', 'p', 'o', '?g');
       const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySource', value: 'I will not be empty' },
             { type: 'nonEmptySource', value: 'I will not be empty' },
           ])});
@@ -112,7 +112,7 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
     it('should run when only metadata is called', () => {
       const pattern = squad('?s', 'p', 'o', '?g');
       const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySource', value: 'I will not be empty' },
             { type: 'nonEmptySource', value: 'I will not be empty' },
           ])});
@@ -124,7 +124,7 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
     it('should run when only data is called', () => {
       const pattern = squad('?s', 'p', 'o', '?g');
       const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySource', value: 'I will not be empty' },
             { type: 'nonEmptySource', value: 'I will not be empty' },
           ])});

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
@@ -1,6 +1,7 @@
 import {ActorRdfResolveQuadPattern} from "@comunica/bus-rdf-resolve-quad-pattern";
 import {ActionContext, Bus} from "@comunica/core";
 import {ArrayIterator} from "asynciterator";
+import {AsyncReiterableArray} from "asyncreiterable";
 import {ActorRdfResolveQuadPatternFederated} from "../lib/ActorRdfResolveQuadPatternFederated";
 const squad = require('rdf-quad');
 const arrayifyStream = require('arrayify-stream');
@@ -78,10 +79,11 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
 
     it('should run', () => {
       const pattern = squad('?s', 'p', 'o', '?g');
-      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-      ]});
+      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+          ])});
       return actor.run({ pattern, context })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 4 });
@@ -99,19 +101,21 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
       const thisActor = new ActorRdfResolveQuadPatternFederated(
         { name: 'actor', bus, mediatorResolveQuadPattern: thisMediator, skipEmptyPatterns });
       const pattern = squad('?s', 'p', 'o', '?g');
-      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-      ]});
+      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+          ])});
       return expect(thisActor.run({ pattern, context })).resolves.toBeTruthy();
     });
 
     it('should run when only metadata is called', () => {
       const pattern = squad('?s', 'p', 'o', '?g');
-      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-      ]});
+      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+          ])});
       return expect(actor.run({ pattern, context })
         .then((output) => output.metadata()))
         .resolves.toEqual({ totalItems: 4 });
@@ -119,10 +123,11 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
 
     it('should run when only data is called', () => {
       const pattern = squad('?s', 'p', 'o', '?g');
-      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-      ]});
+      const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+          ])});
       return actor.run({ pattern, context })
         .then(async (output) => {
           expect(await arrayifyStream(output.data)).toEqual([

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -38,7 +38,7 @@ describe('FederatedQuadSource', () => {
       },
     };
     context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-        AsyncReiterableArray.forFixedData([ { type: 'myType', value: 'myValue' } ]) });
+        AsyncReiterableArray.fromFixedData([ { type: 'myType', value: 'myValue' } ]) });
   });
 
   describe('The FederatedQuadSource module', () => {
@@ -310,7 +310,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([]) });
+          AsyncReiterableArray.fromFixedData([]) });
       source = new FederatedQuadSource(mediator, contextEmpty, emptyPatterns, true);
     });
 
@@ -335,7 +335,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([ { type: 'emptySource', value: 'I will be empty' } ]) });
+          AsyncReiterableArray.fromFixedData([ { type: 'emptySource', value: 'I will be empty' } ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -376,7 +376,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingle = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([{ type: 'nonEmptySource', value: 'I will not be empty' }]) });
+          AsyncReiterableArray.fromFixedData([{ type: 'nonEmptySource', value: 'I will not be empty' }]) });
       source = new FederatedQuadSource(mediator, contextSingle, emptyPatterns, true);
     });
 
@@ -417,7 +417,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'emptySource', value: 'I will be empty' },
             { type: 'nonEmptySource', value: 'I will not be empty' },
           ]) });
@@ -466,7 +466,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'emptySource', value: 'I will be empty' },
             { type: 'emptySource', value: 'I will be empty' },
           ]) });
@@ -511,7 +511,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'emptySource', value: 'I will be empty' },
             { type: 'emptySource', value: 'I will be empty' },
           ]) });
@@ -551,7 +551,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySource', value: 'I will not be empty' },
             { type: 'nonEmptySource2', value: 'I will also not be empty' },
           ]) });
@@ -599,7 +599,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySource', value: 'I will not be empty' },
             { type: 'nonEmptySourceNoMeta', value: 'I will also not be empty, but have no metadata' },
           ]) });
@@ -633,7 +633,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySourceNoMeta', value: 'I will not be empty' },
             { type: 'nonEmptySourceNoMeta', value: 'I will also not be empty, but have no metadata' },
           ]) });
@@ -667,7 +667,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySource', value: 'I will not be empty' },
             { type: 'nonEmptySourceInfMeta', value: 'I will also not be empty, but have inf metadata' },
           ]) });
@@ -701,7 +701,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          AsyncReiterableArray.forFixedData([
+          AsyncReiterableArray.fromFixedData([
             { type: 'nonEmptySourceInfMeta', value: 'I will not be empty' },
             { type: 'nonEmptySourceInfMeta', value: 'I will also not be empty, but have inf metadata' },
           ]) });

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -1,6 +1,7 @@
 import {ActionContext} from "@comunica/core";
 import {ArrayIterator, EmptyIterator} from "asynciterator";
 import {RoundRobinUnionIterator} from "asynciterator-union";
+import {AsyncReiterableArray} from "asyncreiterable";
 import {blankNode, defaultGraph, literal, namedNode, quad, variable} from "rdf-data-model";
 import {FederatedQuadSource} from "../lib/FederatedQuadSource";
 const squad = require('rdf-quad');
@@ -37,7 +38,7 @@ describe('FederatedQuadSource', () => {
       },
     };
     context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-        [ { type: 'myType', value: 'myValue' } ] });
+        AsyncReiterableArray.forFixedData([ { type: 'myType', value: 'myValue' } ]) });
   });
 
   describe('The FederatedQuadSource module', () => {
@@ -308,7 +309,8 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [] });
+      contextEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([]) });
       source = new FederatedQuadSource(mediator, contextEmpty, emptyPatterns, true);
     });
 
@@ -333,7 +335,7 @@ describe('FederatedQuadSource', () => {
     beforeEach(() => {
       emptyPatterns = {};
       contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [ { type: 'emptySource', value: 'I will be empty' } ] });
+          AsyncReiterableArray.forFixedData([ { type: 'emptySource', value: 'I will be empty' } ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -373,9 +375,8 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingle = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-      ] });
+      contextSingle = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([{ type: 'nonEmptySource', value: 'I will not be empty' }]) });
       source = new FederatedQuadSource(mediator, contextSingle, emptyPatterns, true);
     });
 
@@ -415,10 +416,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'emptySource', value: 'I will be empty' },
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'emptySource', value: 'I will be empty' },
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -463,10 +465,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'emptySource', value: 'I will be empty' },
-        { type: 'emptySource', value: 'I will be empty' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'emptySource', value: 'I will be empty' },
+            { type: 'emptySource', value: 'I will be empty' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -507,10 +510,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'emptySource', value: 'I will be empty' },
-        { type: 'emptySource', value: 'I will be empty' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'emptySource', value: 'I will be empty' },
+            { type: 'emptySource', value: 'I will be empty' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, false);
     });
 
@@ -546,10 +550,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-        { type: 'nonEmptySource2', value: 'I will also not be empty' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+            { type: 'nonEmptySource2', value: 'I will also not be empty' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -593,10 +598,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-        { type: 'nonEmptySourceNoMeta', value: 'I will also not be empty, but have no metadata' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+            { type: 'nonEmptySourceNoMeta', value: 'I will also not be empty, but have no metadata' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -626,10 +632,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySourceNoMeta', value: 'I will not be empty' },
-        { type: 'nonEmptySourceNoMeta', value: 'I will also not be empty, but have no metadata' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySourceNoMeta', value: 'I will not be empty' },
+            { type: 'nonEmptySourceNoMeta', value: 'I will also not be empty, but have no metadata' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -659,10 +666,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySource', value: 'I will not be empty' },
-        { type: 'nonEmptySourceInfMeta', value: 'I will also not be empty, but have inf metadata' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySource', value: 'I will not be empty' },
+            { type: 'nonEmptySourceInfMeta', value: 'I will also not be empty, but have inf metadata' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 
@@ -692,10 +700,11 @@ describe('FederatedQuadSource', () => {
 
     beforeEach(() => {
       emptyPatterns = {};
-      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-        { type: 'nonEmptySourceInfMeta', value: 'I will not be empty' },
-        { type: 'nonEmptySourceInfMeta', value: 'I will also not be empty, but have inf metadata' },
-      ] });
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.forFixedData([
+            { type: 'nonEmptySourceInfMeta', value: 'I will not be empty' },
+            { type: 'nonEmptySourceInfMeta', value: 'I will also not be empty, but have inf metadata' },
+          ]) });
       source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
     });
 

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -13,7 +13,7 @@ describe('FederatedQuadSource', () => {
   beforeEach(() => {
     mediator = {
       mediate: (action) => {
-        const type = action.context.get('@comunica/bus-rdf-resolve-quad-pattern:sources')[0].type;
+        const type = action.context.get('@comunica/bus-rdf-resolve-quad-pattern:source').type;
         if (type === 'emptySource') {
           return Promise.resolve({ data: new EmptyIterator(),
             metadata: () => Promise.resolve({ totalItems: 0 }) });

--- a/packages/actor-rdf-resolve-quad-pattern-file/lib/ActorRdfResolveQuadPatternFile.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-file/lib/ActorRdfResolveQuadPatternFile.ts
@@ -47,7 +47,7 @@ export class ActorRdfResolveQuadPatternFile extends ActorRdfResolveQuadPatternSo
   }
 
   protected async getSource(context: ActionContext): Promise<ILazyQuadSource> {
-    const file: string = this.getContextSources(context)[0].value;
+    const file: string = this.getContextSource(context).value;
     if (!this.stores[file]) {
       await this.initializeFile(file, context);
     }
@@ -59,7 +59,7 @@ export class ActorRdfResolveQuadPatternFile extends ActorRdfResolveQuadPatternSo
     // Attach totalItems to the output
     const output: IActorRdfResolveQuadPatternOutput = await super.getOutput(source, pattern, context);
     output.metadata = () => new Promise((resolve, reject) => {
-      const file: string = this.getContextSources(context)[0].value;
+      const file: string = this.getContextSource(context).value;
       this.stores[file].then((store) => {
         const totalItems: number = store.countTriplesByIRI(
           N3StoreIterator.termToString(pattern.subject),

--- a/packages/actor-rdf-resolve-quad-pattern-file/test/ActorRdfResolveQuadPatternFile-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-file/test/ActorRdfResolveQuadPatternFile-test.ts
@@ -54,7 +54,7 @@ describe('ActorRdfResolveQuadPatternFile', () => {
 
     it('should test', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'file', value: 'abc'  }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'file', value: 'abc' }}) }))
         .resolves.toBeTruthy();
     });
 
@@ -68,54 +68,56 @@ describe('ActorRdfResolveQuadPatternFile', () => {
 
     it('should not test on an invalid file', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { sources: [{ type: 'file', value: null  }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'file', value: null  }}) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on no file', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { sources: [{ type: 'entrypoint', value: null  }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'entrypoint', value: null  }}) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on no sources', () => {
-      return expect(actor.test({ pattern: null, context: ActionContext({ sources: [] }) }))
+      return expect(actor.test({ pattern: null, context: ActionContext(
+        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [] }) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on multiple sources', () => {
       return expect(actor.test(
         { pattern: null, context: ActionContext(
-          { sources: [{ type: 'file', value: 'a' }, { type: 'file', value: 'b' }] }) }))
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'file', value: 'a' },
+              { type: 'file', value: 'b' }] }) }))
         .rejects.toBeTruthy();
     });
 
     it('should allow file initialization with a valid file', () => {
-      return expect(actor.initializeFile('myfile')).resolves.toBeTruthy();
+      return expect(actor.initializeFile('myfile', null)).resolves.toBeTruthy();
     });
 
     it('should fail on file initialization with an invalid file', () => {
-      return expect(actor.initializeFile(null)).rejects.toBeTruthy();
+      return expect(actor.initializeFile(null, null)).rejects.toBeTruthy();
     });
 
     it('should allow a file quad source to be created for a context with a valid file', () => {
-      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'file', value: 'myFile'  }] }))).resolves.toBeTruthy();
+      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'file', value: 'myFile'  }}))).resolves.toBeTruthy();
     });
 
     it('should fail on creating a file quad source for a context with an invalid file', () => {
-      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'file', value: null  }] }))).rejects.toBeTruthy();
+      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'file', value: null  }}))).rejects.toBeTruthy();
     });
 
     it('should create only a file quad source only once per file', () => {
       let doc1 = null;
-      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'file', value: 'myFile'  }] }))
+      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'file', value: 'myFile'  }}))
         .then((file: any) => {
           doc1 = file.store;
-          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-              [{ type: 'file', value: 'myFile'  }] }));
+          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+              { type: 'file', value: 'myFile'  }}));
         })
         .then((file: any) => {
           expect(file.store).toBe(doc1);
@@ -124,12 +126,12 @@ describe('ActorRdfResolveQuadPatternFile', () => {
 
     it('should create different documents in file quad source for different files', () => {
       let doc1 = null;
-      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'file', value: 'myFile1'  }] }))
+      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'file', value: 'myFile1'  }}))
         .then((file: any) => {
           doc1 = file.store;
-          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-              [{ type: 'file', value: 'myFile2'  }] }));
+          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+              { type: 'file', value: 'myFile2'  }}));
         })
         .then((file: any) => {
           expect(file.store).not.toBe(doc1);
@@ -146,7 +148,7 @@ describe('ActorRdfResolveQuadPatternFile', () => {
     it('should run on ? ? ?', () => {
       const pattern = quad('?', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'file', value: 'abc'  }] }) })
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'file', value: 'abc'  }}) })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 8 });
           expect(await arrayifyStream(output.data)).toEqual([
@@ -165,7 +167,7 @@ describe('ActorRdfResolveQuadPatternFile', () => {
     it('should run on s1 ? ?', () => {
       const pattern = quad('s1', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'file', value: 'abc'  }] }) })
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'file', value: 'abc' }}) })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 4 });
           expect(await arrayifyStream(output.data)).toEqual([
@@ -180,7 +182,7 @@ describe('ActorRdfResolveQuadPatternFile', () => {
     it('should run on s3 ? ?', () => {
       const pattern = quad('s3', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'file', value: 'abc'  }] }) })
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'file', value: 'abc' }}) })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 0 });
           expect(await arrayifyStream(output.data)).toEqual([]);

--- a/packages/actor-rdf-resolve-quad-pattern-hdt/lib/ActorRdfResolveQuadPatternHdt.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hdt/lib/ActorRdfResolveQuadPatternHdt.ts
@@ -64,7 +64,7 @@ export class ActorRdfResolveQuadPatternHdt extends ActorRdfResolveQuadPatternSou
   }
 
   protected async getSource(context: ActionContext): Promise<ILazyQuadSource> {
-    const hdtFile: string = this.getContextSources(context)[0].value;
+    const hdtFile: string = this.getContextSource(context).value;
     if (!this.hdtDocuments[hdtFile]) {
       await this.initializeHdt(hdtFile);
     }

--- a/packages/actor-rdf-resolve-quad-pattern-hdt/test/ActorRdfResolveQuadPatternHdt-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hdt/test/ActorRdfResolveQuadPatternHdt-test.ts
@@ -52,7 +52,7 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
 
     it('should test', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hdtFile', value: 'abc'  }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hdtFile', value: 'abc'  }}) }))
         .resolves.toBeTruthy();
     });
 
@@ -66,26 +66,26 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
 
     it('should not test on an invalid file', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { sources: [{ type: 'hdtFile', value: null  }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hdtFile', value: null  }}) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on no file', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { sources: [{ type: 'entrypoint', value: null  }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'entrypoint', value: null  }}) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on no sources', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { sources: [] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [] }) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on multiple sources', () => {
       return expect(actor.test(
-        { pattern: null, context: ActionContext(
-          { sources: [{ type: 'hdtFile', value: 'a' }, { type: 'hdtFile', value: 'b' }] }) }))
+        { pattern: null, context: ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+              [{ type: 'hdtFile', value: 'a' }, { type: 'hdtFile', value: 'b' }] }) }))
         .rejects.toBeTruthy();
     });
 
@@ -98,23 +98,24 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
     });
 
     it('should allow a HDT quad source to be created for a context with a valid file', () => {
-      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'hdtFile', value: 'myFile'  }] })))
+      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'hdtFile', value: 'myFile'  }})))
         .resolves.toBeTruthy();
     });
 
     it('should fail on creating a HDT quad source for a context with an invalid file', () => {
-      return expect((<any> actor).getSource({ sources: [{ type: 'hdtFile', value: null  }] })).rejects.toBeTruthy();
+      return expect((<any> actor).getSource({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          { type: 'hdtFile', value: null  }})).rejects.toBeTruthy();
     });
 
     it('should create only a HDT quad source only once per file', () => {
       let doc1 = null;
-      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'hdtFile', value: 'myFile'  }] }))
+      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'hdtFile', value: 'myFile'  }}))
         .then((file: any) => {
           doc1 = file.hdtDocument;
-          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-              [{ type: 'hdtFile', value: 'myFile'  }] }));
+          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+              { type: 'hdtFile', value: 'myFile'  }}));
         })
         .then((file: any) => {
           expect(file.hdtDocument).toBe(doc1);
@@ -123,13 +124,13 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
 
     it('should create different documents in HDT quad source for different files', () => {
       let doc1 = null;
-      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'hdtFile', value: 'myFile1'  }] }))
+      return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'hdtFile', value: 'myFile1' }}))
         .then((file: any) => {
           doc1 = file.hdtDocument;
           require('hdt').__setMockedDocument(new MockedHdtDocument([]));
-          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-              [{ type: 'hdtFile', value: 'myFile2'  }] }));
+          return (<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+              { type: 'hdtFile', value: 'myFile2' }}));
         })
         .then((file: any) => {
           expect(file.hdtDocument).not.toBe(doc1);
@@ -145,7 +146,7 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
     it('should run on ? ? ?', () => {
       const pattern = quad('?', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hdtFile', value: 'abc'  }] }) })
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hdtFile', value: 'abc'  }}) })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 8 });
           expect(await arrayifyStream(output.data)).toEqual([
@@ -164,7 +165,7 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
     it('should run on ? ? ? without data', () => {
       const pattern = quad('?', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hdtFile', value: 'abc'  }] }) })
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hdtFile', value: 'abc'  }}) })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 8 });
         });
@@ -173,7 +174,7 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
     it('should run on s1 ? ?', () => {
       const pattern = quad('s1', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hdtFile', value: 'abc'  }] }) })
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hdtFile', value: 'abc'  }}) })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 4 });
           expect(await arrayifyStream(output.data)).toEqual([
@@ -188,7 +189,7 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
     it('should run on s3 ? ?', () => {
       const pattern = quad('s3', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hdtFile', value: 'abc'  }] }) })
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hdtFile', value: 'abc'  }}) })
         .then(async (output) => {
           expect(await output.metadata()).toEqual({ totalItems: 0 });
           expect(await arrayifyStream(output.data)).toEqual([]);
@@ -208,7 +209,7 @@ describe('ActorRdfResolveQuadPatternHdt', () => {
       expect((<any> actor).shouldClose).toBe(true);
       const pattern = quad('s3', '?', '?');
       return actor.run({ pattern, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hdtFile', value: 'abc'  }] }) })
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hdtFile', value: 'abc'  }}) })
         .then(async (output) => {
           expect(await arrayifyStream(output.data)).toBeTruthy();
           expect((<any> actor).shouldClose).toBe(false);

--- a/packages/actor-rdf-resolve-quad-pattern-qpf/lib/ActorRdfResolveQuadPatternQpf.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-qpf/lib/ActorRdfResolveQuadPatternQpf.ts
@@ -83,7 +83,7 @@ export class ActorRdfResolveQuadPatternQpf extends ActorRdfResolveQuadPatternSou
     const uriConstructor = async (subject?: RDF.Term, predicate?: RDF.Term, object?: RDF.Term, graph?: RDF.Term) => {
       if (!chosenForm) {
         // Collect metadata of the hypermedia
-        const hypermedia: string = this.getContextSources(context)[0].value;
+        const hypermedia: string = this.getContextSource(context).value;
 
         // Save the form, so it is determined only once per source.
         chosenForm = this.chooseForm(hypermedia, context);
@@ -110,7 +110,7 @@ export class ActorRdfResolveQuadPatternQpf extends ActorRdfResolveQuadPatternSou
 
   protected async getSource(context: ActionContext): Promise<ILazyQuadSource> {
     // Cache the source object for each hypermedia entrypoint
-    const hypermedia: string = this.getContextSources(context)[0].value;
+    const hypermedia: string = this.getContextSource(context).value;
     if (this.sources[hypermedia]) {
       return this.sources[hypermedia];
     }

--- a/packages/actor-rdf-resolve-quad-pattern-qpf/test/ActorRdfResolveQuadPatternQpf-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-qpf/test/ActorRdfResolveQuadPatternQpf-test.ts
@@ -136,7 +136,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
     it('should test', () => {
       return expect(actor.test(
         { pattern: pattern1, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})}))
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})}))
         .resolves.toBeTruthy();
     });
 
@@ -151,7 +151,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
     it('should run and error in the stream when no metadata is available', () => {
       mediator.mediate = () => Promise.resolve({});
       return actor.run({ pattern: pattern1, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(arrayifyStream(output.data)).rejects
             .toEqual(new Error('No metadata was found at hypermedia entrypoint hypermedia'));
@@ -161,7 +161,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
     it('should not run when no metadata search forms are available', () => {
       mediator.mediate = () => Promise.resolve({ firstPageMetadata: () => Promise.resolve({}) });
       return actor.run({ pattern: pattern1, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(arrayifyStream(output.data)).rejects
             .toEqual(new Error('No Hydra search forms were discovered in the metadata of hypermedia. ' +
@@ -173,7 +173,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
       mediator.mediate = () => Promise.resolve(
         { firstPageMetadata: () => Promise.resolve({ searchForms: { values: [] } }) });
       return actor.run({ pattern: pattern1, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(arrayifyStream(output.data)).rejects
             .toEqual(new Error('No Hydra search forms were discovered in the metadata of hypermedia. ' +
@@ -196,7 +196,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
         ]}})});
 
       return actor.run({ pattern: pattern1, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(arrayifyStream(output.data)).rejects
             .toEqual(new Error('No valid Hydra search form was found for quad pattern or triple pattern queries.'));
@@ -205,7 +205,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 1', () => {
       return actor.run({ pattern: pattern1, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataQpf);
           expect(await arrayifyStream(output.data)).toEqual([
@@ -218,7 +218,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 2', () => {
       return actor.run({ pattern: pattern2, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataQpf);
           expect(await arrayifyStream(output.data)).toEqual([
@@ -231,7 +231,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 3', () => {
       return actor.run({ pattern: pattern3, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataQpf);
           expect(await arrayifyStream(output.data)).toEqual([
@@ -244,7 +244,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 4', () => {
       return actor.run({ pattern: pattern4, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataQpf);
           expect(await arrayifyStream(output.data)).toEqual([
@@ -257,7 +257,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 5', () => {
       return actor.run({ pattern: pattern5, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataQpf);
           expect(await arrayifyStream(output.data)).toEqual([
@@ -270,7 +270,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 6', () => {
       return actor.run({ pattern: pattern6, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataQpf);
           expect(await arrayifyStream(output.data)).toEqual([
@@ -286,7 +286,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 6 when only the data is called', () => {
       return actor.run({ pattern: pattern6, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await arrayifyStream(output.data)).toEqual([
             quad(namedNode('"a","b"@nl,"c"^^data,_/a'), namedNode('"a","b"@nl,"c"^^data,_/a'),
@@ -301,7 +301,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
 
     it('should run for QPF pattern 6 when only the metadata is called', () => {
       return actor.run({ pattern: pattern6, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataQpf);
         });
@@ -311,7 +311,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
       mediator.mediate = (action) => { throw new Error('This should not be called'); };
       return expect(actor.run(
         { pattern: pattern6, context: ActionContext(
-          { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})}))
+            { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})}))
         .resolves.toBeTruthy();
     });
 
@@ -321,7 +321,7 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
         firstPageMetadata: () => Promise.resolve(metadataTpf),
       });
       return actor.run({ pattern: pattern2, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataTpf);
           expect(await arrayifyStream(output.data)).toEqual([ 'a,b,_/a', 'a,b,_/b', 'a,b,_/c' ]);
@@ -334,13 +334,13 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
         firstPageMetadata: () => Promise.resolve(metadataTpf),
       });
       return actor.run({ pattern: pattern2, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(async (output) => {
           expect(await output.metadata()).toBe(metadataTpf);
           expect(await arrayifyStream(output.data)).toEqual([ 'a,b,_/a', 'a,b,_/b', 'a,b,_/c' ]);
           return actor.run(
             { pattern: pattern2, context: ActionContext(
-              { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+                { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
             .then(async (output2) => {
               expect(await output2.metadata()).toBe(metadataTpf);
               expect(await arrayifyStream(output2.data)).toEqual([ 'a,b,_/a', 'a,b,_/b', 'a,b,_/c' ]);
@@ -351,10 +351,10 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
     it('should cache when run for the same hypermedia twice', () => {
       const spy = jest.spyOn(<any> actor, 'createSource');
       return actor.run({ pattern: pattern1, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
         .then(() => {
           actor.run({ pattern: pattern1, context: ActionContext(
-            { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia' } ]})})
+              { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia' }})})
             .then(() => {
               expect(spy).toHaveBeenCalledTimes(1);
             });
@@ -364,10 +364,10 @@ describe('ActorRdfResolveQuadPatternQpf', () => {
     it('should not cache when run for different hypermedias', () => {
       const spy = jest.spyOn(<any> actor, 'createSource');
       return actor.run({ pattern: pattern1, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia1' } ]})})
+          { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia1' }})})
         .then(() => {
           actor.run({ pattern: pattern1, context: ActionContext(
-            { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'hypermedia', value: 'hypermedia2' } ]})})
+              { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'hypermedia', value: 'hypermedia2' }})})
             .then(() => {
               expect(spy).toHaveBeenCalledTimes(2);
             });

--- a/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/ActorRdfResolveQuadPatternRdfJsSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/ActorRdfResolveQuadPatternRdfJsSource.ts
@@ -15,14 +15,14 @@ export class ActorRdfResolveQuadPatternRdfJsSource extends ActorRdfResolveQuadPa
     if (!this.hasContextSingleSource('rdfjsSource', action.context)) {
       throw new Error(this.name + ' requires a single source with an rdfjsSource to be present in the context.');
     }
-    if (!this.getContextSources(action.context)[0].value.match) {
+    if (!this.getContextSource(action.context).value.match) {
       throw new Error(this.name + ' received an invalid rdfjsSource.');
     }
     return true;
   }
 
   protected async getSource(context: ActionContext): Promise<ILazyQuadSource> {
-    return <any> this.getContextSources(context)[0].value;
+    return <any> this.getContextSource(context).value;
   }
 
 }

--- a/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/test/ActorRdfResolveQuadPatternRdfJsSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/test/ActorRdfResolveQuadPatternRdfJsSource-test.ts
@@ -40,7 +40,7 @@ describe('ActorRdfResolveQuadPatternRdfJsSource', () => {
 
     it('should test', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'rdfjsSource', value: source  }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'rdfjsSource', value: source  } }) }))
         .resolves.toBeTruthy();
     });
 
@@ -54,19 +54,19 @@ describe('ActorRdfResolveQuadPatternRdfJsSource', () => {
 
     it('should not test on an invalid source', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'rdfjsSource', value: null }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'rdfjsSource', value: null } }) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on an invalid source type', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'rdfjsSource', value: {} }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'rdfjsSource', value: {} } }) }))
         .rejects.toBeTruthy();
     });
 
     it('should not test on no source', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{ type: 'entrypoint', value: null }] }) }))
+        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'entrypoint', value: null } }) }))
         .rejects.toBeTruthy();
     });
 
@@ -85,8 +85,8 @@ describe('ActorRdfResolveQuadPatternRdfJsSource', () => {
     });
 
     it('should get the source', () => {
-      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-          [{ type: 'rdfjsSource', value: source }] })))
+      return expect((<any> actor).getSource(ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+          { type: 'rdfjsSource', value: source } })))
         .resolves.toMatchObject(source);
     });
   });

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/lib/ActorRdfResolveQuadPatternSparqlJson.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/lib/ActorRdfResolveQuadPatternSparqlJson.ts
@@ -154,7 +154,7 @@ export class ActorRdfResolveQuadPatternSparqlJson
   }
 
   public async run(action: IActionRdfResolveQuadPattern): Promise<IActorRdfResolveQuadPatternOutput> {
-    const endpoint: string = this.getContextSources(action.context)[0].value;
+    const endpoint: string = this.getContextSource(action.context).value;
     const pattern = ActorRdfResolveQuadPatternSparqlJson.replaceBlankNodes(action.pattern);
     const selectQuery: string = ActorRdfResolveQuadPatternSparqlJson.patternToSelectQuery(pattern);
     const countQuery: string = ActorRdfResolveQuadPatternSparqlJson.patternToCountQuery(pattern);

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/test/ActorRdfResolveQuadPatternSparqlJson-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/test/ActorRdfResolveQuadPatternSparqlJson-test.ts
@@ -148,8 +148,8 @@ describe('ActorRdfResolveQuadPatternSparqlJson', () => {
   describe('An ActorRdfResolveQuadPatternSparqlJson instance', () => {
     let actor: ActorRdfResolveQuadPatternSparqlJson;
     const pattern: any = quad('s', '?p', 'o');
-    const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
-        [ { type: 'sparql', value: 'http://ex' } ] });
+    const context = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:source':
+        { type: 'sparql', value: 'http://ex' } });
     const mediatorHttp: any = {
       mediate: (action) => {
         // tslint:disable: no-trailing-whitespace
@@ -477,7 +477,7 @@ describe('ActorRdfResolveQuadPatternSparqlJson', () => {
 
     it('should allow multiple _read calls on query bindings', () => {
       const thisActor = new ActorRdfResolveQuadPatternSparqlJson({ name: 'actor', bus, mediatorHttp });
-      return thisActor.queryBindings('http://ex', '').then((data) => {
+      return thisActor.queryBindings('http://ex', '', null).then((data) => {
         (<any> data)._read(1, () => { return; });
         (<any> data)._read(1, () => { return; });
       });

--- a/packages/bus-rdf-resolve-quad-pattern/lib/ActorRdfResolveQuadPattern.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/ActorRdfResolveQuadPattern.ts
@@ -33,10 +33,19 @@ export abstract class ActorRdfResolveQuadPattern extends Actor<IActionRdfResolve
   /**
    * Get the sources from the given context.
    * @param {ActionContext} context An optional context.
-   * @return {{type: string; value: string}[]} The array of sources or null.
+   * @return {IDataSource[]} The array of sources or null.
    */
-  protected getContextSources(context: ActionContext): { type: string, value: string }[] {
+  protected getContextSources(context: ActionContext): IDataSource[] {
     return context ? context.get(KEY_CONTEXT_SOURCES) : null;
+  }
+
+  /**
+   * Get the source from the given context.
+   * @param {ActionContext} context An optional context.
+   * @return {IDataSource} The source or null.
+   */
+  protected getContextSource(context: ActionContext): IDataSource {
+    return context ? context.get(KEY_CONTEXT_SOURCE) : null;
   }
 
   /**
@@ -46,17 +55,27 @@ export abstract class ActorRdfResolveQuadPattern extends Actor<IActionRdfResolve
    * @return {boolean} If the given context has a single source of the given type.
    */
   protected hasContextSingleSource(requiredType: string, context: ActionContext): boolean {
-    const sources = this.getContextSources(context);
-    return !!(sources && sources.length === 1 && sources[0].type === requiredType && sources[0].value);
+    const source = this.getContextSource(context);
+    return !!(source && source.type === requiredType && source.value);
   }
 
 }
 
+export interface IDataSource {
+  type: string;
+  value: any;
+}
+export type DataSources = IDataSource[];
 /**
  * @type {string} Context entry for data sources.
- * @value { type: string; value: any }[] An array of sources.
+ * @value {DataSources} An array or stream of sources.
  */
 export const KEY_CONTEXT_SOURCES: string = '@comunica/bus-rdf-resolve-quad-pattern:sources';
+/**
+ * @type {string} Context entry for a data source.
+ * @value {IDataSource} A source.
+ */
+export const KEY_CONTEXT_SOURCE: string = '@comunica/bus-rdf-resolve-quad-pattern:source';
 
 export interface IActionRdfResolveQuadPattern extends IAction {
   /**

--- a/packages/bus-rdf-resolve-quad-pattern/lib/ActorRdfResolveQuadPattern.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/ActorRdfResolveQuadPattern.ts
@@ -1,5 +1,6 @@
 import {ActionContext, Actor, IAction, IActorArgs, IActorOutput, IActorTest} from "@comunica/core";
 import {AsyncIterator} from "asynciterator";
+import {AsyncReiterable} from "asyncreiterable";
 import * as RDF from "rdf-js";
 
 /**
@@ -65,7 +66,7 @@ export interface IDataSource {
   type: string;
   value: any;
 }
-export type DataSources = IDataSource[];
+export type DataSources = AsyncReiterable<IDataSource>;
 /**
  * @type {string} Context entry for data sources.
  * @value {DataSources} An array or stream of sources.

--- a/packages/bus-rdf-resolve-quad-pattern/package.json
+++ b/packages/bus-rdf-resolve-quad-pattern/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "asynciterator": "^2.0.0",
-    "asyncreiterable": "^1.0.0"
+    "asyncreiterable": "^1.1.0"
   },
   "peerDependencies": {
     "@comunica/core": "^1.0.0"

--- a/packages/bus-rdf-resolve-quad-pattern/package.json
+++ b/packages/bus-rdf-resolve-quad-pattern/package.json
@@ -34,7 +34,8 @@
     "index.js"
   ],
   "dependencies": {
-    "asynciterator": "^2.0.0"
+    "asynciterator": "^2.0.0",
+    "asyncreiterable": "^1.0.0"
   },
   "peerDependencies": {
     "@comunica/core": "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,9 +543,9 @@ asynciterator-promiseproxy@^2.0.0:
   dependencies:
     asynciterator "^2.0.0"
 
-asynciterator-union@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/asynciterator-union/-/asynciterator-union-2.0.0.tgz#243236fb12ddea77e3c3c19eaa691c2e486c6f4a"
+asynciterator-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/asynciterator-union/-/asynciterator-union-2.1.0.tgz#607fde4d33478e511f60f00332cf5247c8900270"
   dependencies:
     asynciterator "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,9 +565,9 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-asyncreiterable@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/asyncreiterable/-/asyncreiterable-1.0.0.tgz#76d1ac01c34ebf4bdb415d42ff0656529813c4c1"
+asyncreiterable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/asyncreiterable/-/asyncreiterable-1.1.0.tgz#438175b924139d52503cfbf050e5d61fe19c79c4"
   dependencies:
     asynciterator "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,6 +565,12 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+asyncreiterable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/asyncreiterable/-/asyncreiterable-1.0.0.tgz#76d1ac01c34ebf4bdb415d42ff0656529813c4c1"
+  dependencies:
+    asynciterator "^2.0.0"
+
 atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"


### PR DESCRIPTION
As discussed offline, this makes it so that sources are represented in a stream-like fashion instead of an array. For this the [AsyncReiterable](https://www.npmjs.com/package/asyncreiterable) datastructure was introduced.

This is needed for adding additional sources at query-time.

More information can be found in the commits.