### PR TITLE
Fix tests

### DIFF
--- a/packages/actor-query-operation-extend/test/ActorQueryOperationExtend-test.ts
+++ b/packages/actor-query-operation-extend/test/ActorQueryOperationExtend-test.ts
@@ -133,7 +133,7 @@ describe('ActorQueryOperationExtend', () => {
       ]);
 
       expect(output.type).toEqual('bindings');
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.variables).toMatchObject(['?a', '?l']);
     });
 
@@ -147,7 +147,7 @@ describe('ActorQueryOperationExtend', () => {
       expect(await arrayifyStream(output.bindingsStream)).toMatchObject(input);
       expect(warn).toHaveBeenCalledTimes(3);
       expect(output.type).toEqual('bindings');
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.variables).toMatchObject(['?a', '?l']);
     });
 

--- a/packages/actor-query-operation-filter-direct/test/ActorQueryOperationFilterDirect-test.ts
+++ b/packages/actor-query-operation-filter-direct/test/ActorQueryOperationFilterDirect-test.ts
@@ -91,7 +91,7 @@ describe('ActorQueryOperationFilterDirect', () => {
         Bindings({ '?a': literal('3') }),
       ]);
       expect(output.type).toEqual('bindings');
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.variables).toMatchObject(['a']);
     });
 
@@ -99,7 +99,7 @@ describe('ActorQueryOperationFilterDirect', () => {
       const op = { operation: { type: 'filter', input: {}, expression: falsyExpression } };
       const output: IActorQueryOperationOutputBindings = <any> await actor.run(op);
       expect(await arrayifyStream(output.bindingsStream)).toMatchObject([]);
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.type).toEqual('bindings');
       expect(output.variables).toMatchObject(['a']);
     });

--- a/packages/actor-query-operation-filter-sparqlee/test/ActorQueryOperationFilterSparqlee-test.ts
+++ b/packages/actor-query-operation-filter-sparqlee/test/ActorQueryOperationFilterSparqlee-test.ts
@@ -112,7 +112,7 @@ describe('ActorQueryOperationFilterSparqlee', () => {
         Bindings({ '?a': literal('3') }),
       ]);
       expect(output.type).toEqual('bindings');
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.variables).toMatchObject(['a']);
     });
 
@@ -120,7 +120,7 @@ describe('ActorQueryOperationFilterSparqlee', () => {
       const op = { operation: { type: 'filter', input: {}, expression: falsyExpression } };
       const output: IActorQueryOperationOutputBindings = await actor.run(op) as any;
       expect(await arrayifyStream(output.bindingsStream)).toMatchObject([]);
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 0 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.type).toEqual('bindings');
       expect(output.variables).toMatchObject(['a']);
     });
@@ -129,7 +129,7 @@ describe('ActorQueryOperationFilterSparqlee', () => {
       const op = { operation: { type: 'filter', input: {}, expression: erroringExpression } };
       const output: IActorQueryOperationOutputBindings = await actor.run(op) as any;
       expect(await arrayifyStream(output.bindingsStream)).toMatchObject([]);
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 0 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.type).toEqual('bindings');
       expect(output.variables).toMatchObject(['a']);
     });
@@ -154,7 +154,7 @@ describe('ActorQueryOperationFilterSparqlee', () => {
         Bindings({ '?a': literal('3') }),
       ]);
       expect(output.type).toEqual('bindings');
-      expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+      expect(await output.metadata()).toMatchObject({ totalItems: 3 });
       expect(output.variables).toMatchObject(['a']);
     });
 

--- a/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
@@ -78,7 +78,7 @@ export class ActorQueryOperationLeftJoinNestedLoop extends ActorQueryOperationTy
       .transform<Bindings>({ optional: true, transform });
 
     const variables = ActorRdfJoin.joinVariables({ entries: [left, right] });
-    const metadata = () => Promise.all([pattern.left, pattern.right].map((entry) => entry.metadata))
+    const metadata = () => Promise.all([left, right].map((entry) => entry.metadata()))
       .then((metadatas) => metadatas.reduce((acc, val) => acc * val.totalItems, 1))
       .catch(() => Infinity)
       .then((totalItems) => ({ totalItems }));

--- a/packages/actor-query-operation-leftjoin-nestedloop/test/ActorQueryOperationLeftJoinNestedLoop-test.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/test/ActorQueryOperationLeftJoinNestedLoop-test.ts
@@ -59,7 +59,7 @@ describe('ActorQueryOperationLeftJoinNestedLoop', () => {
         left = !left;
         return Promise.resolve({
           bindingsStream: left ? bindingStreamLeft : bindingStreamRight,
-          metadata: () => arg.operation.hasOwnProperty("rejectMetadata") && arg.operation.rejectMetadata ?
+          metadata: () => arg.operation.rejectMetadata ?
               Promise.reject(new Error('fail')) : Promise.resolve({ totalItems: 3 }),
           operated: arg,
           type: 'bindings',

--- a/packages/actor-query-operation-leftjoin-nestedloop/test/ActorQueryOperationLeftJoinNestedLoop-test.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/test/ActorQueryOperationLeftJoinNestedLoop-test.ts
@@ -111,7 +111,7 @@ describe('ActorQueryOperationLeftJoinNestedLoop', () => {
           Bindings({ '?a': literal('3'), '?b': literal('1') }),
           Bindings({ '?a': literal('3'), '?b': literal('2') }),
         ]);
-        expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+        expect(await output.metadata()).toMatchObject({ totalItems: 9 });
         expect(output.type).toEqual('bindings');
         expect(output.variables).toMatchObject(['?a', '?b']);
       });
@@ -127,7 +127,7 @@ describe('ActorQueryOperationLeftJoinNestedLoop', () => {
           Bindings({ '?a': literal('3'), '?b': literal('1') }),
           Bindings({ '?a': literal('3'), '?b': literal('2') }),
         ]);
-        expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+        expect(await output.metadata()).toMatchObject({ totalItems: 9 });
         expect(output.type).toEqual('bindings');
         expect(output.variables).toMatchObject(['?a', '?b']);
       });
@@ -142,7 +142,7 @@ describe('ActorQueryOperationLeftJoinNestedLoop', () => {
           Bindings({ '?a': literal('2') }),
           Bindings({ '?a': literal('3') }),
         ]);
-        expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+        expect(await output.metadata()).toMatchObject({ totalItems: 9 });
         expect(output.type).toEqual('bindings');
         expect(output.variables).toMatchObject(['?a', '?b']);
       });
@@ -157,7 +157,7 @@ describe('ActorQueryOperationLeftJoinNestedLoop', () => {
           Bindings({ '?a': literal('2') }),
           Bindings({ '?a': literal('3') }),
         ]);
-        expect(output.metadata()).toMatchObject(Promise.resolve({ totalItems: 3 }));
+        expect(await output.metadata()).toMatchObject({ totalItems: 9 });
         expect(output.type).toEqual('bindings');
         expect(output.variables).toMatchObject(['?a', '?b']);
       });

--- a/packages/actor-query-operation-leftjoin-nestedloop/test/ActorQueryOperationLeftJoinNestedLoop-test.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/test/ActorQueryOperationLeftJoinNestedLoop-test.ts
@@ -125,14 +125,14 @@ describe('ActorQueryOperationLeftJoinNestedLoop', () => {
       });
     });
 
-    it('should correctly handle rejecting promise in right', () => {
+    it('should correctly handle rejecting promise in left', () => {
       const op = { operation: { type: 'leftjoin', left: { rejectMetadata: true }, right: {} } };
       return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
         expect(await output.metadata()).toMatchObject({ totalItems: Infinity });
       });
     });
 
-    it('should correctly handle rejecting promise in left', () => {
+    it('should correctly handle rejecting promise in right', () => {
       const op = { operation: { type: 'leftjoin', left: {}, right: { rejectMetadata: true } } };
       return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
         expect(await output.metadata()).toMatchObject({ totalItems: Infinity });

--- a/packages/actor-query-operation-quadpattern/test/ActorQueryOperationQuadpattern-test.ts
+++ b/packages/actor-query-operation-quadpattern/test/ActorQueryOperationQuadpattern-test.ts
@@ -51,13 +51,11 @@ describe('ActorQueryOperationQuadpattern', () => {
     let actor: ActorQueryOperationQuadpattern;
     let mediator;
     let metadata;
-    let metadataRaw;
     let metadataContent;
 
     beforeEach(() => {
       metadataContent = { totalitems: 3};
-      metadataRaw = Promise.resolve(metadataContent);
-      metadata = () => metadataRaw;
+      metadata = () => Promise.resolve(metadataContent);
       mediator = {
         mediate: () => Promise.resolve({ data: new ArrayIterator([
           quad('s1', 'p1', 'o1', 'g1'),

--- a/packages/actor-query-operation-quadpattern/test/ActorQueryOperationQuadpattern-test.ts
+++ b/packages/actor-query-operation-quadpattern/test/ActorQueryOperationQuadpattern-test.ts
@@ -52,9 +52,11 @@ describe('ActorQueryOperationQuadpattern', () => {
     let mediator;
     let metadata;
     let metadataRaw;
+    let metadataContent;
 
     beforeEach(() => {
-      metadataRaw = Promise.resolve({ totalItems: 3 });
+      metadataContent = { totalitems: 3};
+      metadataRaw = Promise.resolve(metadataContent);
       metadata = () => metadataRaw;
       mediator = {
         mediate: () => Promise.resolve({ data: new ArrayIterator([
@@ -124,7 +126,7 @@ describe('ActorQueryOperationQuadpattern', () => {
       };
       return actor.run({ operation }).then(async (output: IActorQueryOperationOutputBindings) => {
         expect(output.variables).toEqual([ '?p' ]);
-        expect(output.metadata()).toBe(metadataRaw);
+        expect(await output.metadata()).toBe(metadataContent);
         expect(await arrayifyStream(output.bindingsStream)).toEqual(
           [ Bindings({ '?p': <RDF.Term> { value: 'p1' } }),
             Bindings({ '?p': <RDF.Term> { value: 'p2' } }),
@@ -144,7 +146,7 @@ describe('ActorQueryOperationQuadpattern', () => {
       const context = ActionContext({});
       return actor.run({ operation, context }).then(async (output: IActorQueryOperationOutputBindings) => {
         expect(output.variables).toEqual([ '?p' ]);
-        expect(output.metadata()).toBe(metadataRaw);
+        expect(await output.metadata()).toBe(metadataContent);
         expect(await arrayifyStream(output.bindingsStream)).toEqual(
           [ Bindings({ '?p': <RDF.Term> { value: 'p1' } }),
             Bindings({ '?p': <RDF.Term> { value: 'p2' } }),


### PR DESCRIPTION
closes #300 

- Change pointless tests to be useful.
- Fix a mistake in query-operation-leftjoin-nestedloop where the returned totalItems would always be Infinity.