### PR TITLE
Make some actors test function consistent and reflective of actual behaviour

### DIFF
--- a/packages/actor-query-operation-extend/lib/ActorQueryOperationExtend.ts
+++ b/packages/actor-query-operation-extend/lib/ActorQueryOperationExtend.ts
@@ -22,7 +22,8 @@ export class ActorQueryOperationExtend extends ActorQueryOperationTypedMediated<
 
   public async testOperation(pattern: Algebra.Extend, context: ActionContext): Promise<IActorTest> {
     // Will throw error for unsupported opperations
-    return pattern.type === "extend" && !!new AsyncEvaluator(pattern.expression);
+    const _ = !!new AsyncEvaluator(pattern.expression);
+    return true;
   }
 
   public async runOperation(pattern: Algebra.Extend, context: ActionContext)

--- a/packages/actor-query-operation-filter-sparqlee/lib/ActorQueryOperationFilterSparqlee.ts
+++ b/packages/actor-query-operation-filter-sparqlee/lib/ActorQueryOperationFilterSparqlee.ts
@@ -18,8 +18,8 @@ export class ActorQueryOperationFilterSparqlee extends ActorQueryOperationTypedM
 
   public async testOperation(pattern: Algebra.Filter, context: ActionContext): Promise<IActorTest> {
     // Will throw error for unsupported operators
-    // Coerce to boolean to check for falsy values
-    return pattern.type === 'filter' && !!new AsyncEvaluator(pattern.expression);
+    const _ = new AsyncEvaluator(pattern.expression);
+    return true;
   }
 
   public async runOperation(pattern: Algebra.Filter, context: ActionContext)

--- a/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
@@ -18,7 +18,7 @@ export class ActorQueryOperationLeftJoinNestedLoop extends ActorQueryOperationTy
   }
 
   public async testOperation(pattern: Algebra.LeftJoin, context: ActionContext): Promise<IActorTest> {
-    return !pattern.expression;
+    return true;
   }
 
   public async runOperation(pattern: Algebra.LeftJoin, context: ActionContext)


### PR DESCRIPTION
During the implementation of some actors I did, i had a wrong impression of how the testOperation function worked. These changes reflect the actual wanted behavior without misleading double checks that are already done in the abstract class.