### PR TITLE
Feature/queryoperation sparql endpoint

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -90,6 +90,7 @@
         "packages/mediator-combine-union/package.json",
         "packages/mediator-number/package.json",
         "packages/mediator-race/package.json",
+        "packages/mediatortype-httprequests/package.json",
         "packages/mediatortype-iterations/package.json",
         "packages/mediatortype-priority/package.json",
         "packages/mediatortype-time/package.json",

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -35,6 +35,7 @@
         "packages/actor-query-operation-orderby-direct/package.json",
         "packages/actor-query-operation-project/package.json",
         "packages/actor-query-operation-quadpattern/package.json",
+        "packages/actor-query-operation-service/package.json",
         "packages/actor-query-operation-slice/package.json",
         "packages/actor-query-operation-sparql-endpoint/package.json",
         "packages/actor-query-operation-union/package.json",

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -36,6 +36,7 @@
         "packages/actor-query-operation-project/package.json",
         "packages/actor-query-operation-quadpattern/package.json",
         "packages/actor-query-operation-slice/package.json",
+        "packages/actor-query-operation-sparql-endpoint/package.json",
         "packages/actor-query-operation-union/package.json",
         "packages/actor-query-operation-values/package.json",
         "packages/actor-rdf-dereference-file/package.json",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "immutable": "^3.8.2",
     "isomorphic-fetch": "^2.2.1",
     "jest": "^23.1.0",
+    "jest-rdf": "^1.0.0",
     "lerna": "^2.11.0",
     "lodash.assign": "^4.2.0",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "pre-commit": "^1.2.2",
     "rdf-data-model": "^1.0.0",
     "rdf-quad": "^1.1.0",
-    "sparqlalgebrajs": "^0.7.5",
+    "sparqlalgebrajs": "^1.0.1",
     "stream-to-string": "^1.1.0",
     "streamify-array": "^1.0.0",
     "streamify-string": "^1.0.1",

--- a/packages/actor-context-preprocess-rdf-source-identifier/lib/ActorContextPreprocessRdfSourceIdentifier.ts
+++ b/packages/actor-context-preprocess-rdf-source-identifier/lib/ActorContextPreprocessRdfSourceIdentifier.ts
@@ -56,6 +56,11 @@ export class ActorContextPreprocessRdfSourceIdentifier extends ActorContextPrepr
         }
       }
 
+      // If the sources are fixed, block until all sources are transformed.
+      if (sources.isEnded()) {
+        await new Promise((resolve) => it.on('end', resolve));
+      }
+
       return { context: action.context.set(KEY_CONTEXT_SOURCES, newSources) };
     }
     return action;

--- a/packages/actor-context-preprocess-rdf-source-identifier/test/ActorContextPreprocessRdfSourceIdentifier-test.ts
+++ b/packages/actor-context-preprocess-rdf-source-identifier/test/ActorContextPreprocessRdfSourceIdentifier-test.ts
@@ -70,6 +70,26 @@ describe('ActorContextPreprocessRdfSourceIdentifier', () => {
         .toEqual([{ type: 'dummy' }, { type: 'dummy' }]);
     });
 
+    it('should run for a context with two ended dummy sources and block until the sources become ended', async () => {
+      return expect((await actor.run({
+        context: ActionContext(
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([
+              { type: 'dummy' },
+              { type: 'dummy' },
+          ]) }),
+      })).context.get('@comunica/bus-rdf-resolve-quad-pattern:sources').isEnded()).toBeTruthy();
+    });
+
+    it('should run for a context with two non-ended dummy sources and not block until the sources end', async () => {
+      return expect((await actor.run({
+        context: ActionContext(
+          { '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromInitialData([
+              { type: 'dummy' },
+              { type: 'dummy' },
+          ]) }),
+      })).context.get('@comunica/bus-rdf-resolve-quad-pattern:sources').isEnded()).toBeFalsy();
+    });
+
     it('should run for a context with two auto sources', async () => {
       return expect(await arrayifyStream((await actor.run({
         context: ActionContext(

--- a/packages/actor-init-sparql/config/sets/resolve-sparql.json
+++ b/packages/actor-init-sparql/config/sets/resolve-sparql.json
@@ -4,6 +4,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^1.0.0/components/context.jsonld",
 
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-sparql-endpoint/^1.0.0/components/context.jsonld",
 
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld",
 
@@ -18,7 +19,15 @@
         "@id": "config-sets:resolve-sparql.json#mediatorHttp",
         "@type": "MediatorNumberMin",
         "field": "time",
+        "ignoreErrors": true,
         "cc:Mediator/bus": { "@id": "cbh:Bus/Http" }
+      }
+    },
+    {
+      "@id": "config-sets:resolve-sparql.json#mySparqlEndpointResolver",
+      "@type": "ActorQueryOperationSparqlEndpoint",
+      "caqose:Actor/QueryOperation/SparqlEndpoint/mediatorHttp": {
+        "@id": "config-sets:resolve-sparql.json#mediatorHttp"
       }
     }
   ]

--- a/packages/actor-init-sparql/config/sets/sparql-queryoperators.json
+++ b/packages/actor-init-sparql/config/sets/sparql-queryoperators.json
@@ -26,6 +26,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-rdf-resolve-quad-pattern/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-rdf-join/^1.0.0/components/context.jsonld",
 
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-number/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-race/^1.0.0/components/context.jsonld"
   ],
   "@id": "urn:comunica:my",
@@ -35,7 +36,9 @@
       "@type": "ActorQueryOperationAsk",
       "cbqo:mediatorQueryOperation": {
         "@id": "config-sets:sparql-queryoperators.json#mediatorQueryOperation",
-        "@type": "MediatorRace",
+        "@type": "MediatorNumberMin",
+        "field": "httpRequests",
+        "ignoreErrors": true,
         "cc:Mediator/bus": { "@id": "cbqo:Bus/QueryOperation" }
       }
     },

--- a/packages/actor-init-sparql/config/sets/sparql-queryoperators.json
+++ b/packages/actor-init-sparql/config/sets/sparql-queryoperators.json
@@ -18,6 +18,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-orderby-direct/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-project/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-quadpattern/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-service/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-slice/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-union/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-values/^1.0.0/components/context.jsonld",
@@ -41,6 +42,16 @@
         "ignoreErrors": true,
         "cc:Mediator/bus": { "@id": "cbqo:Bus/QueryOperation" }
       }
+    },
+
+    {
+      "@id": "config-sets:sparql-queryoperators.json#myServiceQueryOperator",
+      "@type": "ActorQueryOperationService",
+      "cbqo:mediatorQueryOperation": { "@id": "config-sets:sparql-queryoperators.json#mediatorQueryOperation" },
+      "caqoserv:Actor/QueryOperation/Service/mediatorRdfSourceIdentifier": {
+        "@id": "config-sets:context-preprocess-rdf-source-identifiers.json#mediatorRdfSourceIdentifier"
+      },
+      "caqoserv:Actor/QueryOperation/Service/forceSparqlEndpoint": false
     },
 
     {

--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -65,6 +65,7 @@
     "@comunica/actor-query-operation-project": "^1.1.0",
     "@comunica/actor-query-operation-quadpattern": "^1.1.0",
     "@comunica/actor-query-operation-slice": "^1.1.0",
+    "@comunica/actor-query-operation-sparql-endpoint": "^1.0.0",
     "@comunica/actor-query-operation-union": "^1.1.0",
     "@comunica/actor-query-operation-values": "^1.1.0",
     "@comunica/actor-rdf-dereference-http-parse": "^1.1.0",

--- a/packages/actor-query-operation-from-quad/package.json
+++ b/packages/actor-query-operation-from-quad/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "lodash.find": "^4.6.0",
-    "sparqlalgebrajs": "^0.7.5"
+    "sparqlalgebrajs": "^1.0.1"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-service/README.md
+++ b/packages/actor-query-operation-service/README.md
@@ -1,0 +1,17 @@
+# Comunica Service Query Operation Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-query-operation-service.svg)](https://www.npmjs.com/package/@comunica/actor-query-operation-service)
+
+A comunica Service Query Operation Actor.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-query-operation-service
+```
+
+## Usage
+
+TODO

--- a/packages/actor-query-operation-service/components/Actor/QueryOperation/Service.jsonld
+++ b/packages/actor-query-operation-service/components/Actor/QueryOperation/Service.jsonld
@@ -1,0 +1,48 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-service/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-query-operation/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/actor-query-operation-service",
+  "components": [
+    {
+      "@id": "caqoserv:Actor/QueryOperation/Service",
+      "@type": "Class",
+      "extends": "cbqo:Actor/QueryOperationTypedMediated",
+      "requireElement": "ActorQueryOperationService",
+      "comment": "A comunica Service Query Operation Actor.",
+      "parameters": [
+        {
+          "@id": "caqoserv:Actor/QueryOperation/Service/mediatorRdfSourceIdentifier",
+          "comment": "The RDF source identifier mediator",
+          "required": true,
+          "unique": true
+        },
+        {
+          "@id": "caqoserv:Actor/QueryOperation/Service/forceSparqlEndpoint",
+          "comment": "If the SERVICE target should be assumed to be a SPARQL endpoint",
+          "range": "xsd:boolean",
+          "unique": true,
+          "required": true,
+          "default": false
+        }
+      ],
+      "constructorArguments": [
+        {
+          "@id": "caqoserv:Actor/QueryOperation/Service/constructorArgumentsObject",
+          "extends": "cbqo:Actor/QueryOperationTypedMediated/constructorArgumentsObject",
+          "fields": [
+            {
+              "keyRaw": "mediatorRdfSourceIdentifier",
+              "value": "caqoserv:Actor/QueryOperation/Service/mediatorRdfSourceIdentifier"
+            },
+            {
+              "keyRaw": "forceSparqlEndpoint",
+              "value": "caqoserv:Actor/QueryOperation/Service/forceSparqlEndpoint"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/actor-query-operation-service/components/components.jsonld
+++ b/packages/actor-query-operation-service/components/components.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-service/^1.0.0/components/context.jsonld",
+  "@id": "npmd:@comunica/actor-query-operation-service",
+  "@type": "Module",
+  "requireName": "@comunica/actor-query-operation-service",
+  "import": [
+    "files-caqoserv:components/Actor/QueryOperation/Service.jsonld"
+  ]
+}

--- a/packages/actor-query-operation-service/components/context.jsonld
+++ b/packages/actor-query-operation-service/components/context.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/componentsjs/^3.0.0/components/context.jsonld",
+    {
+      "npmd": "https://linkedsoftwaredependencies.org/bundles/npm/",
+      "caqoserv": "npmd:@comunica/actor-query-operation-service/",
+      "files-caqoserv": "caqoserv:^1.0.0/",
+
+      "ActorQueryOperationService": "caqoserv:Actor/QueryOperation/Service"
+    }
+  ]
+}

--- a/packages/actor-query-operation-service/index.ts
+++ b/packages/actor-query-operation-service/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ActorQueryOperationService';

--- a/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
+++ b/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
@@ -1,0 +1,71 @@
+import {ActorQueryOperation, ActorQueryOperationTypedMediated,
+  Bindings, IActorQueryOperationOutputBindings,
+  IActorQueryOperationTypedMediatedArgs} from "@comunica/bus-query-operation";
+import {KEY_CONTEXT_SOURCE, KEY_CONTEXT_SOURCES} from "@comunica/bus-rdf-resolve-quad-pattern";
+import {IActionRdfSourceIdentifier, IActorRdfSourceIdentifierOutput} from "@comunica/bus-rdf-source-identifier";
+import {ActionContext, Actor, IActorTest, Mediator} from "@comunica/core";
+import {SingletonIterator} from "asynciterator";
+import {AsyncReiterableArray} from "asyncreiterable";
+import {Algebra} from "sparqlalgebrajs";
+
+/**
+ * A comunica Service Query Operation Actor.
+ * It unwraps the SERVICE operation and executes it on the given source.
+ */
+export class ActorQueryOperationService extends ActorQueryOperationTypedMediated<Algebra.Service> {
+
+  public readonly forceSparqlEndpoint: boolean;
+  public readonly mediatorRdfSourceIdentifier: Mediator<Actor<IActionRdfSourceIdentifier, IActorTest,
+    IActorRdfSourceIdentifierOutput>, IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput>;
+
+  constructor(args: IActorQueryOperationServiceArgs) {
+    super(args, 'service');
+  }
+
+  public async testOperation(pattern: Algebra.Service, context: ActionContext): Promise<IActorTest> {
+    if (pattern.name.termType !== 'NamedNode') {
+      throw new Error(`${this.name} can only query services by IRI, while a ${pattern.name.termType} was given.`);
+    }
+    return true;
+  }
+
+  public async runOperation(pattern: Algebra.Service, context: ActionContext)
+    : Promise<IActorQueryOperationOutputBindings> {
+    const endpoint: string = pattern.name.value;
+
+    // Adjust our context to only have the endpoint as source
+    context = context || ActionContext({});
+    let subContext: ActionContext = context.delete(KEY_CONTEXT_SOURCE).delete(KEY_CONTEXT_SOURCES);
+    const sourceType = this.forceSparqlEndpoint ? 'sparql' : (await this.mediatorRdfSourceIdentifier
+      .mediate({ sourceValue: endpoint, context: subContext })).sourceType;
+    subContext = subContext.set(KEY_CONTEXT_SOURCES,
+      AsyncReiterableArray.fromFixedData([{ type: sourceType, value: endpoint }]));
+
+    // Query the source
+    let output: IActorQueryOperationOutputBindings;
+    try {
+      output = ActorQueryOperation.getSafeBindings(
+        await this.mediatorQueryOperation.mediate({ operation: pattern.input, context: subContext }));
+    } catch (e) {
+      if (pattern.silent) {
+        // Emit a single empty binding
+        output = {
+          bindingsStream: new SingletonIterator(Bindings({})),
+          type: 'bindings',
+          variables: [],
+        };
+      } else {
+        throw e;
+      }
+    }
+
+    return output;
+  }
+
+}
+
+export interface IActorQueryOperationServiceArgs extends IActorQueryOperationTypedMediatedArgs {
+  forceSparqlEndpoint: boolean;
+  mediatorRdfSourceIdentifier: Mediator<Actor<IActionRdfSourceIdentifier, IActorTest,
+    IActorRdfSourceIdentifierOutput>, IActionRdfSourceIdentifier, IActorTest, IActorRdfSourceIdentifierOutput>;
+}

--- a/packages/actor-query-operation-service/package.json
+++ b/packages/actor-query-operation-service/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@comunica/actor-query-operation-service",
+  "version": "1.0.0",
+  "description": "A service query-operation actor",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-service",
+  "lsd:components": "components/components.jsonld",
+  "lsd:contexts": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-service/^1.0.0/components/context.jsonld": "components/context.jsonld"
+  },
+  "lsd:importPaths": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-service/^1.0.0/components/": "components/"
+  },
+  "main": "index.js",
+  "typings": "index",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/actor-query-operation-service",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "comunica",
+    "actor",
+    "query-operation",
+    "service"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://github.com/comunica/comunica#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "dependencies": {
+    "asynciterator": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@comunica/core": "^1.1.0",
+    "@comunica/bus-query-operation": "^1.1.0"
+  },
+  "devDependencies": {
+    "@comunica/core": "^1.1.0",
+    "@comunica/bus-query-operation": "^1.1.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true
+  },
+  "scripts": {
+    "test": "node \"../../node_modules/jest/bin/jest.js\" ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/actor-query-operation-service/test/ActorQueryOperationService-test.ts
+++ b/packages/actor-query-operation-service/test/ActorQueryOperationService-test.ts
@@ -1,0 +1,170 @@
+import {ActorQueryOperation, Bindings, IActorQueryOperationOutputBindings} from "@comunica/bus-query-operation";
+import {ActionContext, Bus} from "@comunica/core";
+import {ArrayIterator} from "asynciterator";
+import {literal, namedNode} from "rdf-data-model";
+import {ActorQueryOperationService} from "../lib/ActorQueryOperationService";
+const arrayifyStream = require('arrayify-stream');
+
+describe('ActorQueryOperationService', () => {
+  let bus;
+  let mediatorQueryOperation;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+    mediatorQueryOperation = {
+      mediate: (arg) => arg.operation === 'error'
+        ? Promise.reject(new Error('Endpoint error'))
+        : Promise.resolve({
+          bindingsStream: new ArrayIterator([
+            Bindings({ a: literal('1') }),
+            Bindings({ a: literal('2') }),
+            Bindings({ a: literal('3') }),
+          ]),
+          metadata: () => Promise.resolve({ totalItems: 3 }),
+          operated: arg,
+          type: 'bindings',
+          variables: ['?a'],
+        }),
+    };
+  });
+
+  describe('The ActorQueryOperationService module', () => {
+    it('should be a function', () => {
+      expect(ActorQueryOperationService).toBeInstanceOf(Function);
+    });
+
+    it('should be a ActorQueryOperationService constructor', () => {
+      expect(new (<any> ActorQueryOperationService)({ name: 'actor', bus, mediatorQueryOperation }))
+        .toBeInstanceOf(ActorQueryOperationService);
+      expect(new (<any> ActorQueryOperationService)({ name: 'actor', bus, mediatorQueryOperation }))
+        .toBeInstanceOf(ActorQueryOperation);
+    });
+
+    it('should not be able to create new ActorQueryOperationService objects without \'new\'', () => {
+      expect(() => { (<any> ActorQueryOperationService)(); }).toThrow();
+    });
+  });
+
+  describe('An ActorQueryOperationService instance', () => {
+    let actor: ActorQueryOperationService;
+    let mediatorRdfSourceIdentifier;
+    const forceSparqlEndpoint = true;
+
+    beforeEach(() => {
+      mediatorRdfSourceIdentifier = {
+        mediate: () => Promise.resolve({ sourceType: 'hypermedia' }),
+      };
+      actor = new ActorQueryOperationService(
+        { name: 'actor', bus, mediatorQueryOperation, forceSparqlEndpoint, mediatorRdfSourceIdentifier });
+    });
+
+    it('should test on service', () => {
+      const op = { operation: { type: 'service', silent: false, name: namedNode('dummy') } };
+      return expect(actor.test(op)).resolves.toBeTruthy();
+    });
+
+    it('should not test on non-service', () => {
+      const op = { operation: { type: 'some-other-type' } };
+      return expect(actor.test(op)).rejects.toBeTruthy();
+    });
+
+    it('should not test on service with a non-named node name', () => {
+      const op = { operation: { type: 'service', silent: false, name: literal('dummy') } };
+      return expect(actor.test(op)).rejects.toBeTruthy();
+    });
+
+    it('should run with context', () => {
+      const context = ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:sources': { type: 'bla', value: 'blabla' },
+      });
+      const op = { operation: { type: 'service', silent: false, name: literal('dummy') }, context };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['?a']);
+        expect(await output.metadata()).toEqual({ totalItems: 3 });
+        // tslint:disable:max-line-length
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({ a: literal('1') }),
+          Bindings({ a: literal('2') }),
+          Bindings({ a: literal('3') }),
+        ]);
+      });
+    });
+
+    it('should run without context', () => {
+      const op = { operation: { type: 'service', silent: false, name: literal('dummy') } };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['?a']);
+        expect(await output.metadata()).toEqual({ totalItems: 3 });
+        // tslint:disable:max-line-length
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({ a: literal('1') }),
+          Bindings({ a: literal('2') }),
+          Bindings({ a: literal('3') }),
+        ]);
+      });
+    });
+
+    it('should run on a silent operation when the endpoint errors', () => {
+      const op = { operation: { type: 'service', silent: true, name: literal('dummy'), input: 'error' } };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual([]);
+        expect(output.metadata).toBeFalsy();
+        // tslint:disable:max-line-length
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({}),
+        ]);
+      });
+    });
+
+    it('should not run on a non-silent operation when the endpoint errors', () => {
+      const op = { operation: { type: 'service', silent: false, name: literal('dummy'), input: 'error' } };
+      return expect(actor.run(op)).rejects.toBeTruthy();
+    });
+
+    it('should run and auto-identify the source when forceSparqlEndpoint is disabled', () => {
+      const op = { operation: { type: 'service', silent: false, name: literal('dummy') } };
+
+      const mediatorRdfSourceIdentifierThis: any = {
+        mediate: jest.fn(() => Promise.resolve({ sourceType: 'hypermedia' })),
+      };
+      const actorThis = new ActorQueryOperationService(
+        { bus, forceSparqlEndpoint: false, mediatorQueryOperation,
+          mediatorRdfSourceIdentifier: mediatorRdfSourceIdentifierThis, name: 'actor' });
+
+      return actorThis.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(mediatorRdfSourceIdentifierThis.mediate).toHaveBeenCalledTimes(1);
+        expect(output.variables).toEqual(['?a']);
+        expect(await output.metadata()).toEqual({ totalItems: 3 });
+        // tslint:disable:max-line-length
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({ a: literal('1') }),
+          Bindings({ a: literal('2') }),
+          Bindings({ a: literal('3') }),
+        ]);
+      });
+    });
+
+    it('should run and not auto-identify the source when forceSparqlEndpoint is enabled', () => {
+      const op = { operation: { type: 'service', silent: false, name: literal('dummy') } };
+
+      const mediatorRdfSourceIdentifierThis: any = {
+        mediate: jest.fn(() => Promise.resolve({ sourceType: 'hypermedia' })),
+      };
+      const actorThis = new ActorQueryOperationService(
+        { bus, forceSparqlEndpoint: true, mediatorQueryOperation,
+          mediatorRdfSourceIdentifier: mediatorRdfSourceIdentifierThis, name: 'actor' });
+
+      return actorThis.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(mediatorRdfSourceIdentifierThis.mediate).toHaveBeenCalledTimes(0);
+        expect(output.variables).toEqual(['?a']);
+        expect(await output.metadata()).toEqual({ totalItems: 3 });
+        // tslint:disable:max-line-length
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({ a: literal('1') }),
+          Bindings({ a: literal('2') }),
+          Bindings({ a: literal('3') }),
+        ]);
+      });
+    });
+  });
+});

--- a/packages/actor-query-operation-service/test/tsconfig.json
+++ b/packages/actor-query-operation-service/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ]
+  }
+}
+

--- a/packages/actor-query-operation-service/test/tslint.json
+++ b/packages/actor-query-operation-service/test/tslint.json
@@ -1,0 +1,11 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "../tslint.json"
+  ],
+  "rules": {
+    "no-var-requires": false,
+    "no-unused-expression": false
+  }
+}
+

--- a/packages/actor-query-operation-service/tsconfig.json
+++ b/packages/actor-query-operation-service/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/actor-query-operation-service/tslint.json
+++ b/packages/actor-query-operation-service/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}

--- a/packages/actor-query-operation-sparql-endpoint/README.md
+++ b/packages/actor-query-operation-sparql-endpoint/README.md
@@ -1,0 +1,17 @@
+# Comunica SPARQL Endpoint Query Operation Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-query-operation-sparql-endpoint.svg)](https://www.npmjs.com/package/@comunica/actor-query-operation-sparql-endpoint)
+
+A comunica SPARQL Endpoint Query Operation Actor.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-query-operation-sparql-endpoint
+```
+
+## Usage
+
+TODO

--- a/packages/actor-query-operation-sparql-endpoint/components/Actor/QueryOperation/SparqlEndpoint.jsonld
+++ b/packages/actor-query-operation-sparql-endpoint/components/Actor/QueryOperation/SparqlEndpoint.jsonld
@@ -1,0 +1,36 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-sparql-endpoint/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-query-operation/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/actor-query-operation-sparql-endpoint",
+  "components": [
+    {
+      "@id": "caqose:Actor/QueryOperation/SparqlEndpoint",
+      "@type": "Class",
+      "extends": "cbqo:Actor/QueryOperation",
+      "requireElement": "ActorQueryOperationSparqlEndpoint",
+      "comment": "A comunica SPARQL Endpoint Query Operation Actor.",
+      "parameters": [
+        {
+          "@id": "caqose:Actor/QueryOperation/SparqlEndpoint/mediatorHttp",
+          "comment": "The HTTP mediator",
+          "required": true,
+          "unique": true
+        }
+      ],
+      "constructorArguments": [
+        {
+          "@id": "caqose:Actor/QueryOperation/SparqlEndpoint/constructorArgumentsObject",
+          "extends": "cbqo:Actor/QueryOperation/constructorArgumentsObject",
+          "fields": [
+            {
+              "keyRaw": "mediatorHttp",
+              "value": "caqose:Actor/QueryOperation/SparqlEndpoint/mediatorHttp"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/actor-query-operation-sparql-endpoint/components/components.jsonld
+++ b/packages/actor-query-operation-sparql-endpoint/components/components.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-sparql-endpoint/^1.0.0/components/context.jsonld",
+  "@id": "npmd:@comunica/actor-query-operation-sparql-endpoint",
+  "@type": "Module",
+  "requireName": "@comunica/actor-query-operation-sparql-endpoint",
+  "import": [
+    "files-caqose:components/Actor/QueryOperation/SparqlEndpoint.jsonld"
+  ]
+}

--- a/packages/actor-query-operation-sparql-endpoint/components/context.jsonld
+++ b/packages/actor-query-operation-sparql-endpoint/components/context.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/componentsjs/^3.0.0/components/context.jsonld",
+    {
+      "npmd": "https://linkedsoftwaredependencies.org/bundles/npm/",
+      "caqose": "npmd:@comunica/actor-query-operation-sparql-endpoint/",
+      "files-caqose": "caqose:^1.0.0/",
+
+      "ActorQueryOperationSparqlEndpoint": "caqose:Actor/QueryOperation/SparqlEndpoint"
+    }
+  ]
+}

--- a/packages/actor-query-operation-sparql-endpoint/index.ts
+++ b/packages/actor-query-operation-sparql-endpoint/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ActorQueryOperationSparqlEndpoint';

--- a/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
+++ b/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
@@ -1,0 +1,147 @@
+import {IActionHttp, IActorHttpOutput} from "@comunica/bus-http";
+import {ActorQueryOperation, Bindings, IActionQueryOperation,
+  IActorQueryOperationOutput, IActorQueryOperationOutputBindings} from "@comunica/bus-query-operation";
+import {
+  DataSources,
+  IDataSource,
+  KEY_CONTEXT_SOURCE,
+  KEY_CONTEXT_SOURCES,
+} from "@comunica/bus-rdf-resolve-quad-pattern";
+import {Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {ActionContext} from "@comunica/core";
+import {IMediatorTypeHttpRequests} from "@comunica/mediatortype-httprequests";
+import {BufferedIterator, TransformIterator} from "asynciterator";
+import {SparqlEndpointFetcher} from "fetch-sparql-endpoint";
+import * as RDF from "rdf-js";
+import {termToString} from "rdf-string";
+import {uniqTerms} from "rdf-terms";
+import {Algebra, Factory, toSparql} from "sparqlalgebrajs";
+
+/**
+ * A comunica SPARQL Endpoint Query Operation Actor.
+ */
+export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
+
+  protected static readonly FACTORY: Factory = new Factory();
+  private static ALGEBRA_TYPES: string[] = Object.keys(Algebra.types).map((key) => (<any> Algebra.types)[key]);
+
+  public readonly mediatorHttp: Mediator<Actor<IActionHttp, IActorTest, IActorHttpOutput>,
+    IActionHttp, IActorTest, IActorHttpOutput>;
+  public readonly endpointFetcher: SparqlEndpointFetcher;
+
+  constructor(args: IActorQueryOperationSparqlEndpointArgs) {
+    super(args);
+    this.endpointFetcher = new SparqlEndpointFetcher({
+      fetch: (input?: Request | string, init?: RequestInit) => this.mediatorHttp.mediate({ input, init }),
+      prefixVariableQuestionMark: true,
+    });
+  }
+
+  /**
+   * Recursively find all variables in an operation.
+   * @param {Operation} operation An operation.
+   * @return The variables in the operation.
+   */
+  public static getVariables(operation: Algebra.Operation): RDF.Variable[] {
+    const variables: RDF.Variable[] = [];
+    getVariableCb(operation,  (variable: RDF.Variable) => variables.push(variable));
+    return uniqTerms(variables);
+
+    function getVariableCb(op: Algebra.Operation, variablesCb: (variable: RDF.Variable) => void) {
+      for (const key of Object.keys(op)) {
+        if (Array.isArray(op[key])) {
+          for (const subOperation of op[key]) {
+            getVariableCb(subOperation, variablesCb);
+          }
+        } else if (ActorQueryOperationSparqlEndpoint.ALGEBRA_TYPES.indexOf(op[key].type) >= 0) {
+          getVariableCb(op[key], variablesCb);
+        } else if (op[key].termType === 'Variable') {
+          variablesCb(op[key]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Wrap a pattern in a select query.
+   * @param {Operation} operation An operation.
+   * @return {Project} A select query.
+   */
+  public static patternToSelectQuery(operation: Algebra.Operation): Algebra.Project {
+    if (operation.type === 'project') {
+      return <Algebra.Project> operation;
+    }
+    const variables: RDF.Variable[] = ActorQueryOperationSparqlEndpoint.getVariables(operation);
+    return ActorQueryOperationSparqlEndpoint.FACTORY.createProject(operation, variables);
+  }
+
+  /**
+   * Get the single source if the context contains just a single source.
+   * @param {ActionContext} context A context, can be null.
+   * @return {Promise<IDataSource>} A promise resolving to the single datasource or null.
+   */
+  public static async getSingleSource(context: ActionContext): Promise<IDataSource> {
+    if (context && context.has(KEY_CONTEXT_SOURCE)) {
+      return context.get(KEY_CONTEXT_SOURCE);
+    } else if (context && context.has(KEY_CONTEXT_SOURCES)) {
+      const datasources: DataSources = context.get(KEY_CONTEXT_SOURCES);
+      if (datasources.isEnded()) {
+        const datasourcesArray: IDataSource[] = await require('arrayify-stream')(datasources.iterator());
+        if (datasourcesArray.length === 1) {
+          return datasourcesArray[0];
+        }
+      }
+    }
+    return null;
+  }
+
+  public async test(action: IActionQueryOperation): Promise<IMediatorTypeHttpRequests> {
+    if (!action.operation) {
+      throw new Error('Missing field \'operation\' in the query operation action: ' + require('util').inspect(action));
+    }
+    const source: IDataSource = await ActorQueryOperationSparqlEndpoint.getSingleSource(action.context);
+    if (source && source.type === 'sparql') {
+      return { httpRequests: 1 };
+    }
+    throw new Error(this.name + ' requires a single source with a \'sparql\' endpoint to be present in the context.');
+  }
+
+  public async run(action: IActionQueryOperation): Promise<IActorQueryOperationOutputBindings> {
+    const endpoint: string = (await ActorQueryOperationSparqlEndpoint.getSingleSource(action.context)).value;
+    const selectQuery: Algebra.Project = ActorQueryOperationSparqlEndpoint.patternToSelectQuery(action.operation);
+    const query: string = toSparql(selectQuery);
+
+    const bindingsStream: BufferedIterator<Bindings> = new BufferedIterator<Bindings>(
+      { autoStart: false, maxBufferSize: Infinity });
+    this.endpointFetcher.fetchBindings(endpoint, query)
+      .then((rawBindingsStream) => {
+        let totalItems = 0;
+        rawBindingsStream.on('error', (error) => bindingsStream.emit('error', error));
+        rawBindingsStream.on('data', (rawBindings) => {
+          totalItems++;
+          bindingsStream._push(Bindings(rawBindings));
+        });
+        rawBindingsStream.on('end', () => {
+          bindingsStream.emit('metadata', { totalItems });
+          bindingsStream.close();
+        });
+      });
+
+    const metadata = ActorQueryOperationSparqlEndpoint.cachifyMetadata(
+      () => new Promise((resolve, reject) => {
+        bindingsStream._fillBuffer();
+        bindingsStream.on('error', reject);
+        bindingsStream.on('end', () => reject(new Error('No metadata was found')));
+        bindingsStream.on('metadata', resolve);
+      }));
+
+    return { type: 'bindings', metadata, bindingsStream, variables: selectQuery.variables.map(termToString) };
+  }
+
+}
+
+export interface IActorQueryOperationSparqlEndpointArgs
+  extends IActorArgs<IActionQueryOperation, IActorTest, IActorQueryOperationOutput> {
+  mediatorHttp: Mediator<Actor<IActionHttp, IActorTest, IActorHttpOutput>,
+    IActionHttp, IActorTest, IActorHttpOutput>;
+}

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -40,7 +40,7 @@
     "fetch-sparql-endpoint": "^1.0.0",
     "rdf-string": "^1.1.1",
     "rdf-terms":"^1.1.0",
-    "sparqlalgebrajs": "^0.7.8"
+    "sparqlalgebrajs": "^1.0.1"
   },
   "peerDependencies": {
     "@comunica/bus-http": "^1.1.0",

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -1,26 +1,26 @@
 {
-  "name": "@comunica/actor-rdf-resolve-quad-pattern-sparql-json",
-  "version": "1.1.0",
-  "description": "A sparql rdf-resolve-quad-pattern actor",
-  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-quad-pattern-sparql-json",
+  "name": "@comunica/actor-query-operation-sparql-endpoint",
+  "version": "1.0.0",
+  "description": "A sparql-endpoint query-operation actor",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-sparql-endpoint",
   "lsd:components": "components/components.jsonld",
   "lsd:contexts": {
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/^1.0.0/components/context.jsonld": "components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-sparql-endpoint/^1.0.0/components/context.jsonld": "components/context.jsonld"
   },
   "lsd:importPaths": {
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/^1.0.0/components/": "components/"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-sparql-endpoint/^1.0.0/components/": "components/"
   },
   "main": "index.js",
   "typings": "index",
-  "repository": "https://github.com/comunica/comunica/tree/master/packages/actor-rdf-resolve-quad-pattern-sparql-json",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/actor-query-operation-sparql-endpoint",
   "publishConfig": {
     "access": "public"
   },
   "keywords": [
     "comunica",
     "actor",
-    "rdf-resolve-quad-pattern",
-    "sparql"
+    "query-operation",
+    "sparql-endpoint"
   ],
   "license": "MIT",
   "bugs": {
@@ -35,24 +35,23 @@
     "index.js"
   ],
   "dependencies": {
+    "arrayify-stream": "^1.0.0",
     "asynciterator": "^2.0.0",
-    "asynciterator-promiseproxy": "^2.0.0",
-    "node-web-streams": "^0.2.2",
-    "sparqljson-parse": "^1.1.1",
-    "rdf-data-model": "^1.0.0",
-    "rdf-terms": "^1.1.0",
-    "sparqlalgebrajs": "^0.7.5"
+    "fetch-sparql-endpoint": "^1.0.0",
+    "rdf-string": "^1.1.1",
+    "rdf-terms":"^1.1.0",
+    "sparqlalgebrajs": "^0.7.8"
   },
   "peerDependencies": {
-    "@comunica/bus-http": "^1.0.0",
-    "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",
-    "@comunica/core": "^1.0.0"
+    "@comunica/bus-http": "^1.1.0",
+    "@comunica/core": "^1.1.0",
+    "@comunica/bus-query-operation": "^1.1.0"
   },
   "devDependencies": {
     "@comunica/bus-http": "^1.1.0",
+    "@comunica/core": "^1.1.0",
     "@comunica/bus-query-operation": "^1.1.0",
-    "@comunica/bus-rdf-resolve-quad-pattern": "^1.1.0",
-    "@comunica/core": "^1.1.0"
+    "@comunica/mediatortype-httprequests": "^1.0.0"
   },
   "jest": {
     "transform": {

--- a/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
+++ b/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
@@ -1,0 +1,233 @@
+import {ActorQueryOperation, Bindings} from "@comunica/bus-query-operation";
+import {ActionContext, Bus} from "@comunica/core";
+import {AsyncReiterableArray} from "asyncreiterable";
+import {namedNode, variable} from "rdf-data-model";
+import Factory from "sparqlalgebrajs/lib/Factory";
+import {ActorQueryOperationSparqlEndpoint} from "../lib/ActorQueryOperationSparqlEndpoint";
+const arrayifyStream = require('arrayify-stream');
+const streamifyString = require('streamify-string');
+
+const factory = new Factory();
+
+describe('ActorQueryOperationSparqlEndpoint', () => {
+  let bus;
+  let mediatorHttp;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+    mediatorHttp = {
+      mediate: (action) => {
+        // tslint:disable: no-trailing-whitespace
+        return {
+          body: streamifyString(`{
+  "head": { "vars": [ "p" ]
+  } ,
+  "results": { 
+    "bindings": [
+      {
+        "p": { "type": "uri" , "value": "${action.input}/1" }
+      },
+      {
+        "p": { "type": "uri" , "value": "${action.input}/2" }
+      },
+      {
+        "p": { "type": "uri" , "value": "${action.input}/3" }
+      }
+    ]
+  }
+}`),
+          ok: true,
+        };
+        // tslint:enable: no-trailing-whitespace
+      },
+    };
+  });
+
+  describe('The ActorQueryOperationSparqlEndpoint module', () => {
+    it('should be a function', () => {
+      expect(ActorQueryOperationSparqlEndpoint).toBeInstanceOf(Function);
+    });
+
+    it('should be a ActorQueryOperationSparqlEndpoint constructor', () => {
+      expect(new (<any> ActorQueryOperationSparqlEndpoint)({ name: 'actor', bus, mediatorHttp }))
+        .toBeInstanceOf(ActorQueryOperationSparqlEndpoint);
+      expect(new (<any> ActorQueryOperationSparqlEndpoint)({ name: 'actor', bus, mediatorHttp }))
+        .toBeInstanceOf(ActorQueryOperation);
+    });
+
+    it('should not be able to create new ActorQueryOperationSparqlEndpoint objects without \'new\'', () => {
+      expect(() => { (<any> ActorQueryOperationSparqlEndpoint)(); }).toThrow();
+    });
+  });
+
+  describe('#getVariables should return all variables for', () => {
+    it('a pattern', () => {
+      const op = factory.createPattern(namedNode('s'), variable('p'), namedNode('o'));
+      return expect(ActorQueryOperationSparqlEndpoint.getVariables(op))
+        .toEqual([variable('p')]);
+    });
+
+    it('a BGP', () => {
+      const op = factory.createBgp([
+        factory.createPattern(variable('s'), variable('p'), namedNode('o')),
+        factory.createPattern(variable('s'), namedNode('p'), namedNode('o')),
+        factory.createPattern(namedNode('s'), namedNode('p'), variable('o')),
+      ]);
+      return expect(ActorQueryOperationSparqlEndpoint.getVariables(op))
+        .toEqual([variable('s'), variable('p'), variable('o')]);
+    });
+
+    it('a project', () => {
+      const op = factory.createProject(factory.createBgp([
+        factory.createPattern(variable('s'), variable('p'), namedNode('o')),
+        factory.createPattern(variable('s'), namedNode('p'), namedNode('o')),
+        factory.createPattern(namedNode('s'), namedNode('p'), variable('o')),
+      ]), []);
+      return expect(ActorQueryOperationSparqlEndpoint.getVariables(op))
+        .toEqual([variable('s'), variable('p'), variable('o')]);
+    });
+  });
+
+  describe('#patternToSelectQuery', () => {
+    it('should convert a pattern', () => {
+      const op = factory.createPattern(namedNode('s'), variable('p'), namedNode('o'));
+      return expect(ActorQueryOperationSparqlEndpoint.patternToSelectQuery(op))
+        .toEqual(factory.createProject(op, [variable('p')]));
+    });
+
+    it('should convert a BGP', () => {
+      const op = factory.createBgp([
+        factory.createPattern(variable('s'), variable('p'), namedNode('o')),
+        factory.createPattern(variable('s'), namedNode('p'), namedNode('o')),
+        factory.createPattern(namedNode('s'), namedNode('p'), variable('o')),
+      ]);
+      return expect(ActorQueryOperationSparqlEndpoint.patternToSelectQuery(op))
+        .toEqual(factory.createProject(op, [variable('s'), variable('p'), variable('o')]));
+    });
+
+    it('should not convert a project', () => {
+      const op = factory.createProject(factory.createBgp([
+        factory.createPattern(variable('s'), variable('p'), namedNode('o')),
+        factory.createPattern(variable('s'), namedNode('p'), namedNode('o')),
+        factory.createPattern(namedNode('s'), namedNode('p'), variable('o')),
+      ]), []);
+      return expect(ActorQueryOperationSparqlEndpoint.patternToSelectQuery(op)).toEqual(op);
+    });
+  });
+
+  describe('#getSingleSource', () => {
+    it('return null for a falsy context', async () => {
+      return expect(await ActorQueryOperationSparqlEndpoint.getSingleSource(null)).toBe(null);
+    });
+
+    it('return null for a context without source or sources', async () => {
+      return expect(await ActorQueryOperationSparqlEndpoint.getSingleSource(ActionContext({}))).toBe(null);
+    });
+
+    it('return a single source', async () => {
+      return expect(await ActorQueryOperationSparqlEndpoint.getSingleSource(ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'bla' },
+      }))).toEqual({ type: 'bla' });
+    });
+
+    it('return null for sources that are not ended', async () => {
+      return expect(await ActorQueryOperationSparqlEndpoint.getSingleSource(ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromInitialEmpty(),
+      }))).toBe(null);
+    });
+
+    it('return null for empty sources that are ended', async () => {
+      return expect(await ActorQueryOperationSparqlEndpoint.getSingleSource(ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([]),
+      }))).toBe(null);
+    });
+
+    it('return null for empty sources with two elements', async () => {
+      return expect(await ActorQueryOperationSparqlEndpoint.getSingleSource(ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([
+          { type: 'bla1' }, { type: 'bla2' },
+        ]),
+      }))).toBe(null);
+    });
+
+    it('return the single source for empty sources with one elements', async () => {
+      return expect(await ActorQueryOperationSparqlEndpoint.getSingleSource(ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:sources': AsyncReiterableArray.fromFixedData([
+          { type: 'bla' },
+        ]),
+      }))).toEqual({ type: 'bla' });
+    });
+  });
+
+  describe('An ActorQueryOperationSparqlEndpoint instance', () => {
+    let actor: ActorQueryOperationSparqlEndpoint;
+
+    beforeEach(() => {
+      actor = new ActorQueryOperationSparqlEndpoint({ name: 'actor', bus, mediatorHttp });
+    });
+
+    it('should test on a single sparql source', () => {
+      const context = ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'sparql' },
+      });
+      const op: any = { operation: 'bla', context };
+      return expect(actor.test(op)).resolves.toBeTruthy();
+    });
+
+    it('should not test on a single non-sparql source', () => {
+      const context = ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'nosparql' },
+      });
+      const op: any = { operation: 'bla', context };
+      return expect(actor.test(op)).rejects.toBeTruthy();
+    });
+
+    it('should not test on a missing operation', () => {
+      const context = ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'sparql' },
+      });
+      const op = { operation: null, context };
+      return expect(actor.test(op)).rejects.toBeTruthy();
+    });
+
+    it('should run', () => {
+      const context = ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'sparql', value: 'http://example.org/sparql' },
+      });
+      const op = { context, operation: factory.createPattern(namedNode('http://s'), variable('p'),
+          namedNode('http://o')) };
+      return actor.run(op).then(async (output) => {
+        expect(output.variables).toEqual(['?p']);
+        expect(await output.metadata()).toEqual({ totalItems: 3 });
+        // tslint:disable:max-line-length
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({ '?p': namedNode('http://example.org/sparql?query=SELECT%20%3Fp%20WHERE%20%7B%20%3Chttp%3A%2F%2Fs%3E%20%3Fp%20%3Chttp%3A%2F%2Fo%3E.%20%7D/1') }),
+          Bindings({ '?p': namedNode('http://example.org/sparql?query=SELECT%20%3Fp%20WHERE%20%7B%20%3Chttp%3A%2F%2Fs%3E%20%3Fp%20%3Chttp%3A%2F%2Fo%3E.%20%7D/2') }),
+          Bindings({ '?p': namedNode('http://example.org/sparql?query=SELECT%20%3Fp%20WHERE%20%7B%20%3Chttp%3A%2F%2Fs%3E%20%3Fp%20%3Chttp%3A%2F%2Fo%3E.%20%7D/3') }),
+        ]);
+      });
+    });
+
+    it('should run and error for a server error', () => {
+      const thisMediator: any = {
+        mediate: () => {
+          return {
+            body: streamifyString(``),
+            ok: false,
+            status: 500,
+            statusText: 'Error!',
+          };
+        },
+      };
+      const context = ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'sparql', value: 'http://ex' },
+      });
+      const op = { context, operation: factory.createPattern(namedNode('http://s'), variable('p'),
+          namedNode('http://o')) };
+      const thisActor = new ActorQueryOperationSparqlEndpoint({ name: 'actor', bus, mediatorHttp: thisMediator });
+      return expect(new Promise((resolve, reject) => {
+        thisActor.run(op).then(async (output) => output.bindingsStream.on('error', resolve));
+      })).resolves.toEqual(new Error('Invalid SPARQL endpoint (http://ex) response: Error!'));
+    });
+  });
+});

--- a/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
+++ b/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
@@ -60,34 +60,6 @@ describe('ActorQueryOperationSparqlEndpoint', () => {
     });
   });
 
-  describe('#getVariables should return all variables for', () => {
-    it('a pattern', () => {
-      const op = factory.createPattern(namedNode('s'), variable('p'), namedNode('o'));
-      return expect(ActorQueryOperationSparqlEndpoint.getVariables(op))
-        .toEqual([variable('p')]);
-    });
-
-    it('a BGP', () => {
-      const op = factory.createBgp([
-        factory.createPattern(variable('s'), variable('p'), namedNode('o')),
-        factory.createPattern(variable('s'), namedNode('p'), namedNode('o')),
-        factory.createPattern(namedNode('s'), namedNode('p'), variable('o')),
-      ]);
-      return expect(ActorQueryOperationSparqlEndpoint.getVariables(op))
-        .toEqual([variable('s'), variable('p'), variable('o')]);
-    });
-
-    it('a project', () => {
-      const op = factory.createProject(factory.createBgp([
-        factory.createPattern(variable('s'), variable('p'), namedNode('o')),
-        factory.createPattern(variable('s'), namedNode('p'), namedNode('o')),
-        factory.createPattern(namedNode('s'), namedNode('p'), variable('o')),
-      ]), []);
-      return expect(ActorQueryOperationSparqlEndpoint.getVariables(op))
-        .toEqual([variable('s'), variable('p'), variable('o')]);
-    });
-  });
-
   describe('#patternToSelectQuery', () => {
     it('should convert a pattern', () => {
       const op = factory.createPattern(namedNode('s'), variable('p'), namedNode('o'));

--- a/packages/actor-query-operation-sparql-endpoint/test/tsconfig.json
+++ b/packages/actor-query-operation-sparql-endpoint/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ]
+  }
+}
+

--- a/packages/actor-query-operation-sparql-endpoint/test/tslint.json
+++ b/packages/actor-query-operation-sparql-endpoint/test/tslint.json
@@ -1,0 +1,11 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "../tslint.json"
+  ],
+  "rules": {
+    "no-var-requires": false,
+    "no-unused-expression": false
+  }
+}
+

--- a/packages/actor-query-operation-sparql-endpoint/tsconfig.json
+++ b/packages/actor-query-operation-sparql-endpoint/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/actor-query-operation-sparql-endpoint/tslint.json
+++ b/packages/actor-query-operation-sparql-endpoint/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/ActorRdfResolveQuadPatternFederated.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/ActorRdfResolveQuadPatternFederated.ts
@@ -22,7 +22,7 @@ export class ActorRdfResolveQuadPatternFederated extends ActorRdfResolveQuadPatt
 
   public async test(action: IActionRdfResolveQuadPattern): Promise<IActorTest> {
     const sources = this.getContextSources(action.context);
-    if (!sources || sources.length < 1) {
+    if (!sources) {
       throw new Error('Actor ' + this.name + ' can only resolve quad pattern queries against a sources array.');
     }
     return true;

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
@@ -53,14 +53,9 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
         { name: 'actor', bus, mediatorResolveQuadPattern, skipEmptyPatterns });
     });
 
-    it('should test with >= 1 sources', () => {
+    it('should test with sources', () => {
       return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [{}] }) })).resolves.toBeTruthy();
-    });
-
-    it('should not test with < 1 sources', () => {
-      return expect(actor.test({ pattern: null, context: ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:sources': [] }) })).rejects.toBeTruthy();
+        { '@comunica/bus-rdf-resolve-quad-pattern:sources': 'something' }) })).resolves.toBeTruthy();
     });
 
     it('should not test with a single source', () => {

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
@@ -35,10 +35,10 @@
     "index.js"
   ],
   "dependencies": {
-    "JSONStream": "^1.3.2",
     "asynciterator": "^2.0.0",
     "asynciterator-promiseproxy": "^2.0.0",
     "node-web-streams": "^0.2.2",
+    "sparqljson-parse": "^1.1.0",
     "rdf-data-model": "^1.0.0",
     "rdf-terms": "^1.1.0",
     "sparqlalgebrajs": "^0.7.5"

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
@@ -41,7 +41,7 @@
     "sparqljson-parse": "^1.1.1",
     "rdf-data-model": "^1.0.0",
     "rdf-terms": "^1.1.0",
-    "sparqlalgebrajs": "^0.7.5"
+    "sparqlalgebrajs": "^1.0.1"
   },
   "peerDependencies": {
     "@comunica/bus-http": "^1.0.0",

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/test/ActorRdfResolveQuadPatternSparqlJson-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/test/ActorRdfResolveQuadPatternSparqlJson-test.ts
@@ -97,54 +97,6 @@ describe('ActorRdfResolveQuadPatternSparqlJson', () => {
     });
   });
 
-  describe('#parseJsonBindings', () => {
-    it('should convert bindings with named nodes', () => {
-      return expect(ActorRdfResolveQuadPatternSparqlJson.parseJsonBindings({
-        book: { type: 'uri', value: 'http://example.org/book/book6' },
-      }).toJS()).toEqual({ '?book': namedNode('http://example.org/book/book6') });
-    });
-
-    it('should convert bindings with blank nodes', () => {
-      return expect(ActorRdfResolveQuadPatternSparqlJson.parseJsonBindings({
-        book: { type: 'bnode', value: 'abc' },
-      }).toJS()).toEqual({ '?book': blankNode('abc') });
-    });
-
-    it('should convert bindings with literals', () => {
-      return expect(ActorRdfResolveQuadPatternSparqlJson.parseJsonBindings({
-        book: { type: 'literal', value: 'abc' },
-      }).toJS()).toEqual({ '?book': literal('abc') });
-    });
-
-    it('should convert bindings with languaged literals', () => {
-      return expect(ActorRdfResolveQuadPatternSparqlJson.parseJsonBindings({
-        book: { 'type': 'literal', 'value': 'abc', 'xml:lang': 'en-us' },
-      }).toJS()).toEqual({ '?book': literal('abc', 'en-us') });
-    });
-
-    it('should convert bindings with datatyped literals', () => {
-      return expect(ActorRdfResolveQuadPatternSparqlJson.parseJsonBindings({
-        book: { type: 'literal', value: 'abc', datatype: 'http://ex' },
-      }).toJS()).toEqual({ '?book': literal('abc', namedNode('http://ex')) });
-    });
-
-    it('should convert mixed bindings', () => {
-      return expect(ActorRdfResolveQuadPatternSparqlJson.parseJsonBindings({
-        book1: { type: 'uri', value: 'http://example.org/book/book6' },
-        book2: { type: 'bnode', value: 'abc' },
-        book3: { type: 'literal', value: 'abc' },
-        book4: { 'type': 'literal', 'value': 'abc', 'xml:lang': 'en-us' },
-        book5: { type: 'literal', value: 'abc', datatype: 'http://ex' },
-      }).toJS()).toEqual({
-        '?book1': namedNode('http://example.org/book/book6'),
-        '?book2': blankNode('abc'),
-        '?book3': literal('abc'),
-        '?book4': literal('abc', 'en-us'),
-        '?book5': literal('abc', namedNode('http://ex')),
-      });
-    });
-  });
-
   describe('An ActorRdfResolveQuadPatternSparqlJson instance', () => {
     let actor: ActorRdfResolveQuadPatternSparqlJson;
     const pattern: any = quad('s', '?p', 'o');

--- a/packages/actor-sparql-parse-algebra/package.json
+++ b/packages/actor-sparql-parse-algebra/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlalgebrajs": "^0.7.5"
+    "sparqlalgebrajs": "^1.0.1"
   },
   "peerDependencies": {
     "@comunica/bus-sparql-parse": "^1.0.0",

--- a/packages/mediator-number/components/Mediator/Number.jsonld
+++ b/packages/mediator-number/components/Mediator/Number.jsonld
@@ -50,7 +50,7 @@
             },
             {
               "keyRaw": "ignoreErrors",
-              "valueRawReference": "cmn:Mediator/Number/ignoreErrors"
+              "value": "cmn:Mediator/Number/ignoreErrors"
             }
           ]
         }

--- a/packages/mediator-number/test/MediatorNumber-test.ts
+++ b/packages/mediator-number/test/MediatorNumber-test.ts
@@ -135,6 +135,24 @@ describe('MediatorNumber', () => {
         return expect(mediatorMax.mediate({})).resolves.toEqual({ field: 100 });
       });
     });
+
+    describe('with only actors throwing errors', () => {
+      beforeEach(() => {
+        mediatorMin = new MediatorNumber({ bus, field: 'field', ignoreErrors: true,
+          name: 'mediatorMin', type: MediatorNumber.MIN });
+        mediatorMax = new MediatorNumber({ bus, field: 'field', ignoreErrors: true,
+          name: 'mediatorMax', type: MediatorNumber.MAX });
+        bus.subscribe(new ErrorDummyActor(null, bus));
+      });
+
+      it('should not mediate to the minimum value for type MIN', () => {
+        return expect(mediatorMin.mediate({})).rejects.toBeTruthy();
+      });
+
+      it('should not mediate to the maximum value for type MAX', () => {
+        return expect(mediatorMax.mediate({})).rejects.toBeTruthy();
+      });
+    });
   });
 });
 
@@ -160,7 +178,7 @@ class DummyActor extends Actor<IAction, IDummyTest, IDummyTest> {
 // tslint:disable-next-line:max-classes-per-file
 class ErrorDummyActor extends DummyActor {
   public async test(action: IAction): Promise<IDummyTest> {
-    throw new Error();
+    throw new Error('abc');
   }
 }
 

--- a/packages/mediatortype-httprequests/README.md
+++ b/packages/mediatortype-httprequests/README.md
@@ -1,0 +1,17 @@
+# Comunica Mediatortype Http Requests
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Fmediatortype-time.svg)](https://www.npmjs.com/package/@comunica/mediatortype-httprequests)
+
+A comunica mediator type for mediation on 'httpRequests'.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/mediatortype-httprequests
+```
+
+## Usage
+
+TODO

--- a/packages/mediatortype-httprequests/index.ts
+++ b/packages/mediatortype-httprequests/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/MediatorTypeHttpRequests';

--- a/packages/mediatortype-httprequests/lib/MediatorTypeHttpRequests.ts
+++ b/packages/mediatortype-httprequests/lib/MediatorTypeHttpRequests.ts
@@ -1,0 +1,11 @@
+import {IActorTest} from "@comunica/core";
+
+/**
+ * A mediator type that has a httpRequests parameter.
+ */
+export interface IMediatorTypeHttpRequests extends IActorTest {
+  /**
+   * An estimation of a number of HTTP requests.
+   */
+  httpRequests?: number;
+}

--- a/packages/mediatortype-httprequests/package.json
+++ b/packages/mediatortype-httprequests/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@comunica/mediatortype-httprequests",
+  "version": "1.1.0",
+  "description": "A comunica mediator type for the 'httpRequests' parameter.",
+  "main": "index.js",
+  "typings": "index",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/mediatortype-httprequests",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "comunica",
+    "bus",
+    "init"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://github.com/comunica/comunica#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@comunica/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@comunica/core": "^1.1.0"
+  },
+  "scripts": {
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/mediatortype-httprequests/tsconfig.json
+++ b/packages/mediatortype-httprequests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/mediatortype-httprequests/tslint.json
+++ b/packages/mediatortype-httprequests/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,7 +2363,7 @@ fetch-sparql-endpoint@^1.0.0:
     node-web-streams "^0.2.2"
     rdf-string "^1.1.1"
     sparqljs "^2.0.3"
-    sparqljson-parse "^1.1.0"
+    sparqljson-parse "^1.1.1"
     stream-to-string "^1.1.0"
 
 figures@^2.0.0:
@@ -5582,20 +5582,6 @@ sparqljs@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-2.0.3.tgz#7f5d2416dc7339f2cea73b08e521c3a8c2c8e32d"
 
-sparqljson-parse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-1.0.0.tgz#d9160a2ad96f7f2ac762d39c17069e849622b90f"
-  dependencies:
-    JSONStream "^1.3.3"
-    rdf-data-model "^1.0.0"
-
-sparqljson-parse@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-1.1.0.tgz#e46663f47409aaca90c1bd480e2b03ad3ed27381"
-  dependencies:
-    JSONStream "^1.3.3"
-    rdf-data-model "^1.0.0"
-
 sparqljson-parse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-1.1.1.tgz#f0ad2f742a81292d10f326462fa589cc539aa927"
@@ -5607,7 +5593,7 @@ sparqljson-to-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/sparqljson-to-tree/-/sparqljson-to-tree-1.1.0.tgz#ad5a2996e6605eec3d66521cd7595b4474f4f80c"
   dependencies:
-    sparqljson-parse "^1.0.0"
+    sparqljson-parse "^1.1.1"
 
 spawn-sync@^1.0.15:
   version "1.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,7 +289,7 @@
     "@webassemblyjs/wast-parser" "1.5.13"
     long "^3.2.0"
 
-JSONStream@^1.0.4, JSONStream@^1.3.2, JSONStream@^1.3.3:
+JSONStream@^1.0.4, JSONStream@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.3.tgz#27b4b8fbbfeab4e71bcf551e7f27be8d952239bf"
   dependencies:
@@ -2352,6 +2352,20 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fetch-sparql-endpoint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-1.0.0.tgz#3940c6c2cafb59b7562f1c0580667c1c16dc8118"
+  dependencies:
+    is-stream "^1.1.0"
+    isomorphic-fetch "^2.2.1"
+    minimist "^1.2.0"
+    n3 "^1.0.0-beta.1"
+    node-web-streams "^0.2.2"
+    rdf-string "^1.1.1"
+    sparqljs "^2.0.3"
+    sparqljson-parse "^1.1.0"
+    stream-to-string "^1.1.0"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -3471,6 +3485,12 @@ jest-mock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
 
+jest-rdf@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-rdf/-/jest-rdf-1.0.0.tgz#ba97ab0442670024a9bbcb39103f98e167a0fc8d"
+  dependencies:
+    rdf-string "^1.1.1"
+
 jest-regex-util@^23.3.0:
   version "23.3.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
@@ -4273,6 +4293,10 @@ n3@^0.11.2:
 n3@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/n3/-/n3-0.9.1.tgz#430b547d58dc7381408c45784dd8058171903932"
+
+n3@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.0.0-beta.1.tgz#ecd0b7068ee393a3894c0b425d3f2f27bbc177f5"
 
 nan@^2.10.0, nan@^2.9.2:
   version "2.10.0"
@@ -5544,7 +5568,7 @@ source-map@~0.1.38:
   dependencies:
     amdefine ">=0.0.4"
 
-sparqlalgebrajs@^0.7.5:
+sparqlalgebrajs@^0.7.5, sparqlalgebrajs@^0.7.8:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-0.7.8.tgz#418b9bc1b6a72cf4ac73513d9ff6a0eff8a2595d"
   dependencies:
@@ -5561,6 +5585,20 @@ sparqljs@^2.0.3:
 sparqljson-parse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-1.0.0.tgz#d9160a2ad96f7f2ac762d39c17069e849622b90f"
+  dependencies:
+    JSONStream "^1.3.3"
+    rdf-data-model "^1.0.0"
+
+sparqljson-parse@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-1.1.0.tgz#e46663f47409aaca90c1bd480e2b03ad3ed27381"
+  dependencies:
+    JSONStream "^1.3.3"
+    rdf-data-model "^1.0.0"
+
+sparqljson-parse@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-1.1.1.tgz#f0ad2f742a81292d10f326462fa589cc539aa927"
   dependencies:
     JSONStream "^1.3.3"
     rdf-data-model "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@rdfjs/data-model@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@rdfjs/data-model/-/data-model-1.1.0.tgz#15d9c5b7b8166893696565aefb65bad95da3fd99"
+
 "@types/asynciterator@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/asynciterator/-/asynciterator-1.1.1.tgz#21ae5e3729ab2e87d324a044b2cd6288226da7fc"
@@ -2363,7 +2367,7 @@ fetch-sparql-endpoint@^1.0.0:
     node-web-streams "^0.2.2"
     rdf-string "^1.1.1"
     sparqljs "^2.0.3"
-    sparqljson-parse "^1.1.1"
+    sparqljson-parse "^1.1.0"
     stream-to-string "^1.1.0"
 
 figures@^2.0.0:
@@ -5029,6 +5033,12 @@ rdf-string@^1.1.1:
   dependencies:
     rdf-data-model "^1.0.0"
 
+rdf-string@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.2.0.tgz#25cd45ab168c8ed1cde62eb64ac3c2291fc551c0"
+  dependencies:
+    "@rdfjs/data-model" "^1.1.0"
+
 rdf-terms@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.1.0.tgz#88ea0128c60a6a47d9c39fafc1a7ac8c2e470bef"
@@ -5568,7 +5578,7 @@ source-map@~0.1.38:
   dependencies:
     amdefine ">=0.0.4"
 
-sparqlalgebrajs@^0.7.5, sparqlalgebrajs@^0.7.8:
+sparqlalgebrajs@^0.7.5:
   version "0.7.8"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-0.7.8.tgz#418b9bc1b6a72cf4ac73513d9ff6a0eff8a2595d"
   dependencies:
@@ -5578,9 +5588,26 @@ sparqlalgebrajs@^0.7.5, sparqlalgebrajs@^0.7.8:
     rdf-string "^1.1.1"
     sparqljs "^2.0.3"
 
+sparqlalgebrajs@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-1.0.1.tgz#f45baced82e9a1cc6fa7bfb7736e6ee68e453532"
+  dependencies:
+    "@rdfjs/data-model" "^1.1.0"
+    lodash.isequal "^4.5.0"
+    minimist "^1.2.0"
+    rdf-string "^1.2.0"
+    sparqljs "^2.0.3"
+
 sparqljs@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-2.0.3.tgz#7f5d2416dc7339f2cea73b08e521c3a8c2c8e32d"
+
+sparqljson-parse@^1.0.0, sparqljson-parse@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-1.2.0.tgz#4e8e2ed2db38d7a5c0c48afbf2f5c851142a7de8"
+  dependencies:
+    "@rdfjs/data-model" "^1.1.0"
+    JSONStream "^1.3.3"
 
 sparqljson-parse@^1.1.1:
   version "1.1.1"
@@ -5593,7 +5620,7 @@ sparqljson-to-tree@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/sparqljson-to-tree/-/sparqljson-to-tree-1.1.0.tgz#ad5a2996e6605eec3d66521cd7595b4474f4f80c"
   dependencies:
-    sparqljson-parse "^1.1.1"
+    sparqljson-parse "^1.0.0"
 
 spawn-sync@^1.0.15:
   version "1.0.15"


### PR DESCRIPTION
This adds an actor that sends a full SPARQL query to an endpoint if only a single SPARQL endpoint source is defined (#181).

Based on that, a new actor is added that implements the SERVICE keyword (#91).