### PR TITLE
Copy sources so the input array remains unchanged

### DIFF
--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -116,7 +116,7 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs {
 
     // Ensure sources are an async re-iterable
     if (Array.isArray(context[KEY_CONTEXT_SOURCES])) {
-      context[KEY_CONTEXT_SOURCES] = AsyncReiterableArray.fromFixedData(context[KEY_CONTEXT_SOURCES]);
+      context[KEY_CONTEXT_SOURCES] = AsyncReiterableArray.fromFixedData(context[KEY_CONTEXT_SOURCES].slice());
     }
 
     context = ActionContext(context);


### PR DESCRIPTION
This fixes #377 .

The fix is quite easy, less so the reason for the fix. :D

The problem is that the context preprocessor pushed a `null` into the sources array after parsing the sources to indicate the end of the sources array ( https://github.com/comunica/comunica/blob/master/packages/actor-context-preprocess-rdf-source-identifier/lib/ActorContextPreprocessRdfSourceIdentifier.ts#L30 ). Problem is that since this was the same array, in the next run there would be 2 nulls at the end of the array, then 3, etc. Funnily enough this is actually not a problem until you reach the 4th iteration. Reason for that can actually be found in the ArrayIterator code. 

The ArrayIterator only closes the stream when the array has been fully read, no matter what is in it ( https://github.com/RubenVerborgh/AsyncIterator/blob/master/asynciterator.js#L574 ). The emitData function on the other hand, that is responsible for sending out data to data listeners, reads an element from the iterator, and emits it to the listeners **if it is not null**. ( https://github.com/RubenVerborgh/AsyncIterator/blob/master/asynciterator.js#L373 ).

So what happens is that the emitData function doesn't get called again since there's no new 'readable' trigger. But the ArrayIterator is not finished yet since there are still null elements in the array so it never fires its end event, causing the actor to never finish the preprocessing. Not sure why this still works in the first iterations that have multiple null elements. There are multiple emitData calls causing the nulls to still be cleared there, but at 4 there are no longer enough extra calls.

The reason for all this text is because I'm not sure if this is something that might need to be fixed in AsyncIterator or not :D