### PR TITLE
Fix the Docker build for actor-init-sparql

### DIFF
--- a/packages/actor-init-sparql/Dockerfile
+++ b/packages/actor-init-sparql/Dockerfile
@@ -3,19 +3,12 @@ FROM node:10
 # Install location
 ENV dir /var/www/@comunica/actor-init-sparql/
 
-# Copy the engine files (generated from package.json!files)
-COPY components ${dir}/components/
-COPY config ${dir}/config/
-COPY lib/*.js ${dir}/lib/
-COPY bin/*.js ${dir}/bin/
-COPY index.js index-browser.js engine-default.js package.json ${dir}
-
-# Install the node module
-RUN cd ${dir} && npm install --only=production
-
 # Run base binary (generated from package.json!bin)
 WORKDIR ${dir}
-ENTRYPOINT ["node", "./bin/query.js"]
+
+RUN npm install -g @comunica/actor-init-sparql
+
+ENTRYPOINT ["comunica-sparql"]
 
 # Default command
 CMD ["--help"]


### PR DESCRIPTION
Fixed the Dockerfile to implement new installation process `npm install -g @comunica/actor-init-sparql` . Now working properly

Build:
```shell
docker build -t comunica-sparql .
```

Run:
```shell
docker run -it comunica-sparql http://fragments.dbpedia.org/2015-10/en "CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100"
```