### PR TITLE
Replace XMLHttpRequest by fetch

### DIFF
--- a/packages/actor-http-native/lib/Requester-browser.ts
+++ b/packages/actor-http-native/lib/Requester-browser.ts
@@ -1,4 +1,4 @@
-/*! @license MIT ©2013-2016 Ruben Verborgh, Ghent University - imec */
+/*! @license MIT ©2013-2018 Ruben Verborgh, Ghent University - imec */
 /* Single-function HTTP(S) request module for browsers */
 /* Translated from https://github.com/LinkedDataFragments/Client.js/blob/master/lib/browser/Request.js */
 
@@ -7,89 +7,70 @@ import {IncomingMessage} from "http";
 import * as parseLink from 'parse-link-header';
 import {Readable} from "stream";
 
-// Headers we cannot send (see https://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader()-method)
-const UNSAFE_REQUEST_HEADERS = {'accept-encoding': true, 'user-agent': true, 'referer': true};
-
 export default class Requester {
-
   // Resources that were already time-negotiated
-  private negotiatedResources: {[id: string]: boolean};
-
-  constructor() {
-    this.negotiatedResources = {};
-  }
+  private negotiatedResources = new Set<string>();
 
   // Creates an HTTP request with the given settings
-  public createRequest(settings: any): EventEmitter {
+  public createRequest({ url, headers, method, timeout }: {
+    url: string,
+    headers: {[id: string]: string},
+    method: string,
+    timeout: number,
+  }): EventEmitter {
     // PERFORMANCE HACK:
     // Reduce OPTIONS preflight requests by removing the Accept-Datetime header
     // on requests for resources that are presumed to have been time-negotiated
-    if (this.negotiatedResources[this.removeQuery(settings.url)]) {
-      delete settings.headers['accept-datetime'];
+    if (this.negotiatedResources.has(this.removeQuery(url))) {
+      delete headers['accept-datetime'];
     }
 
-    // Create the actual XMLHttpRequest
-    const request = new XMLHttpRequest();
-    const reqHeaders = settings.headers;
-    request.open(settings.method, settings.url, true);
-    request.timeout = settings.timeout;
-    for (const header in reqHeaders) {
-      if (!(header in UNSAFE_REQUEST_HEADERS) && reqHeaders[header]) {
-        request.setRequestHeader(header, reqHeaders[header]);
-      }
+    // Create the actual request
+    const reqController = new AbortController();
+    const signal = reqController.signal;
+    const request = fetch(url, { headers, method, signal });
+    if (timeout) {
+      setTimeout(() => reqController.abort(), timeout);
     }
 
-    // Create a proxy for the XMLHttpRequest
+    // Create a proxy for the request
     const requestProxy = new EventEmitter();
-    (<any> requestProxy).abort = () => { request.abort(); };
+    (<any> requestProxy).abort = () => reqController.abort();
 
     // Handle the arrival of a response
-    request.onload = () => {
-      // Convert the response into an iterator
-      const response: IncomingMessage = <IncomingMessage> new Readable();
-      response.push(request.responseText || '');
-      response.push(null);
-      response.statusCode = request.status;
-      (<any> response).responseUrl = request.responseURL;
+    request.then(async (response) => {
+      // Convert the response into a stream
+      const responseProxy: IncomingMessage = <IncomingMessage> new Readable();
+      responseProxy.push(await response.text());
+      responseProxy.push(null);
+      responseProxy.statusCode = response.status;
+      (<any> responseProxy).responseUrl = response.url;
 
       // Parse the response headers
-      response.headers = {};
-      const resHeaders = response.headers;
-      const rawHeaders = request.getAllResponseHeaders() || '';
-      const headerMatcher = /^([^:\n\r]+):[ \t]*([^\r\n]*)$/mg;
-      let match = headerMatcher.exec(rawHeaders);
-      while (match) {
-        resHeaders[match[1].toLowerCase()] = match[2];
-        match = headerMatcher.exec(rawHeaders);
+      const resHeaders: {[id: string]: string} = {};
+      responseProxy.headers = resHeaders;
+      for (const [name, value] of (<any> response.headers).entries()) {
+        resHeaders[name.toLowerCase()] = value;
       }
 
       // Emit the response
-      requestProxy.emit('response', response);
+      requestProxy.emit('response', responseProxy);
 
       // If the resource was time-negotiated, store its queryless URI
       // to enable the PERFORMANCE HACK explained above
-      if (reqHeaders['accept-datetime'] && resHeaders['memento-datetime']) {
-        const resource = this.removeQuery(resHeaders['content-location'] || settings.url);
-        if (!this.negotiatedResources[resource]) {
+      if (headers['accept-datetime'] && resHeaders['memento-datetime']) {
+        const resource = this.removeQuery(resHeaders['content-location'] || url);
+        if (!this.negotiatedResources.has(resource)) {
           // Ensure the resource is not a timegate
-          const links = resHeaders.link && parseLink(<string> resHeaders.link);
+          const links = resHeaders.link && parseLink(resHeaders.link);
           const timegate = this.removeQuery(links && links.timegate && links.timegate.url);
           if (resource !== timegate) {
-            this.negotiatedResources[resource] = true;
+            this.negotiatedResources.add(resource);
           }
         }
       }
-    };
-    // Report errors and timeouts
-    request.onerror = () => {
-      requestProxy.emit('error', new Error('Error requesting ' + settings.url));
-    };
-    request.ontimeout = () => {
-      requestProxy.emit('error', new Error('Timeout requesting ' + settings.url));
-    };
-
-    // Execute the request
-    request.send();
+    })
+    .catch((error) => requestProxy.emit('error', error));
     return requestProxy;
   }
 


### PR DESCRIPTION
By using the latest `fetch` interface, we can more easily swap in other libraries.

Related: #313.

Warning: untested, just ported on sight and with help from the TypeScript compiler. But I figured you guys could more easily test this in the browser than I can.