### PR TITLE
Feature/logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@types/asynciterator": "^1.1.1",
     "@types/bluebird": "^3.5.11",
+    "@types/bunyan": "^1.8.4",
     "@types/graphql": "^0.13.1",
     "@types/jest": "^23.0.0",
     "@types/lodash.assign": "^4.2.3",

--- a/packages/actor-http-native/lib/ActorHttpNative.ts
+++ b/packages/actor-http-native/lib/ActorHttpNative.ts
@@ -57,6 +57,8 @@ export class ActorHttpNative extends ActorHttp {
 
     options.method = options.method || 'GET';
 
+    this.logInfo(action.context, `Requesting ${options.url}`, { actor: this.name });
+
     // not all options are supported
 
     return new Promise<IActorHttpOutput>((resolve, reject) => {

--- a/packages/actor-init-sparql/README.md
+++ b/packages/actor-init-sparql/README.md
@@ -150,6 +150,27 @@ myEngine.query('{ label writer(label_en: \"Michael Jackson\") artist { label } }
   .then(console.log);
 ```
 
+_Logging_
+
+Optionally, a custom logger can be used inside Comunica.
+By default, [`@comunica/logger-void`](https://github.com/comunica/comunica/tree/master/packages/logger-void/) is used,
+which will simply void all log calls.
+(_This default can be changed in the [configuration file](https://github.com/comunica/comunica/blob/master/packages/actor-init-sparql/config/config-default.json)_)
+
+Alternatively, [`@comunica/logger-pretty`](https://github.com/comunica/comunica/tree/master/packages/logger-pretty/),
+[`@comunica/logger-bunyan`](https://github.com/comunica/comunica/tree/master/packages/logger-bunyan/),
+or a custom logger implementing the [`Logger`](https://github.com/comunica/comunica/blob/master/packages/core/lib/Logger.ts) interface can be used.
+
+These loggers can be configured through the context as follows:
+```javascript
+import {LoggerPretty} from "@comunica/logger-pretty";
+
+const context = {
+  log: new LoggerPretty({ level: 'warn' });
+};
+myEngine.query('...', context);
+```
+
 ### Usage within browser
 
 This engine can run in the browser using [Webpack](https://www.npmjs.com/package/webpack).

--- a/packages/actor-init-sparql/bin/http.ts
+++ b/packages/actor-init-sparql/bin/http.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import {AsyncIterator, IntegerIterator} from "asynciterator";
+import {LoggerPretty} from "@comunica/logger-pretty";
 import * as fs from 'fs';
 import * as http from 'http';
 import minimist = require('minimist');
@@ -16,7 +16,7 @@ const MIME_JSON  = 'application/json';
 const args = minimist(process.argv.slice(2));
 if (args._.length !== 1 || args.h || args.help) {
   process.stderr.write(
-    'usage: comunica-sparql-http context [-p port] [-t timeout] [--help]\n' +
+    'usage: comunica-sparql-http context [-p port] [-t timeout] [-l log-level] [--help]\n' +
     '  context should be a JSON object, e.g.\n' +
     '      { "sources": [{ "type": "hypermedia", "value" : "http://fragments.dbpedia.org/2015/en" }]}\n' +
     '  or the path to such a JSON file\n',
@@ -28,6 +28,11 @@ if (args._.length !== 1 || args.h || args.help) {
 const context = JSON.parse(fs.existsSync(args._[0]) ? fs.readFileSync(args._[0], 'utf8') : args._[0]);
 const timeout = (parseInt(args.t, 10) || 60) * 1000;
 const port = parseInt(args.p, 10) || 3000;
+
+// Set the logger
+if (!context.log) {
+  context.log = new LoggerPretty({ level: args.l || 'warn' });
+}
 
 const options = { configResourceUrl: process.env.COMUNICA_CONFIG
   ? process.cwd() + '/' + process.env.COMUNICA_CONFIG : null };

--- a/packages/actor-init-sparql/components/Actor/Init/Sparql.jsonld
+++ b/packages/actor-init-sparql/components/Actor/Init/Sparql.jsonld
@@ -1,6 +1,7 @@
 {
   "@context": [
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-init-sparql/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-void/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-init/^1.0.0/components/context.jsonld"
   ],
   "@id": "npmd:@comunica/actor-init-sparql",
@@ -43,6 +44,14 @@
           "unique": true
         },
         {
+          "@id": "cais:logger",
+          "comment": "The logger of this actor.",
+          "range": "cc:Logger",
+          "default": { "@type": "LoggerVoid" },
+          "required": true,
+          "unique": true
+        },
+        {
           "@id": "cais:query",
           "comment": "A SPARQL query string",
           "unique": true
@@ -81,6 +90,10 @@
             {
               "keyRaw": "mediatorContextPreprocess",
               "value": "cais:mediatorContextPreprocess"
+            },
+            {
+              "keyRaw": "logger",
+              "value": "cais:logger"
             },
             {
               "keyRaw": "queryString",

--- a/packages/actor-init-sparql/config/sets/http-memento.json
+++ b/packages/actor-init-sparql/config/sets/http-memento.json
@@ -3,9 +3,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-init-sparql/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^1.0.0/components/context.jsonld",
 
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-memento/^1.0.0/components/context.jsonld",
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld",
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-number/^1.0.0/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-memento/^1.0.0/components/context.jsonld"
   ],
   "@id": "urn:comunica:my",
   "actors": [
@@ -13,10 +11,7 @@
       "@id": "config-sets:http-memento.json#myHttpFetcher",
       "@type": "ActorHttpMemento",
       "cahm:Actor/Http/Memento/mediatorHttp": {
-        "@id": "config-sets:http-memento.json#mediatorHttp",
-        "@type": "MediatorNumberMin",
-        "field": "time",
-        "cc:Mediator/bus": { "@id": "cbh:Bus/Http" }
+        "@id": "config-sets:http.json#mediatorHttp"
       }
     }
   ]

--- a/packages/actor-init-sparql/config/sets/http.json
+++ b/packages/actor-init-sparql/config/sets/http.json
@@ -3,13 +3,27 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-init-sparql/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^1.0.0/components/context.jsonld",
 
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-native/^1.0.0/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-native/^1.0.0/components/context.jsonld",
+
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-number/^1.0.0/components/context.jsonld"
   ],
-  "@id": "urn:comunica:my",
-  "actors": [
+  "@graph": [
     {
-      "@id": "config-sets:http.json#myHttpFetcher",
-      "@type": "ActorHttpNative"
+      "@id": "urn:comunica:my",
+      "actors": [
+        {
+          "@id": "config-sets:http.json#myHttpFetcher",
+          "@type": "ActorHttpNative"
+        }
+      ]
+    },
+    {
+      "@id": "config-sets:http.json#mediatorHttp",
+      "@type": "MediatorNumberMin",
+      "field": "time",
+      "ignoreErrors": true,
+      "cc:Mediator/bus": { "@id": "cbh:Bus/Http" }
     }
   ]
 }

--- a/packages/actor-init-sparql/config/sets/rdf-dereference.json
+++ b/packages/actor-init-sparql/config/sets/rdf-dereference.json
@@ -9,7 +9,6 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-rdf-parse/^1.0.0/components/context.jsonld",
 
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-number/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-race/^1.0.0/components/context.jsonld"
   ],
   "@id": "urn:comunica:my",
@@ -18,10 +17,7 @@
       "@id": "config-sets:rdf-dereference.json#myRdfDereferencer",
       "@type": "ActorRdfDereferenceHttpParse",
       "mediatorHttp": {
-        "@id": "config-sets:rdf-dereference.json#mediatorHttp",
-        "@type": "MediatorNumberMin",
-        "field": "time",
-        "cc:Mediator/bus": { "@id": "cbh:Bus/Http" }
+        "@id": "config-sets:http.json#mediatorHttp"
       },
       "mediatorRdfParse": {
         "@id": "config-sets:rdf-dereference.json#mediatorRdfParse",

--- a/packages/actor-init-sparql/config/sets/rdf-source-identifiers.json
+++ b/packages/actor-init-sparql/config/sets/rdf-source-identifiers.json
@@ -7,9 +7,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-source-identifier-hypermedia-qpf/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-source-identifier-sparql/^1.0.0/components/context.jsonld",
 
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld",
-
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-number/^1.0.0/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld"
   ],
   "@id": "urn:comunica:my",
   "actors": [
@@ -17,21 +15,22 @@
       "@id": "config-sets:rdf-source-identifiers.json#myActorRdfSourceIdentifierHypermediaQpf",
       "@type": "ActorRdfSourceIdentifierHypermediaQpf",
       "carsihq:Actor/RdfSourceIdentifier/HypermediaQpf/mediatorHttp": {
-        "@id": "config-sets:rdf-source-identifiers.json#mediatorHttp",
-        "@type": "MediatorNumberMin",
-        "field": "time",
-        "cc:Mediator/bus": { "@id": "cbh:Bus/Http" }
+        "@id": "config-sets:http.json#mediatorHttp"
       }
     },
     {
       "@id": "config-sets:rdf-source-identifiers.json#myActorRdfSourceIdentifierSparql",
       "@type": "ActorRdfSourceIdentifierSparql",
-      "carsis:Actor/RdfSourceIdentifier/Sparql/mediatorHttp": { "@id": "config-sets:rdf-source-identifiers.json#mediatorHttp" }
+      "carsis:Actor/RdfSourceIdentifier/Sparql/mediatorHttp": {
+        "@id": "config-sets:http.json#mediatorHttp"
+      }
     },
     {
       "@id": "config-sets:rdf-source-identifiers.json#myActorRdfSourceIdentifierFileContentType",
       "@type": "ActorRdfSourceIdentifierFileContentType",
-      "carsifct:Actor/RdfSourceIdentifier/FileContentType/mediatorHttp": { "@id": "config-sets:rdf-source-identifiers.json#mediatorHttp" }
+      "carsifct:Actor/RdfSourceIdentifier/FileContentType/mediatorHttp": {
+        "@id": "config-sets:http.json#mediatorHttp"
+      }
     }
   ]
 }

--- a/packages/actor-init-sparql/config/sets/resolve-sparql.json
+++ b/packages/actor-init-sparql/config/sets/resolve-sparql.json
@@ -6,9 +6,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-sparql-endpoint/^1.0.0/components/context.jsonld",
 
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld",
-
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-number/^1.0.0/components/context.jsonld"
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^1.0.0/components/context.jsonld"
   ],
   "@id": "urn:comunica:my",
   "actors": [
@@ -16,18 +14,14 @@
       "@id": "config-sets:resolve-sparql.json#mySparqlQuadPatternResolver",
       "@type": "ActorRdfResolveQuadPatternSparqlJson",
       "carrqpsj:Actor/RdfResolveQuadPattern/SparqlJson/mediatorHttp": {
-        "@id": "config-sets:resolve-sparql.json#mediatorHttp",
-        "@type": "MediatorNumberMin",
-        "field": "time",
-        "ignoreErrors": true,
-        "cc:Mediator/bus": { "@id": "cbh:Bus/Http" }
+        "@id": "config-sets:http.json#mediatorHttp"
       }
     },
     {
       "@id": "config-sets:resolve-sparql.json#mySparqlEndpointResolver",
       "@type": "ActorQueryOperationSparqlEndpoint",
       "caqose:Actor/QueryOperation/SparqlEndpoint/mediatorHttp": {
-        "@id": "config-sets:resolve-sparql.json#mediatorHttp"
+        "@id": "config-sets:http.json#mediatorHttp"
       }
     }
   ]

--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -7,7 +7,7 @@ import {IActionSparqlSerialize} from "@comunica/bus-sparql-serialize";
 import {IActionRootSparqlParse, IActorOutputRootSparqlParse,
   IActorTestRootSparqlParse} from "@comunica/bus-sparql-serialize";
 import {IActorSparqlSerializeOutput} from "@comunica/bus-sparql-serialize";
-import {ActionContext, Actor, IAction, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {ActionContext, Actor, IAction, IActorArgs, IActorTest, KEY_CONTEXT_LOG, Logger, Mediator} from "@comunica/core";
 import {AsyncReiterableArray} from "asyncreiterable";
 import * as RDF from "rdf-js";
 import {termToString} from "rdf-string";
@@ -32,6 +32,7 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
     IActorOutputRootSparqlParse>;
   public readonly mediatorContextPreprocess: Mediator<Actor<IAction, IActorTest,
     IActorContextPreprocessOutput>, IAction, IActorTest, IActorContextPreprocessOutput>;
+  public readonly logger: Logger;
   public readonly queryString?: string;
   public readonly defaultQueryInputFormat?: string;
   public readonly context?: string;
@@ -107,6 +108,13 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
     if (context.queryFormat) {
       context[KEY_CONTEXT_QUERYFORMAT] = context.queryFormat;
       delete context.queryFormat;
+    }
+    if (context.log) {
+      context[KEY_CONTEXT_LOG] = context.log;
+      delete context.log;
+    }
+    if (!context[KEY_CONTEXT_LOG]) {
+      context[KEY_CONTEXT_LOG] = this.logger;
     }
     if (Array.isArray(context[KEY_CONTEXT_SOURCES])) {
       context[KEY_CONTEXT_SOURCES] = AsyncReiterableArray.fromFixedData(context[KEY_CONTEXT_SOURCES]);
@@ -194,6 +202,7 @@ export interface IActorInitSparqlArgs extends IActorArgs<IActionInit, IActorTest
     IActorOutputRootSparqlParse>;
   mediatorContextPreprocess: Mediator<Actor<IAction, IActorTest, IActorContextPreprocessOutput>,
     IAction, IActorTest, IActorContextPreprocessOutput>;
+  logger: Logger;
   queryString?: string;
   defaultQueryInputFormat?: string;
   context?: string;

--- a/packages/actor-init-sparql/lib/ActorInitSparql.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql.ts
@@ -2,6 +2,7 @@ import {KEY_CONTEXT_DATETIME} from "@comunica/actor-http-memento";
 import {IActionInit, IActorOutputInit} from "@comunica/bus-init";
 import {IActorQueryOperationOutput} from "@comunica/bus-query-operation";
 import {KEY_CONTEXT_SOURCES} from "@comunica/bus-rdf-resolve-quad-pattern";
+import {LoggerPretty} from "@comunica/logger-pretty";
 import {exec} from "child_process";
 import {existsSync, readFileSync} from "fs";
 import minimist = require('minimist');
@@ -56,6 +57,7 @@ Options:
   -c            use the given JSON configuration file (e.g., config.json)
   -t            the MIME type of the output (e.g., application/json)
   -i            the query input format (e.g., graphql, defaults to sparql)
+  -l            sets the log level (e.g., debug, info, warn, ... defaults to error)
   -d            sets a datetime for querying Memento-enabled archives'
   --help        print this help message
   --listformats prints the supported MIME types
@@ -100,6 +102,9 @@ Options:
     if (args.i) {
       context.queryFormat = args.i;
     }
+
+    // Set the logger
+    context.log = new LoggerPretty({ level: args.l || 'warn' });
 
     // Define the datetime
     if (args.d) {

--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -113,6 +113,8 @@
     "@comunica/bus-sparql-parse": "^1.1.0",
     "@comunica/bus-sparql-serialize": "^1.1.0",
     "@comunica/core": "^1.1.0",
+    "@comunica/logger-pretty": "^1.0.0",
+    "@comunica/logger-void": "^1.0.0",
     "@comunica/mediator-combine-pipeline": "^1.1.0",
     "@comunica/mediator-combine-union": "^1.1.0",
     "@comunica/mediator-number": "^1.1.0",

--- a/packages/actor-query-operation-bgp-left-deep-smallest/lib/ActorQueryOperationBgpLeftDeepSmallest.ts
+++ b/packages/actor-query-operation-bgp-left-deep-smallest/lib/ActorQueryOperationBgpLeftDeepSmallest.ts
@@ -196,6 +196,9 @@ export class ActorQueryOperationBgpLeftDeepSmallest extends ActorQueryOperationT
       async (patternOutput) => patternOutput.metadata ? await patternOutput.metadata() : {}));
     const smallestId: number = ActorQueryOperationBgpLeftDeepSmallest.getSmallestPatternId(metadatas);
 
+    this.logDebug(context, 'Smallest pattern: ',
+      { actor: this.name, pattern: pattern.patterns[smallestId], metadata: metadatas[smallestId] });
+
     // Close the non-smallest streams
     for (let i: number = 0; i < patternOutputs.length; i++) {
       if (i !== smallestId) {

--- a/packages/actor-query-operation-bgp-left-deep-smallest/test/ActorQueryOperationBgpLeftDeepSmallest-test.ts
+++ b/packages/actor-query-operation-bgp-left-deep-smallest/test/ActorQueryOperationBgpLeftDeepSmallest-test.ts
@@ -1,5 +1,5 @@
 import {ActorQueryOperation, Bindings, IActorQueryOperationOutputBindings} from "@comunica/bus-query-operation";
-import {Bus} from "@comunica/core";
+import {ActionContext, Bus} from "@comunica/core";
 import {ArrayIterator, EmptyIterator, SingletonIterator} from "asynciterator";
 import {blankNode, defaultGraph, literal, namedNode, quad, variable} from "rdf-data-model";
 import {Algebra} from "sparqlalgebrajs";
@@ -20,9 +20,9 @@ describe('ActorQueryOperationBgpLeftDeepSmallest', () => {
           predicate: arg.operation.predicate,
           subject: arg.operation.subject,
         })),
-        metadata: () => Promise.resolve({ totalItems: (arg.context || {}).totalItems }),
+        metadata: () => Promise.resolve({ totalItems: (arg.context || ActionContext({})).get('totalItems') }),
         type: 'bindings',
-        variables: (arg.context || {}).variables || [],
+        variables: (arg.context || ActionContext({})).get('variables') || [],
       }),
     };
   });
@@ -466,7 +466,7 @@ describe('ActorQueryOperationBgpLeftDeepSmallest', () => {
     const patterns = [ pattern1, pattern2 ];
 
     it('should run with a context and delegate the pattern to the mediator', () => {
-      const op = { operation: { type: 'bgp', patterns }, context: { totalItems: 10, variables: ['a'] } };
+      const op = { operation: { type: 'bgp', patterns }, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
       return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
         expect(output.variables).toEqual(['a']);
         expect(output.type).toEqual('bindings');

--- a/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
+++ b/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
@@ -28,10 +28,13 @@ export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
     IActionHttp, IActorTest, IActorHttpOutput>;
   public readonly endpointFetcher: SparqlEndpointFetcher;
 
+  protected lastContext: ActionContext;
+
   constructor(args: IActorQueryOperationSparqlEndpointArgs) {
     super(args);
     this.endpointFetcher = new SparqlEndpointFetcher({
-      fetch: (input?: Request | string, init?: RequestInit) => this.mediatorHttp.mediate({ input, init }),
+      fetch: (input?: Request | string, init?: RequestInit) => this.mediatorHttp.mediate(
+        { input, init, context: this.lastContext }),
       prefixVariableQuestionMark: true,
     });
   }
@@ -87,6 +90,7 @@ export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
 
     const bindingsStream: BufferedIterator<Bindings> = new BufferedIterator<Bindings>(
       { autoStart: false, maxBufferSize: Infinity });
+    this.lastContext = action.context;
     this.endpointFetcher.fetchBindings(endpoint, query)
       .then((rawBindingsStream) => {
         let totalItems = 0;

--- a/packages/core/components/Logger.jsonld
+++ b/packages/core/components/Logger.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld",
+  "@id": "npmd:@comunica/core",
+  "components": [
+    {
+      "@id": "cc:Logger",
+      "@type": "AbstractClass",
+      "comment": "A logger accepts messages from different levels and emits them in a certain way.",
+      "constructorArguments": [
+        {
+          "@id": "cc:Logger/constructorArgumentsObject",
+          "@type": "om:ObjectMapping"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/components/components.jsonld
+++ b/packages/core/components/components.jsonld
@@ -7,6 +7,7 @@
     "files-cc:components/ActionObserver.jsonld",
     "files-cc:components/Actor.jsonld",
     "files-cc:components/Bus.jsonld",
+    "files-cc:components/Logger.jsonld",
     "files-cc:components/Mediator.jsonld"
   ]
 }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/Bus';
 export * from './lib/ActionObserver';
 export * from './lib/Actor';
+export * from './lib/Logger';
 export * from './lib/Mediator';

--- a/packages/core/lib/Actor.ts
+++ b/packages/core/lib/Actor.ts
@@ -1,5 +1,6 @@
 import {Map} from "immutable";
 import {Bus} from "./Bus";
+import {KEY_CONTEXT_LOG, Logger} from "./Logger";
 
 /**
  * An actor can act on messages of certain types and provide output of a certain type.
@@ -37,6 +38,15 @@ export abstract class Actor<I extends IAction, T extends IActorTest, O extends I
   constructor(args: IActorArgs<I, T, O>) {
     require('lodash.assign')(this, args);
     this.bus.subscribe(this);
+  }
+
+  /**
+   * Get the logger from the given context.
+   * @param {ActionContext} context An optional context.
+   * @return {Logger} The logger or null.
+   */
+  public static getContextLogger(context: ActionContext): Logger {
+    return context ? context.get(KEY_CONTEXT_LOG) : null;
   }
 
   /**
@@ -92,6 +102,50 @@ export abstract class Actor<I extends IAction, T extends IActorTest, O extends I
    */
   public async deinitialize(): Promise<any> {
     return true;
+  }
+
+  /* Proxy methods for the (optional) logger that is defined in the context */
+
+  protected logTrace(context: ActionContext, message: string, data?: any): void {
+    const logger: Logger = Actor.getContextLogger(context);
+    if (logger) {
+      logger.trace(message, data);
+    }
+  }
+
+  protected logDebug(context: ActionContext, message: string, data?: any): void {
+    const logger: Logger = Actor.getContextLogger(context);
+    if (logger) {
+      logger.debug(message, data);
+    }
+  }
+
+  protected logInfo(context: ActionContext, message: string, data?: any): void {
+    const logger: Logger = Actor.getContextLogger(context);
+    if (logger) {
+      logger.info(message, data);
+    }
+  }
+
+  protected logWarn(context: ActionContext, message: string, data?: any): void {
+    const logger: Logger = Actor.getContextLogger(context);
+    if (logger) {
+      logger.warn(message, data);
+    }
+  }
+
+  protected logError(context: ActionContext, message: string, data?: any): void {
+    const logger: Logger = Actor.getContextLogger(context);
+    if (logger) {
+      logger.error(message, data);
+    }
+  }
+
+  protected logFatal(context: ActionContext, message: string, data?: any): void {
+    const logger: Logger = Actor.getContextLogger(context);
+    if (logger) {
+      logger.fatal(message, data);
+    }
   }
 
 }

--- a/packages/core/lib/Logger.ts
+++ b/packages/core/lib/Logger.ts
@@ -1,0 +1,42 @@
+/**
+ * A logger accepts messages from different levels
+ * and emits them in a certain way.
+ */
+export abstract class Logger {
+
+  /**
+   * All available logging levels.
+   * @type {{trace: number; debug: number; info: number; warn: number; error: number; fatal: number}}
+   */
+  // tslint:disable:object-literal-sort-keys
+  public static readonly LEVELS: {[id: string]: number} = {
+    trace: 0,
+    debug: 1,
+    info: 2,
+    warn: 3,
+    error: 4,
+    fatal: 5,
+  };
+
+  /**
+   * Convert a string-based logging level to a numerical logging level.
+   * @param level A string-based logging level
+   * @return The numerical logging level, or undefined.
+   */
+  public static getLevelOrdinal(level: string): number {
+    return Logger.LEVELS[level];
+  }
+
+  public abstract trace(message: string, data?: any): void;
+  public abstract debug(message: string, data?: any): void;
+  public abstract info(message: string, data?: any): void;
+  public abstract warn(message: string, data?: any): void;
+  public abstract error(message: string, data?: any): void;
+  public abstract fatal(message: string, data?: any): void;
+}
+
+/**
+ * @type {string} Context entry for a logger instance.
+ * @value {Logger} A logger.
+ */
+export const KEY_CONTEXT_LOG: string = '@comunica/core:log';

--- a/packages/core/test/Actor-test.ts
+++ b/packages/core/test/Actor-test.ts
@@ -1,5 +1,7 @@
-import {Actor} from "../lib/Actor";
+import {LoggerVoid} from "../../logger-void/lib/LoggerVoid";
+import {ActionContext, Actor} from "../lib/Actor";
 import {Bus} from "../lib/Bus";
+import {KEY_CONTEXT_LOG} from "../lib/Logger";
 
 describe('Actor', () => {
   const bus = new Bus({ name: 'bus' });
@@ -48,6 +50,95 @@ describe('Actor', () => {
       const output = actor.runObservable(action);
       expect(actor.run).toBeCalledWith(action);
       expect(bus.onRun).toBeCalledWith(actor, action, output);
+    });
+
+    describe('logger proxy methods without logger', () => {
+      const context = ActionContext({});
+
+      it('should void on trace', () => {
+        return actor.logTrace(context, 'bla');
+      });
+
+      it('should void on debug', () => {
+        return actor.logDebug(context, 'bla');
+      });
+
+      it('should void on info', () => {
+        return actor.logInfo(context, 'bla');
+      });
+
+      it('should void on warn', () => {
+        return actor.logWarn(context, 'bla');
+      });
+
+      it('should void on error', () => {
+        return actor.logError(context, 'bla');
+      });
+
+      it('should void on fatal', () => {
+        return actor.logFatal(context, 'bla');
+      });
+    });
+
+    describe('logger proxy methods with logger', () => {
+      let logger;
+      let context;
+
+      beforeEach(() => {
+        logger = new LoggerVoid();
+        jest.spyOn(logger, 'trace');
+        jest.spyOn(logger, 'debug');
+        jest.spyOn(logger, 'info');
+        jest.spyOn(logger, 'warn');
+        jest.spyOn(logger, 'error');
+        jest.spyOn(logger, 'fatal');
+        context = ActionContext({ [KEY_CONTEXT_LOG]: logger });
+      });
+
+      it('should call the logger on trace', () => {
+        actor.logTrace(context, 'bla', {});
+        return expect(logger.trace).toBeCalledWith('bla', {});
+      });
+
+      it('should call the logger on debug', () => {
+        actor.logDebug(context, 'bla', {});
+        return expect(logger.debug).toBeCalledWith('bla', {});
+      });
+
+      it('should call the logger on info', () => {
+        actor.logInfo(context, 'bla', {});
+        return expect(logger.info).toBeCalledWith('bla', {});
+      });
+
+      it('should call the logger on warn', () => {
+        actor.logWarn(context, 'bla', {});
+        return expect(logger.warn).toBeCalledWith('bla', {});
+      });
+
+      it('should call the logger on error', () => {
+        actor.logError(context, 'bla', {});
+        return expect(logger.error).toBeCalledWith('bla', {});
+      });
+
+      it('should call the logger on fatal', () => {
+        actor.logFatal(context, 'bla', {});
+        return expect(logger.fatal).toBeCalledWith('bla', {});
+      });
+    });
+  });
+
+  describe('#getContextLogger', () => {
+    it('for a falsy context should return a falsy value', () => {
+      return expect(Actor.getContextLogger(null)).toBeFalsy();
+    });
+
+    it('for a context without logger should return a falsy value', () => {
+      return expect(Actor.getContextLogger(ActionContext({}))).toBeFalsy();
+    });
+
+    it('for a context with logger should return the logger', () => {
+      const logger = 'blabla';
+      return expect(Actor.getContextLogger(ActionContext({ [KEY_CONTEXT_LOG]: logger }))).toBe(logger);
     });
   });
 });

--- a/packages/core/test/Logger-test.ts
+++ b/packages/core/test/Logger-test.ts
@@ -1,0 +1,33 @@
+import {Logger} from "../lib/Logger";
+
+describe('Logger', () => {
+  describe('#getLevelOrdinal', () => {
+    it('should return 0 for trace', () => {
+      expect(Logger.getLevelOrdinal('trace')).toBe(0);
+    });
+
+    it('should return 1 for debug', () => {
+      expect(Logger.getLevelOrdinal('debug')).toBe(1);
+    });
+
+    it('should return 2 for info', () => {
+      expect(Logger.getLevelOrdinal('info')).toBe(2);
+    });
+
+    it('should return 3 for warn', () => {
+      expect(Logger.getLevelOrdinal('warn')).toBe(3);
+    });
+
+    it('should return 4 for error', () => {
+      expect(Logger.getLevelOrdinal('error')).toBe(4);
+    });
+
+    it('should return 5 for fatal', () => {
+      expect(Logger.getLevelOrdinal('fatal')).toBe(5);
+    });
+
+    it('should return falsy for unknown', () => {
+      expect(Logger.getLevelOrdinal('unknown')).toBeFalsy();
+    });
+  });
+});

--- a/packages/logger-bunyan/README.md
+++ b/packages/logger-bunyan/README.md
@@ -1,0 +1,17 @@
+# Comunica Bus SPARQL Parse
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Fbus-sparql-parse.svg)](https://www.npmjs.com/package/@comunica/bus-sparql-parse)
+
+A comunica [bunyan](https://www.npmjs.com/package/bunyan)-based logger.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/logger-bunyan
+```
+
+## Usage
+
+TODO

--- a/packages/logger-bunyan/components/Logger/Bunyan.jsonld
+++ b/packages/logger-bunyan/components/Logger/Bunyan.jsonld
@@ -1,0 +1,64 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/logger-bunyan",
+  "components": [
+    {
+      "@id": "clb:Logger/Bunyan",
+      "@type": "Class",
+      "extends": "Logger",
+      "requireElement": "LoggerBunyan",
+      "comment": "A bunyan-based logger implementation.",
+      "parameters": [
+        {
+          "@id": "clb:Logger/Bunyan/name",
+          "defaultScoped": {
+            "defaultScope": "clb:Logger/Bunyan",
+            "defaultScopedValue": "comunica"
+          },
+          "comment": "The name of this logger",
+          "range": "xsd:string",
+          "unique": true
+        },
+        {
+          "@id": "clb:Logger/Bunyan/level",
+          "comment": "The logging level to emit",
+          "range": "xsd:string",
+          "unique": true,
+          "required": false
+        },
+        {
+          "@id": "clb:Logger/Bunyan/stream",
+          "comment": "A stream to output to",
+          "range": "clb:Logger/Bunyan/Stream",
+          "unique": false,
+          "required": false
+        }
+      ],
+      "constructorArguments": [
+        {
+          "@id": "clb:Logger/Bunyan/constructorArgumentsObject",
+          "extends": "cc:Logger/constructorArgumentsObject",
+          "fields": [
+            {
+              "keyRaw": "name",
+              "value": "clb:Logger/Bunyan/name"
+            },
+            {
+              "keyRaw": "level",
+              "value": "clb:Logger/Bunyan/level"
+            },
+            {
+              "keyRaw": "streamProviders",
+              "value": {
+                "elements": "clb:Logger/Bunyan/stream"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/logger-bunyan/components/Logger/Bunyan/Stream.jsonld
+++ b/packages/logger-bunyan/components/Logger/Bunyan/Stream.jsonld
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/logger-bunyan",
+  "components": [
+    {
+      "@id": "clb:Logger/Bunyan/Stream",
+      "@type": "AbstractClass",
+      "comment": "A bunyan output stream.",
+      "parameters": [
+        {
+          "@id": "clb:Logger/Bunyan/name"
+        },
+        {
+          "@id": "clb:Logger/Bunyan/level"
+        }
+      ],
+      "constructorArguments": [
+        {
+          "@id": "clb:Logger/Bunyan/Stream/constructorArgumentsObject",
+          "fields": [
+            {
+              "keyRaw": "name",
+              "value": "clb:Logger/Bunyan/name"
+            },
+            {
+              "keyRaw": "level",
+              "value": "clb:Logger/Bunyan/level"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/logger-bunyan/components/Logger/Bunyan/Stream/File.jsonld
+++ b/packages/logger-bunyan/components/Logger/Bunyan/Stream/File.jsonld
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/logger-bunyan",
+  "components": [
+    {
+      "@id": "clb:Logger/Bunyan/Stream/File",
+      "@type": "Class",
+      "extends": "clb:Logger/Bunyan/Stream",
+      "requireElement": "BunyanStreamProviderFile",
+      "comment": "A file bunyan stream provider.",
+      "parameters": [
+        {
+          "@id": "clb:Logger/Bunyan/Stream/File/path",
+          "comment": "Path to the target log file",
+          "range": "xsd:string",
+          "unique": true,
+          "required": true
+        }
+      ],
+      "constructorArguments": [
+        {
+          "@id": "clb:Logger/Bunyan/Stream/File/constructorArgumentsObject",
+          "extends": "clb:Logger/Bunyan/Stream/constructorArgumentsObject",
+          "fields": [
+            {
+              "keyRaw": "path",
+              "value": "clb:Logger/Bunyan/Stream/File/path"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/logger-bunyan/components/Logger/Bunyan/Stream/Stderr.jsonld
+++ b/packages/logger-bunyan/components/Logger/Bunyan/Stream/Stderr.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/logger-bunyan",
+  "components": [
+    {
+      "@id": "clb:Logger/Bunyan/Stream/Stderr",
+      "@type": "Class",
+      "extends": "clb:Logger/Bunyan/Stream",
+      "requireElement": "BunyanStreamProviderStderr",
+      "comment": "A stderr bunyan stream provider.",
+      "constructorArguments": [
+        {
+          "@id": "clb:Logger/Bunyan/Stream/Stderr/constructorArgumentsObject",
+          "extends": "clb:Logger/Bunyan/Stream/constructorArgumentsObject"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/logger-bunyan/components/Logger/Bunyan/Stream/Stdout.jsonld
+++ b/packages/logger-bunyan/components/Logger/Bunyan/Stream/Stdout.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/logger-bunyan",
+  "components": [
+    {
+      "@id": "clb:Logger/Bunyan/Stream/Stdout",
+      "@type": "Class",
+      "extends": "clb:Logger/Bunyan/Stream",
+      "requireElement": "BunyanStreamProviderStdout",
+      "comment": "A stdout bunyan stream provider.",
+      "constructorArguments": [
+        {
+          "@id": "clb:Logger/Bunyan/Stream/Stdout/constructorArgumentsObject",
+          "extends": "clb:Logger/Bunyan/Stream/constructorArgumentsObject"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/logger-bunyan/components/components.jsonld
+++ b/packages/logger-bunyan/components/components.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/context.jsonld",
+  "@id": "npmd:@comunica/logger-bunyan",
+  "@type": "Module",
+  "requireName": "@comunica/logger-bunyan",
+  "import": [
+    "files-clb:components/Logger/Bunyan.jsonld",
+    "files-clb:components/Logger/Bunyan/Stream.jsonld",
+    "files-clb:components/Logger/Bunyan/Stream/File.jsonld",
+    "files-clb:components/Logger/Bunyan/Stream/Stderr.jsonld",
+    "files-clb:components/Logger/Bunyan/Stream/Stdout.jsonld"
+  ]
+}

--- a/packages/logger-bunyan/components/context.jsonld
+++ b/packages/logger-bunyan/components/context.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld",
+    {
+      "clb": "npmd:@comunica/logger-bunyan/",
+      "files-clb": "clb:^1.0.0/",
+
+      "LoggerBunyan": "clb:Logger/Bunyan",
+      "name": "clb:Logger/Bunyan/name",
+      "level": "clb:Logger/Bunyan/level",
+      "stream": "clb:Logger/Bunyan/stream",
+      "streams": "clb:Logger/Bunyan/stream",
+
+      "path": "clb:Logger/Bunyan/Stream/File/path"
+    }
+  ]
+}

--- a/packages/logger-bunyan/index.ts
+++ b/packages/logger-bunyan/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/LoggerBunyan';
+export * from './lib/stream/BunyanStreamProvider';
+export * from './lib/stream/BunyanStreamProviderFile';
+export * from './lib/stream/BunyanStreamProviderStderr';
+export * from './lib/stream/BunyanStreamProviderStdout';

--- a/packages/logger-bunyan/lib/LoggerBunyan.ts
+++ b/packages/logger-bunyan/lib/LoggerBunyan.ts
@@ -1,0 +1,52 @@
+import {Logger} from "@comunica/core";
+import BunyanLogger = require("bunyan");
+import {LogLevelString} from "bunyan";
+import {BunyanStreamProvider} from "./stream/BunyanStreamProvider";
+
+/**
+ * A bunyan-based logger implementation.
+ */
+export class LoggerBunyan extends Logger {
+
+  private readonly bunyanLogger: BunyanLogger;
+
+  constructor(args: ILoggerBunyanArgs) {
+    super();
+    args = <ILoggerBunyanArgs> args;
+    args.streams = args.streamProviders.map((p) => p.createStream());
+    delete args.streamProviders;
+    this.bunyanLogger = BunyanLogger.createLogger(args);
+  }
+
+  public fatal(message: string, data?: any): void {
+    this.bunyanLogger.fatal(data, message);
+  }
+
+  public error(message: string, data?: any): void {
+    this.bunyanLogger.error(data, message);
+  }
+
+  public warn(message: string, data?: any): void {
+    this.bunyanLogger.warn(data, message);
+  }
+
+  public info(message: string, data?: any): void {
+    this.bunyanLogger.info(data, message);
+  }
+
+  public debug(message: string, data?: any): void {
+    this.bunyanLogger.debug(data, message);
+  }
+
+  public trace(message: string, data?: any): void {
+    this.bunyanLogger.trace(data, message);
+  }
+
+}
+
+export interface ILoggerBunyanArgs {
+  name: string;
+  streamProviders: BunyanStreamProvider[];
+  level?: LogLevelString;
+  [custom: string]: any;
+}

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProvider.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProvider.ts
@@ -1,0 +1,22 @@
+import {LogLevelString, Stream} from "bunyan";
+
+/**
+ * BunyanStreamProvider is able to create bunyan streams.
+ */
+export abstract class BunyanStreamProvider {
+
+  public readonly name: string;
+  public readonly level: LogLevelString;
+
+  constructor(args: IBunyanStreamProviderArgs) {
+    Object.assign(this, args);
+  }
+
+  public abstract createStream(): Stream;
+
+}
+
+export interface IBunyanStreamProviderArgs {
+  name?: string;
+  level?: LogLevelString;
+}

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProviderFile.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProviderFile.ts
@@ -1,0 +1,23 @@
+import {Stream} from "bunyan";
+import {BunyanStreamProvider, IBunyanStreamProviderArgs} from "./BunyanStreamProvider";
+
+/**
+ * A file bunyan stream provider.
+ */
+export class BunyanStreamProviderFile extends BunyanStreamProvider {
+
+  public readonly path: string;
+
+  constructor(args: IBunyanStreamProviderFileArgs) {
+    super(args);
+  }
+
+  public createStream(): Stream {
+    return { type: 'file', name: this.name, path: this.path.substr(8), level: this.level };
+  }
+
+}
+
+export interface IBunyanStreamProviderFileArgs extends IBunyanStreamProviderArgs {
+  path: string;
+}

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProviderStderr.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProviderStderr.ts
@@ -1,0 +1,17 @@
+import {Stream} from "bunyan";
+import {BunyanStreamProvider, IBunyanStreamProviderArgs} from "./BunyanStreamProvider";
+
+/**
+ * A stderr bunyan stream provider.
+ */
+export class BunyanStreamProviderStderr extends BunyanStreamProvider {
+
+  constructor(args: IBunyanStreamProviderArgs) {
+    super(args);
+  }
+
+  public createStream(): Stream {
+    return { name: this.name, stream: process.stderr, level: this.level };
+  }
+
+}

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProviderStdout.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProviderStdout.ts
@@ -1,0 +1,17 @@
+import {Stream} from "bunyan";
+import {BunyanStreamProvider, IBunyanStreamProviderArgs} from "./BunyanStreamProvider";
+
+/**
+ * A stdout bunyan stream provider.
+ */
+export class BunyanStreamProviderStdout extends BunyanStreamProvider {
+
+  constructor(args: IBunyanStreamProviderArgs) {
+    super(args);
+  }
+
+  public createStream(): Stream {
+    return { name: this.name, stream: process.stdout, level: this.level };
+  }
+
+}

--- a/packages/logger-bunyan/package.json
+++ b/packages/logger-bunyan/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@comunica/logger-bunyan",
+  "version": "1.1.0",
+  "description": "A comunica bunyan-based logger.",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan",
+  "lsd:components": "components/components.jsonld",
+  "lsd:contexts": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/context.jsonld": "components/context.jsonld"
+  },
+  "lsd:importPaths": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-bunyan/^1.0.0/components/": "components/"
+  },
+  "main": "index.js",
+  "typings": "index",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/logger-bunyan",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "comunica",
+    "logger",
+    "bunyan"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://github.com/comunica/comunica#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "dependencies": {
+    "bunyan": "^1.8.12"
+  },
+  "peerDependencies": {
+    "@comunica/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@comunica/core": "^1.1.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true
+  },
+  "scripts": {
+    "test": "node \"../../node_modules/jest/bin/jest.js\" ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/logger-bunyan/test/BunyanStreamProviderFile-test.ts
+++ b/packages/logger-bunyan/test/BunyanStreamProviderFile-test.ts
@@ -1,0 +1,8 @@
+import {BunyanStreamProviderFile} from "../lib/stream/BunyanStreamProviderFile";
+
+describe('BunyanStreamProviderFile', () => {
+  it('should create a file stream', () => {
+    const myProvider = new BunyanStreamProviderFile({ name: 'bla', level: 'warn', path: 'file:////abc' });
+    expect(myProvider.createStream()).toEqual({ type: 'file', name: 'bla', path: '/abc', level: 'warn' });
+  });
+});

--- a/packages/logger-bunyan/test/BunyanStreamProviderStderr-test.ts
+++ b/packages/logger-bunyan/test/BunyanStreamProviderStderr-test.ts
@@ -1,0 +1,8 @@
+import {BunyanStreamProviderStderr} from "../lib/stream/BunyanStreamProviderStderr";
+
+describe('BunyanStreamProviderStderr', () => {
+  it('should create a stderr stream', () => {
+    const myProvider = new BunyanStreamProviderStderr({ name: 'bla', level: 'warn' });
+    expect(myProvider.createStream()).toEqual({ name: 'bla', stream: process.stderr, level: 'warn' });
+  });
+});

--- a/packages/logger-bunyan/test/BunyanStreamProviderStdout-test.ts
+++ b/packages/logger-bunyan/test/BunyanStreamProviderStdout-test.ts
@@ -1,0 +1,8 @@
+import {BunyanStreamProviderStdout} from "../lib/stream/BunyanStreamProviderStdout";
+
+describe('BunyanStreamProviderStdout', () => {
+  it('should create a stdout stream', () => {
+    const myProvider = new BunyanStreamProviderStdout({ name: 'bla', level: 'warn' });
+    expect(myProvider.createStream()).toEqual({ name: 'bla', stream: process.stdout, level: 'warn' });
+  });
+});

--- a/packages/logger-bunyan/test/LoggerBunyan-test.ts
+++ b/packages/logger-bunyan/test/LoggerBunyan-test.ts
@@ -1,0 +1,73 @@
+// tslint:disable:object-literal-sort-keys
+jest.mock('bunyan', () => {
+  return {
+    createLogger: (args: any) => ({
+      ...args,
+      trace: jest.fn(() => null),
+      debug: jest.fn(() => null),
+      info: jest.fn(() => null),
+      warn: jest.fn(() => null),
+      error: jest.fn(() => null),
+      fatal: jest.fn(() => null),
+    }),
+  };
+});
+
+import {LoggerBunyan} from "../lib/LoggerBunyan";
+import {BunyanStreamProviderStderr} from "../lib/stream/BunyanStreamProviderStderr";
+
+describe('LoggerBunyan', () => {
+
+  it('should create streams from providers during construction', () => {
+    const myProvider = new BunyanStreamProviderStderr({ name: 'def', level: 'warn' });
+    jest.spyOn(myProvider, 'createStream');
+    const myLogger = new LoggerBunyan({ name: 'abc', streamProviders: [ myProvider ] });
+    expect(myProvider.createStream).toHaveBeenCalledTimes(1);
+    expect((<any> myLogger).bunyanLogger.streams).toEqual([myProvider.createStream()]);
+  });
+
+  describe('a LoggerBunyan instance', () => {
+    let logger: LoggerBunyan;
+
+    beforeEach(() => {
+      logger = new LoggerBunyan({ name: 'abc', a: 'a', b: 'b', streamProviders: [] });
+    });
+
+    it('should pass all args except for streamProviders', () => {
+      expect((<any> logger).bunyanLogger.name).toEqual('abc');
+      expect((<any> logger).bunyanLogger.a).toEqual('a');
+      expect((<any> logger).bunyanLogger.b).toEqual('b');
+      expect((<any> logger).bunyanLogger.streamProviders).toBeFalsy();
+    });
+
+    it('should forward trace', () => {
+      logger.trace('bla', {});
+      return expect((<any> logger).bunyanLogger.trace).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forward debug', () => {
+      logger.debug('bla', {});
+      return expect((<any> logger).bunyanLogger.debug).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forward info', () => {
+      logger.info('bla', {});
+      return expect((<any> logger).bunyanLogger.info).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forward warn', () => {
+      logger.warn('bla', {});
+      return expect((<any> logger).bunyanLogger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forward error', () => {
+      logger.error('bla', {});
+      return expect((<any> logger).bunyanLogger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should forward fatal', () => {
+      logger.fatal('bla', {});
+      return expect((<any> logger).bunyanLogger.fatal).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/logger-bunyan/tsconfig.json
+++ b/packages/logger-bunyan/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/logger-bunyan/tslint.json
+++ b/packages/logger-bunyan/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}

--- a/packages/logger-pretty/README.md
+++ b/packages/logger-pretty/README.md
@@ -1,0 +1,17 @@
+# Comunica Bus SPARQL Parse
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Fbus-sparql-parse.svg)](https://www.npmjs.com/package/@comunica/bus-sparql-parse)
+
+A comunica logger that pretty-prints.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/logger-pretty
+```
+
+## Usage
+
+TODO

--- a/packages/logger-pretty/components/Logger/Pretty.jsonld
+++ b/packages/logger-pretty/components/Logger/Pretty.jsonld
@@ -1,0 +1,38 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-pretty/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/logger-pretty",
+  "components": [
+    {
+      "@id": "clp:Logger/Pretty",
+      "@type": "Class",
+      "extends": "Logger",
+      "requireElement": "LoggerPretty",
+      "comment": "A logger that pretty-prints.",
+      "parameters": [
+        {
+          "@id": "clp:Logger/Pretty#level",
+          "default": "warn",
+          "comment": "The logging level",
+          "range": "xsd:string",
+          "unique": true,
+          "required": true
+        }
+      ],
+      "constructorArguments": [
+        {
+          "@id": "clp:Logger/Pretty/constructorArgumentsObject",
+          "extends": "cc:Logger/constructorArgumentsObject",
+          "fields": [
+            {
+              "keyRaw": "level",
+              "value": "clp:Logger/Pretty#level"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/logger-pretty/components/components.jsonld
+++ b/packages/logger-pretty/components/components.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-pretty/^1.0.0/components/context.jsonld",
+  "@id": "npmd:@comunica/logger-pretty",
+  "@type": "Module",
+  "requireName": "@comunica/logger-pretty",
+  "import": [
+    "files-clp:components/Logger/Pretty.jsonld"
+  ]
+}

--- a/packages/logger-pretty/components/context.jsonld
+++ b/packages/logger-pretty/components/context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld",
+    {
+      "clp": "npmd:@comunica/logger-pretty/",
+      "files-clp": "clp:^1.0.0/",
+
+      "LoggerPretty": "clp:Logger/Pretty"
+    }
+  ]
+}

--- a/packages/logger-pretty/index.ts
+++ b/packages/logger-pretty/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/LoggerPretty';

--- a/packages/logger-pretty/lib/LoggerPretty.ts
+++ b/packages/logger-pretty/lib/LoggerPretty.ts
@@ -1,0 +1,52 @@
+import {Logger} from "@comunica/core";
+
+/**
+ * A logger that pretty-prints everything.
+ */
+export class LoggerPretty extends Logger {
+
+  private readonly level: string;
+  private readonly levelOrdinal: number;
+
+  constructor(args: ILoggerPrettyArgs) {
+    super();
+    this.level = args.level;
+    this.levelOrdinal = Logger.getLevelOrdinal(this.level);
+  }
+
+  public debug(message: string, data?: any): void {
+    this.log('debug', message, data);
+  }
+
+  public error(message: string, data?: any): void {
+    this.log('error', message, data);
+  }
+
+  public fatal(message: string, data?: any): void {
+    this.log('fatal', message, data);
+  }
+
+  public info(message: string, data?: any): void {
+    this.log('info', message, data);
+  }
+
+  public trace(message: string, data?: any): void {
+    this.log('trace', message, data);
+  }
+
+  public warn(message: string, data?: any): void {
+    this.log('warn', message, data);
+  }
+
+  protected log(level: string, message: string, data?: any): void {
+    if (Logger.getLevelOrdinal(level) >= this.levelOrdinal) {
+      // tslint:disable-next-line:no-console
+      console.error(`[${new Date().toISOString()}]  ${level.toUpperCase()}: ${message}`, data);
+    }
+  }
+
+}
+
+export interface ILoggerPrettyArgs {
+  level: string;
+}

--- a/packages/logger-pretty/package.json
+++ b/packages/logger-pretty/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@comunica/logger-pretty",
+  "version": "1.1.0",
+  "description": "A comunica logger that pretty-prints.",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-pretty",
+  "lsd:components": "components/components.jsonld",
+  "lsd:contexts": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-pretty/^1.0.0/components/context.jsonld": "components/context.jsonld"
+  },
+  "lsd:importPaths": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-pretty/^1.0.0/components/": "components/"
+  },
+  "main": "index.js",
+  "typings": "index",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/logger-pretty",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "comunica",
+    "logger",
+    "void"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://github.com/comunica/comunica#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@comunica/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@comunica/core": "^1.1.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true
+  },
+  "scripts": {
+    "test": "node \"../../node_modules/jest/bin/jest.js\" ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/logger-pretty/test/LoggerPretty-test.ts
+++ b/packages/logger-pretty/test/LoggerPretty-test.ts
@@ -1,0 +1,237 @@
+import {LoggerPretty} from "../lib/LoggerPretty";
+
+// tslint:disable:no-console
+describe('LoggerPretty', () => {
+
+  beforeEach(() => {
+    (<any> global).console = { error: jest.fn() };
+  });
+
+  describe('a LoggerPretty instance on trace level', () => {
+    let logger: LoggerPretty;
+
+    beforeEach(() => {
+      logger = new LoggerPretty({ level: 'trace' });
+    });
+
+    it('should log for trace', () => {
+      logger.trace('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for debug', () => {
+      logger.debug('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for info', () => {
+      logger.info('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for warn', () => {
+      logger.warn('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for error', () => {
+      logger.error('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for fatal', () => {
+      logger.fatal('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('a LoggerPretty instance on debug level', () => {
+    let logger: LoggerPretty;
+
+    beforeEach(() => {
+      logger = new LoggerPretty({ level: 'debug' });
+    });
+
+    it('should void for trace', () => {
+      logger.trace('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for debug', () => {
+      logger.debug('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for info', () => {
+      logger.info('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for warn', () => {
+      logger.warn('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for error', () => {
+      logger.error('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for fatal', () => {
+      logger.fatal('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('a LoggerPretty instance on info level', () => {
+    let logger: LoggerPretty;
+
+    beforeEach(() => {
+      logger = new LoggerPretty({ level: 'info' });
+    });
+
+    it('should void for trace', () => {
+      logger.trace('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for debug', () => {
+      logger.debug('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for info', () => {
+      logger.info('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for warn', () => {
+      logger.warn('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for error', () => {
+      logger.error('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for fatal', () => {
+      logger.fatal('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('a LoggerPretty instance on warn level', () => {
+    let logger: LoggerPretty;
+
+    beforeEach(() => {
+      logger = new LoggerPretty({ level: 'warn' });
+    });
+
+    it('should void for trace', () => {
+      logger.trace('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for debug', () => {
+      logger.debug('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for info', () => {
+      logger.info('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for warn', () => {
+      logger.warn('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for error', () => {
+      logger.error('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for fatal', () => {
+      logger.fatal('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('a LoggerPretty instance on error level', () => {
+    let logger: LoggerPretty;
+
+    beforeEach(() => {
+      logger = new LoggerPretty({ level: 'error' });
+    });
+
+    it('should void for trace', () => {
+      logger.trace('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for debug', () => {
+      logger.debug('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for info', () => {
+      logger.info('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for warn', () => {
+      logger.warn('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for error', () => {
+      logger.error('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log for fatal', () => {
+      logger.fatal('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('a LoggerPretty instance on fatal level', () => {
+    let logger: LoggerPretty;
+
+    beforeEach(() => {
+      logger = new LoggerPretty({ level: 'fatal' });
+    });
+
+    it('should void for trace', () => {
+      logger.trace('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for debug', () => {
+      logger.debug('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for info', () => {
+      logger.info('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for warn', () => {
+      logger.warn('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for error', () => {
+      logger.error('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(0);
+    });
+
+    it('should log for fatal', () => {
+      logger.fatal('bla', {});
+      return expect(console.error).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/logger-pretty/tsconfig.json
+++ b/packages/logger-pretty/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/logger-pretty/tslint.json
+++ b/packages/logger-pretty/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}

--- a/packages/logger-void/README.md
+++ b/packages/logger-void/README.md
@@ -1,0 +1,17 @@
+# Comunica Bus SPARQL Parse
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Fbus-sparql-parse.svg)](https://www.npmjs.com/package/@comunica/bus-sparql-parse)
+
+A comunica void-based logger.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/logger-void
+```
+
+## Usage
+
+TODO

--- a/packages/logger-void/components/Logger/Void.jsonld
+++ b/packages/logger-void/components/Logger/Void.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-void/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/logger-void",
+  "components": [
+    {
+      "@id": "clv:Logger/Void",
+      "@type": "Class",
+      "extends": "Logger",
+      "requireElement": "LoggerVoid",
+      "comment": "A logger that voids everything.",
+      "constructorArguments": [
+        {
+          "@id": "clv:Logger/Void/constructorArgumentsObject",
+          "extends": "cc:Logger/constructorArgumentsObject"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/logger-void/components/components.jsonld
+++ b/packages/logger-void/components/components.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-void/^1.0.0/components/context.jsonld",
+  "@id": "npmd:@comunica/logger-void",
+  "@type": "Module",
+  "requireName": "@comunica/logger-void",
+  "import": [
+    "files-clv:components/Logger/Void.jsonld"
+  ]
+}

--- a/packages/logger-void/components/context.jsonld
+++ b/packages/logger-void/components/context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld",
+    {
+      "clv": "npmd:@comunica/logger-void/",
+      "files-clv": "clv:^1.0.0/",
+
+      "LoggerVoid": "clv:Logger/Void"
+    }
+  ]
+}

--- a/packages/logger-void/index.ts
+++ b/packages/logger-void/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/LoggerVoid';

--- a/packages/logger-void/lib/LoggerVoid.ts
+++ b/packages/logger-void/lib/LoggerVoid.ts
@@ -1,0 +1,32 @@
+import {Logger} from "@comunica/core";
+
+/**
+ * A logger that voids everything.
+ */
+export class LoggerVoid extends Logger {
+
+  public debug(message: string, data?: any): void {
+    // Void
+  }
+
+  public error(message: string, data?: any): void {
+    // Void
+  }
+
+  public fatal(message: string, data?: any): void {
+    // Void
+  }
+
+  public info(message: string, data?: any): void {
+    // Void
+  }
+
+  public trace(message: string, data?: any): void {
+    // Void
+  }
+
+  public warn(message: string, data?: any): void {
+    // Void
+  }
+
+}

--- a/packages/logger-void/package.json
+++ b/packages/logger-void/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@comunica/logger-void",
+  "version": "1.1.0",
+  "description": "A comunica void-based logger.",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-void",
+  "lsd:components": "components/components.jsonld",
+  "lsd:contexts": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-void/^1.0.0/components/context.jsonld": "components/context.jsonld"
+  },
+  "lsd:importPaths": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/logger-void/^1.0.0/components/": "components/"
+  },
+  "main": "index.js",
+  "typings": "index",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/logger-void",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "comunica",
+    "logger",
+    "void"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://github.com/comunica/comunica#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@comunica/core": "^1.0.0"
+  },
+  "devDependencies": {
+    "@comunica/core": "^1.1.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts$": "<rootDir>/../../node_modules/ts-jest/preprocessor.js"
+    },
+    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true
+  },
+  "scripts": {
+    "test": "node \"../../node_modules/jest/bin/jest.js\" ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/logger-void/test/LoggerVoid-test.ts
+++ b/packages/logger-void/test/LoggerVoid-test.ts
@@ -1,0 +1,36 @@
+import {LoggerVoid} from "../lib/LoggerVoid";
+
+describe('LoggerVoid', () => {
+  describe('a LoggerVoid instance', () => {
+
+    let logger: LoggerVoid;
+
+    beforeEach(() => {
+      logger = new LoggerVoid();
+    });
+
+    it('should void for trace', () => {
+      logger.trace('bla', {});
+    });
+
+    it('should void for debug', () => {
+      logger.debug('bla', {});
+    });
+
+    it('should void for info', () => {
+      logger.info('bla', {});
+    });
+
+    it('should void for warn', () => {
+      logger.warn('bla', {});
+    });
+
+    it('should void for error', () => {
+      logger.error('bla', {});
+    });
+
+    it('should void for fatal', () => {
+      logger.fatal('bla', {});
+    });
+  });
+});

--- a/packages/logger-void/tsconfig.json
+++ b/packages/logger-void/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/logger-void/tslint.json
+++ b/packages/logger-void/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,6 +31,13 @@
   version "3.5.22"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.22.tgz#519b87fe3c9d290ca6c06381ffc3040770ab452b"
 
+"@types/bunyan@^1.8.4":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.4.tgz#69c11adc7b50538d45fb68d9ae39d062b9432f38"
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -1234,6 +1241,15 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bunyan@^1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.10.6"
+    mv "~2"
+    safe-json-stringify "~1"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -2047,6 +2063,12 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
+dtrace-provider@~0.8:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.7.tgz#dc939b4d3e0620cfe0c1cd803d0d2d7ed04ffd04"
+  dependencies:
+    nan "^2.10.0"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
@@ -2645,6 +2667,16 @@ glob2base@^0.0.12:
   resolved "https://registry.yarnpkg.com/glob2base/-/glob2base-0.0.12.tgz#9d419b3e28f12e83a362164a277055922c9c0d56"
   dependencies:
     find-index "^0.1.1"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
@@ -4193,7 +4225,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -4257,7 +4289,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -4267,7 +4299,7 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
 
-moment@^2.6.0:
+moment@^2.10.6, moment@^2.6.0:
   version "2.22.2"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
@@ -4289,6 +4321,14 @@ ms@2.0.0:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
 
 n3@^0.11.2:
   version "0.11.3"
@@ -4325,6 +4365,10 @@ nanomatch@^1.2.9:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
 
 needle@^2.2.1:
   version "2.2.1"
@@ -5335,6 +5379,12 @@ rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  dependencies:
+    glob "^6.0.1"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -5377,6 +5427,10 @@ rxjs@^6.1.0:
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This implements logging as required by #114.

Logging is available everywhere:

* By default, comunica will use a void logger.
* When on the command-line, it will use the pretty-print logger (unless overridden via the context) with a given configurable logging level.
* Via the API, the logger instance can be overridden by providing it via the context.

At the moment, only the HTTP actor and left-deep-smallest BGP actor will do some basic logging to resp. INFO and DEBUG, just like `ldf-client`.

For advanced logging purposes, a [bunyan](https://www.npmjs.com/package/bunyan)-based logger is available. This is currently not being used anywhere.

This will allow https://github.com/comunica/jQuery-Widget.js/issues/2 to be implemented.