### PR TITLE
Check HTTP stream type when identifying source

### DIFF
--- a/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
+++ b/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
@@ -1,4 +1,3 @@
-import {DataSourceUtils} from "@comunica/utils-datasource";
 import {IActionHttp, IActorHttpOutput} from "@comunica/bus-http";
 import {ActorQueryOperation, Bindings, IActionQueryOperation,
   IActorQueryOperationOutput, IActorQueryOperationOutputBindings} from "@comunica/bus-query-operation";
@@ -11,6 +10,7 @@ import {
 import {Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
 import {ActionContext} from "@comunica/core";
 import {IMediatorTypeHttpRequests} from "@comunica/mediatortype-httprequests";
+import {DataSourceUtils} from "@comunica/utils-datasource";
 import {BufferedIterator} from "asynciterator";
 import {SparqlEndpointFetcher} from "fetch-sparql-endpoint";
 import * as RDF from "rdf-js";

--- a/packages/actor-rdf-resolve-hypermedia-qpf/lib/ActorRdfResolveHypermediaQpf.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/lib/ActorRdfResolveHypermediaQpf.ts
@@ -1,7 +1,7 @@
 import {ISearchForms} from "@comunica/actor-rdf-metadata-extract-hydra-controls";
-import {KEY_CONTEXT_SOURCE} from "@comunica/bus-rdf-resolve-quad-pattern";
 import {ActorRdfResolveHypermedia, IActionRdfResolveHypermedia,
   IActorRdfResolveHypermediaOutput} from "@comunica/bus-rdf-resolve-hypermedia";
+import {KEY_CONTEXT_SOURCE} from "@comunica/bus-rdf-resolve-quad-pattern";
 import {ActionContext, IActorArgs, IActorTest} from "@comunica/core";
 
 /**

--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/ActorRdfResolveQuadPatternHypermedia.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/ActorRdfResolveQuadPatternHypermedia.ts
@@ -1,10 +1,10 @@
-import {DataSourceUtils} from "@comunica/utils-datasource";
 import {ISearchForm} from "@comunica/actor-rdf-metadata-extract-hydra-controls";
 import {IActionRdfDereferencePaged, IActorRdfDereferencePagedOutput} from "@comunica/bus-rdf-dereference-paged";
 import {IActionRdfResolveHypermedia, IActorRdfResolveHypermediaOutput} from "@comunica/bus-rdf-resolve-hypermedia";
 import {ActorRdfResolveQuadPatternSource, IActionRdfResolveQuadPattern,
   IActorRdfResolveQuadPatternOutput, ILazyQuadSource, KEY_CONTEXT_SOURCE} from "@comunica/bus-rdf-resolve-quad-pattern";
 import {ActionContext, Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {DataSourceUtils} from "@comunica/utils-datasource";
 import * as RDF from "rdf-js";
 import {termToString} from "rdf-string";
 import {MediatedQuadSource} from "./MediatedQuadSource";

--- a/packages/actor-rdf-source-identifier-hypermedia-qpf/lib/ActorRdfSourceIdentifierHypermediaQpf.ts
+++ b/packages/actor-rdf-source-identifier-hypermedia-qpf/lib/ActorRdfSourceIdentifierHypermediaQpf.ts
@@ -31,7 +31,9 @@ export class ActorRdfSourceIdentifierHypermediaQpf extends ActorRdfSourceIdentif
     const httpAction: IActionHttp = { context: action.context, input: action.sourceValue, init: { headers } };
     const httpResponse: IActorHttpOutput = await this.mediatorHttp.mediate(httpAction);
     if (httpResponse.ok) {
-      const body = (await require('stream-to-string')(httpResponse.body));
+      const stream = require('is-stream')(httpResponse.body)
+        ? httpResponse.body : require('node-web-streams').toNodeReadable(httpResponse.body);
+      const body = (await require('stream-to-string')(stream));
 
       // Check if body contains all required things
       let valid = true;


### PR DESCRIPTION
So the fetch problem in the browser was actually not related to the fetch library being outdated (although that could still have an impact in the command line version), but due to the fact that the stream was not converted properly when doing source type identification on QPF sources