### PR TITLE
Fix JSON-LD parser to parse JSON with an @context attribute

### DIFF
--- a/packages/actor-rdf-parse-jsonld/lib/ActorRdfParseJsonLd.ts
+++ b/packages/actor-rdf-parse-jsonld/lib/ActorRdfParseJsonLd.ts
@@ -43,7 +43,7 @@ export class ActorRdfParseJsonLd extends ActorRdfParseFixedMediaTypes {
       if (!initialized) {
         initialized = true;
         const jsonString = await require('stream-to-string')(action.input);
-        const quadsArray = await this.jsonLd.toRDF(JSON.parse(jsonString), { baseIRI: action.baseIRI });
+        const quadsArray = await this.jsonLd.toRDF(JSON.parse(jsonString), { base: action.baseIRI });
         for (const quad of quadsArray) {
           quads.push(mapTerms(quad, ActorRdfParseJsonLd.mapTerm));
         }


### PR DESCRIPTION
Apperantly setting the base IRI is done through the [`base`](https://github.com/digitalbazaar/jsonld.js/blob/1fae88fd856be2bdb63e3a9d71d54e848a1aafe5/lib/jsonld.js#L100) parameter and not `baseIRI` when parsing JSON using jsonld.js. This closes #342.