### PR TITLE
Remove unnecessary code

### DIFF
--- a/packages/actor-init-sparql/lib/ActorInitSparql.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql.ts
@@ -85,9 +85,6 @@ Options:
     // Define query
     let query: string = null;
     if (args.q) {
-      if (typeof args.q !== 'string') {
-        throw new Error('The query option must be a string');
-      }
       query = args.q;
     } else if (args.f) {
       query = readFileSync(args.f, { encoding: 'utf8' });


### PR DESCRIPTION
Since every command line argument (and thus also `args.q`) will be a string this seems unnecessary code in `ActorInitSparql`.