### PR TITLE
Support newest Sparqlalgebra.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rdf-quad": "^1.4.0",
     "rdf-test-suite": "^1.10.6",
     "rdf-test-suite-ldf": "^1.1.3",
-    "sparqlalgebrajs": "^1.5.2",
+    "sparqlalgebrajs": "^2.0.0",
     "stream-to-string": "^1.1.0",
     "streamify-array": "^1.0.0",
     "streamify-string": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rdf-quad": "^1.4.0",
     "rdf-test-suite": "^1.10.6",
     "rdf-test-suite-ldf": "^1.1.3",
-    "sparqlalgebrajs": "^2.0.1",
+    "sparqlalgebrajs": "^2.1.0",
     "stream-to-string": "^1.1.0",
     "streamify-array": "^1.0.0",
     "streamify-string": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "rdf-quad": "^1.4.0",
     "rdf-test-suite": "^1.10.6",
     "rdf-test-suite-ldf": "^1.1.3",
-    "sparqlalgebrajs": "^2.0.0",
+    "sparqlalgebrajs": "^2.0.1",
     "stream-to-string": "^1.1.0",
     "streamify-array": "^1.0.0",
     "streamify-string": "^1.0.1",

--- a/packages/actor-abstract-path/package.json
+++ b/packages/actor-abstract-path/package.json
@@ -41,7 +41,7 @@
     "@rdfjs/data-model": "^1.1.1",
     "asynciterator": "^2.0.1",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-abstract-path/package.json
+++ b/packages/actor-abstract-path/package.json
@@ -41,7 +41,7 @@
     "@rdfjs/data-model": "^1.1.1",
     "asynciterator": "^2.0.1",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-abstract-path/package.json
+++ b/packages/actor-abstract-path/package.json
@@ -41,7 +41,7 @@
     "@rdfjs/data-model": "^1.1.1",
     "asynciterator": "^2.0.1",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-optimize-query-operation-join-bgp/package.json
+++ b/packages/actor-optimize-query-operation-join-bgp/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "peerDependencies": {
     "@comunica/bus-optimize-query-operation": "^1.0.0",

--- a/packages/actor-optimize-query-operation-join-bgp/package.json
+++ b/packages/actor-optimize-query-operation-join-bgp/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "peerDependencies": {
     "@comunica/bus-optimize-query-operation": "^1.0.0",

--- a/packages/actor-optimize-query-operation-join-bgp/package.json
+++ b/packages/actor-optimize-query-operation-join-bgp/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "peerDependencies": {
     "@comunica/bus-optimize-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-extend/package.json
+++ b/packages/actor-query-operation-extend/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlee": "^1.2.1"
+    "sparqlee": "^1.3.0"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.4.0",

--- a/packages/actor-query-operation-filter-sparqlee/package.json
+++ b/packages/actor-query-operation-filter-sparqlee/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlee": "^1.2.1"
+    "sparqlee": "^1.3.0"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.4.0",

--- a/packages/actor-query-operation-from-quad/package.json
+++ b/packages/actor-query-operation-from-quad/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "lodash.find": "^4.6.0",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-from-quad/package.json
+++ b/packages/actor-query-operation-from-quad/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "lodash.find": "^4.6.0",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-from-quad/package.json
+++ b/packages/actor-query-operation-from-quad/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "lodash.find": "^4.6.0",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-group/package.json
+++ b/packages/actor-query-operation-group/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@comunica/actor-abstract-bindings-hash": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlee": "^1.2.1"
+    "sparqlee": "^1.3.0"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.6.0",

--- a/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
+++ b/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
@@ -447,7 +447,7 @@ describe('ActorQueryOperationGroup', () => {
       return {
         type: "expression",
         expressionType: "aggregate",
-        aggregator,
+        aggregator: <any> aggregator,
         expression: {
           type: "expression",
           expressionType: "term",

--- a/packages/actor-query-operation-leftjoin-nestedloop/package.json
+++ b/packages/actor-query-operation-leftjoin-nestedloop/package.json
@@ -36,7 +36,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlee": "^1.2.1"
+    "sparqlee": "^1.3.0"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-orderby-sparqlee/package.json
+++ b/packages/actor-query-operation-orderby-sparqlee/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "rdf-string": "^1.3.1",
-    "sparqlee": "^1.2.1"
+    "sparqlee": "^1.3.0"
   },
   "devDependencies": {
     "@comunica/actor-query-operation-filter-direct": "^1.9.2",

--- a/packages/actor-query-operation-path-alt/package.json
+++ b/packages/actor-query-operation-path-alt/package.json
@@ -42,7 +42,7 @@
     "@comunica/actor-abstract-path": "^1.9.2",
     "asynciterator-union": "^2.1.1",
     "lodash.uniq": "^4.5.0",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-alt/package.json
+++ b/packages/actor-query-operation-path-alt/package.json
@@ -42,7 +42,7 @@
     "@comunica/actor-abstract-path": "^1.9.2",
     "asynciterator-union": "^2.1.1",
     "lodash.uniq": "^4.5.0",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-alt/package.json
+++ b/packages/actor-query-operation-path-alt/package.json
@@ -42,7 +42,7 @@
     "@comunica/actor-abstract-path": "^1.9.2",
     "asynciterator-union": "^2.1.1",
     "lodash.uniq": "^4.5.0",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-inv/package.json
+++ b/packages/actor-query-operation-path-inv/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",
     "@comunica/core": "^1.9.2",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "jest": {
     "globals": {

--- a/packages/actor-query-operation-path-inv/package.json
+++ b/packages/actor-query-operation-path-inv/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",
     "@comunica/core": "^1.9.2",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "jest": {
     "globals": {

--- a/packages/actor-query-operation-path-inv/package.json
+++ b/packages/actor-query-operation-path-inv/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",
     "@comunica/core": "^1.9.2",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "jest": {
     "globals": {

--- a/packages/actor-query-operation-path-link/package.json
+++ b/packages/actor-query-operation-path-link/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-link/package.json
+++ b/packages/actor-query-operation-path-link/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-link/package.json
+++ b/packages/actor-query-operation-path-link/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-nps/package.json
+++ b/packages/actor-query-operation-path-nps/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-nps/package.json
+++ b/packages/actor-query-operation-path-nps/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-nps/package.json
+++ b/packages/actor-query-operation-path-nps/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-one-or-more/package.json
+++ b/packages/actor-query-operation-path-one-or-more/package.json
@@ -43,7 +43,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-one-or-more/package.json
+++ b/packages/actor-query-operation-path-one-or-more/package.json
@@ -43,7 +43,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-one-or-more/package.json
+++ b/packages/actor-query-operation-path-one-or-more/package.json
@@ -43,7 +43,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-seq/package.json
+++ b/packages/actor-query-operation-path-seq/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-seq/package.json
+++ b/packages/actor-query-operation-path-seq/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-seq/package.json
+++ b/packages/actor-query-operation-path-seq/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-zero-or-more/package.json
+++ b/packages/actor-query-operation-path-zero-or-more/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-zero-or-more/package.json
+++ b/packages/actor-query-operation-path-zero-or-more/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-path-zero-or-more/package.json
+++ b/packages/actor-query-operation-path-zero-or-more/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.2",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "devDependencies": {
     "@comunica/bus-query-operation": "^1.9.2",

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -41,7 +41,7 @@
     "fetch-sparql-endpoint": "^1.4.0",
     "rdf-string": "^1.3.1",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "peerDependencies": {
     "@comunica/bus-http": "^1.2.0",

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -41,7 +41,7 @@
     "fetch-sparql-endpoint": "^1.4.0",
     "rdf-string": "^1.3.1",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "peerDependencies": {
     "@comunica/bus-http": "^1.2.0",

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -41,7 +41,7 @@
     "fetch-sparql-endpoint": "^1.4.0",
     "rdf-string": "^1.3.1",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "peerDependencies": {
     "@comunica/bus-http": "^1.2.0",

--- a/packages/actor-rdf-metadata-extract-sparql-service/lib/ActorRdfMetadataExtractSparqlService.ts
+++ b/packages/actor-rdf-metadata-extract-sparql-service/lib/ActorRdfMetadataExtractSparqlService.ts
@@ -1,4 +1,5 @@
-import {ActorRdfMetadataExtract, IActionRdfMetadataExtract, IActorRdfMetadataExtractOutput} from "@comunica/bus-rdf-metadata-extract";
+import {ActorRdfMetadataExtract,
+  IActionRdfMetadataExtract, IActorRdfMetadataExtractOutput} from "@comunica/bus-rdf-metadata-extract";
 import {IActorArgs, IActorTest} from "@comunica/core";
 
 /**

--- a/packages/actor-rdf-resolve-hypermedia-sparql/lib/RdfSourceSparql.ts
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/lib/RdfSourceSparql.ts
@@ -103,7 +103,7 @@ export class RdfSourceSparql implements RDF.Source {
           [RdfSourceSparql.FACTORY.createBoundAggregate(
             variable('var0'),
             'count',
-            RdfSourceSparql.FACTORY.createTermExpression(namedNode('*')),
+            RdfSourceSparql.FACTORY.createWildcardExpression(),
             false,
           )],
         ),

--- a/packages/actor-rdf-resolve-hypermedia-sparql/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/package.json
@@ -39,7 +39,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^2.0.1",
+    "sparqlalgebrajs": "^2.1.0",
     "sparqljson-parse": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-hypermedia-sparql/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/package.json
@@ -39,7 +39,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^1.5.2",
+    "sparqlalgebrajs": "^2.0.0",
     "sparqljson-parse": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-hypermedia-sparql/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/package.json
@@ -39,7 +39,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^2.0.0",
+    "sparqlalgebrajs": "^2.0.1",
     "sparqljson-parse": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-quad-pattern-file/lib/ActorRdfResolveQuadPatternFile.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-file/lib/ActorRdfResolveQuadPatternFile.ts
@@ -3,12 +3,12 @@ import {IActionRdfDereference, IActorRdfDereferenceOutput} from "@comunica/bus-r
 import {ActorRdfResolveQuadPatternSource, IActionRdfResolveQuadPattern, IActorRdfResolveQuadPatternOutput,
   ILazyQuadSource} from "@comunica/bus-rdf-resolve-quad-pattern";
 import {ActionContext, Actor, IActorArgs, IActorTest, Mediator} from "@comunica/core";
+import {AsyncIterator} from "asynciterator";
 import * as LRUCache from "lru-cache";
 import {N3Store, Store} from "n3";
 import * as RDF from "rdf-js";
 import {N3StoreIterator} from "./N3StoreIterator";
 import {N3StoreQuadSource} from "./N3StoreQuadSource";
-import {AsyncIterator} from "asynciterator";
 
 /**
  * A comunica File RDF Resolve Quad Pattern Actor.

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/lib/ActorRdfResolveQuadPatternSparqlJson.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/lib/ActorRdfResolveQuadPatternSparqlJson.ts
@@ -104,7 +104,7 @@ export class ActorRdfResolveQuadPatternSparqlJson
           [ActorRdfResolveQuadPatternSparqlJson.FACTORY.createBoundAggregate(
             variable('var0'),
             'count',
-            ActorRdfResolveQuadPatternSparqlJson.FACTORY.createTermExpression(namedNode('*')),
+            ActorRdfResolveQuadPatternSparqlJson.FACTORY.createWildcardExpression(),
             false,
           )],
         ),

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
@@ -39,7 +39,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^2.0.1",
+    "sparqlalgebrajs": "^2.1.0",
     "sparqljson-parse": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
@@ -39,7 +39,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^1.5.2",
+    "sparqlalgebrajs": "^2.0.0",
     "sparqljson-parse": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
@@ -39,7 +39,7 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.0.0",
     "rdf-terms": "^1.4.0",
-    "sparqlalgebrajs": "^2.0.0",
+    "sparqlalgebrajs": "^2.0.1",
     "sparqljson-parse": "^1.5.0"
   },
   "peerDependencies": {

--- a/packages/actor-sparql-parse-algebra/lib/ActorSparqlParseAlgebra.ts
+++ b/packages/actor-sparql-parse-algebra/lib/ActorSparqlParseAlgebra.ts
@@ -10,7 +10,7 @@ export class ActorSparqlParseAlgebra extends ActorSparqlParse {
 
   public readonly prefixes: {[id: string]: string};
 
-  constructor(args: IActorArgs<IActionSparqlParse, IActorTest, IActorSparqlParseOutput>) {
+  constructor(args: IActorSparqlParseAlgebraArgs) {
     super(args);
     this.prefixes = Object.freeze(this.prefixes);
   }
@@ -23,7 +23,8 @@ export class ActorSparqlParseAlgebra extends ActorSparqlParse {
   }
 
   public async run(action: IActionSparqlParse): Promise<IActorSparqlParseOutput> {
-    const parser = new SparqlParser(this.prefixes, action.baseIRI);
+    // TODO: will have to remove <any> once sparql.js types are updated
+    const parser = new SparqlParser(<any> { prefixes: this.prefixes, baseIRI: action.baseIRI });
     // resets the identifier counter used for blank nodes
     // provides nicer and more consistent output if there are multiple calls
     (<any> parser)._resetBlanks();
@@ -36,4 +37,12 @@ export class ActorSparqlParseAlgebra extends ActorSparqlParse {
     };
   }
 
+}
+
+export interface IActorSparqlParseAlgebraArgs
+  extends IActorArgs<IActionSparqlParse, IActorTest, IActorSparqlParseOutput> {
+  /**
+   * Default prefixes to use
+   */
+  prefixes?: { [id: string]: string };
 }

--- a/packages/actor-sparql-parse-algebra/package.json
+++ b/packages/actor-sparql-parse-algebra/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@types/sparqljs": "^2.1.0",
     "rdf-string": "^1.3.1",
-    "sparqlalgebrajs": "^2.0.1",
+    "sparqlalgebrajs": "^2.1.0",
     "sparqljs": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/actor-sparql-parse-algebra/package.json
+++ b/packages/actor-sparql-parse-algebra/package.json
@@ -36,7 +36,8 @@
   ],
   "dependencies": {
     "@types/sparqljs": "^2.1.0",
-    "sparqlalgebrajs": "^2.0.0",
+    "rdf-string": "^1.3.1",
+    "sparqlalgebrajs": "^2.0.1",
     "sparqljs": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/actor-sparql-parse-algebra/package.json
+++ b/packages/actor-sparql-parse-algebra/package.json
@@ -36,8 +36,8 @@
   ],
   "dependencies": {
     "@types/sparqljs": "^2.1.0",
-    "sparqlalgebrajs": "^1.5.2",
-    "sparqljs": "^2.2.3"
+    "sparqlalgebrajs": "^2.0.0",
+    "sparqljs": "^3.0.0"
   },
   "peerDependencies": {
     "@comunica/bus-sparql-parse": "^1.0.0",

--- a/packages/actor-sparql-parse-algebra/test/ActorSparqlParseAlgebra-test.ts
+++ b/packages/actor-sparql-parse-algebra/test/ActorSparqlParseAlgebra-test.ts
@@ -43,8 +43,11 @@ describe('ActorSparqlParseAlgebra', () => {
       return expect(actor.test({ query: 'a', queryFormat: 'sparql' })).resolves.toBeTruthy();
     });
 
-    it('should run', () => {
-      return expect(actor.run({ query: "SELECT * WHERE { ?a a ?b }" })).resolves.toMatchObject(
+    it('should run', async () => {
+      const result = await actor.run({ query: "SELECT * WHERE { ?a a ?b }" });
+
+      // TODO: I am unable to find why the match only works like this
+      return expect(JSON.parse(JSON.stringify(result))).toMatchObject(
         {
           operation: {
             input: {
@@ -76,34 +79,35 @@ describe('ActorSparqlParseAlgebra', () => {
         .rejects.toThrow(new Error('Translate only works on complete query objects.'));
     });
 
-    it('should run with an overridden baseIRI', () => {
-      return expect(actor.run({ query: "BASE <http://example.org/book/> SELECT * WHERE { ?a a ?b }" }))
-        .resolves.toMatchObject(
-        {
-          baseIRI: 'http://example.org/book/',
-          operation: {
-            input: {
-              patterns: [
-                {
-                  graph: {value: ""},
-                  object: {value: "b"},
-                  predicate: {value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},
-                  subject: {value: "a"},
-                  type: "pattern",
-                },
-              ],
-              type: "bgp"},
-            type: "project",
-            variables: [
+    it('should run with an overridden baseIRI', async () => {
+      const result = await actor.run({ query: "BASE <http://example.org/book/> SELECT * WHERE { ?a a ?b }" });
+
+      // TODO: I am unable to find why the match only works like this
+      return expect(JSON.parse(JSON.stringify(result))).toMatchObject({
+        baseIRI: 'http://example.org/book/',
+        operation: {
+          input: {
+            patterns: [
               {
-                value: "a",
-              },
-              {
-                value: "b",
+                graph: {value: ""},
+                object: {value: "b"},
+                predicate: {value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"},
+                subject: {value: "a"},
+                type: "pattern",
               },
             ],
-          },
-        });
+            type: "bgp"},
+          type: "project",
+          variables: [
+            {
+              value: "a",
+            },
+            {
+              value: "b",
+            },
+          ],
+        },
+      });
     });
   });
 });

--- a/packages/bus-optimize-query-operation/package.json
+++ b/packages/bus-optimize-query-operation/package.json
@@ -34,7 +34,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlalgebrajs": "^2.0.0"
+    "sparqlalgebrajs": "^2.0.1"
   },
   "peerDependencies": {
     "@comunica/core": "^1.4.0"

--- a/packages/bus-optimize-query-operation/package.json
+++ b/packages/bus-optimize-query-operation/package.json
@@ -34,7 +34,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlalgebrajs": "^1.5.2"
+    "sparqlalgebrajs": "^2.0.0"
   },
   "peerDependencies": {
     "@comunica/core": "^1.4.0"

--- a/packages/bus-optimize-query-operation/package.json
+++ b/packages/bus-optimize-query-operation/package.json
@@ -34,7 +34,7 @@
     "index.js"
   ],
   "dependencies": {
-    "sparqlalgebrajs": "^2.0.1"
+    "sparqlalgebrajs": "^2.1.0"
   },
   "peerDependencies": {
     "@comunica/core": "^1.4.0"

--- a/packages/bus-rdf-resolve-hypermedia-links/lib/ActorRdfResolveHypermediaLinks.ts
+++ b/packages/bus-rdf-resolve-hypermedia-links/lib/ActorRdfResolveHypermediaLinks.ts
@@ -11,7 +11,8 @@ import {Actor, IAction, IActorArgs, IActorOutput, IActorTest} from "@comunica/co
  * @see IActionRdfResolveHypermediaLinks
  * @see IActorRdfResolveHypermediaLinksOutput
  */
-export abstract class ActorRdfResolveHypermediaLinks extends Actor<IActionRdfResolveHypermediaLinks, IActorTest, IActorRdfResolveHypermediaLinksOutput> {
+export abstract class ActorRdfResolveHypermediaLinks
+  extends Actor<IActionRdfResolveHypermediaLinks, IActorTest, IActorRdfResolveHypermediaLinksOutput> {
 
   constructor(args: IActorArgs<IActionRdfResolveHypermediaLinks, IActorTest, IActorRdfResolveHypermediaLinksOutput>) {
     super(args);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8351,7 +8351,7 @@ source-map@~0.1.38:
   dependencies:
     amdefine ">=0.0.4"
 
-sparqlalgebrajs@^1.1.0, sparqlalgebrajs@^1.5.1, sparqlalgebrajs@^1.5.2:
+sparqlalgebrajs@^1.5.1, sparqlalgebrajs@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-1.5.2.tgz#3b136382cf418706adf5340d20fe4a4da5459103"
   integrity sha512-PaUnQI0iw+QBnAxWHWRW+VIjV50TbK3XaCwEv6jzgyaIBSo9fnE0OIhBN7Jn1KTZfMNHUTMUo7q/3Ok3ml29Lw==
@@ -8362,10 +8362,10 @@ sparqlalgebrajs@^1.1.0, sparqlalgebrajs@^1.5.1, sparqlalgebrajs@^1.5.2:
     rdf-string "^1.3.1"
     sparqljs "^2.2.1"
 
-sparqlalgebrajs@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-2.0.1.tgz#1f1c7f42c11784226ebb6dc3cafe98415b82f71f"
-  integrity sha512-cZe2s5pUG7T9Z6YuL17RuL+mCD8o+WvBVHj1zlrHiVKA9Z4ykiQ9NjQVNARmQ7tk7eOz02CBeEyJJMPmPl4QTw==
+sparqlalgebrajs@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-2.1.0.tgz#1e56c1308af48378ebf958f602620de8296f4041"
+  integrity sha512-7Au010F8vqLn9nCJUo5M8wnlYBftUwjFLxPt+5MEdFguDAJEfdkGoLdqJQVWZ1H+Dn7lDSqIj29sVWZWJ7jnxw==
   dependencies:
     "@rdfjs/data-model" "^1.1.1"
     fast-deep-equal "^2.0.1"
@@ -8373,10 +8373,10 @@ sparqlalgebrajs@^2.0.1:
     rdf-string "^1.3.1"
     sparqljs "^3.0.0"
 
-sparqlee@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-1.2.1.tgz#17d5cc662fe9980583b8f354fc88040f5a40d843"
-  integrity sha512-53k71TZny074twc8RHoOon4dlFvMjjqo4oScPkyN6cqrj33qea9rFNW2hCV/xv9oZApKSBaffUu4DoRre6Ytrg==
+sparqlee@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-1.3.0.tgz#d4663f9a76a5a6151dd30b3877ad767e07713479"
+  integrity sha512-zENiBZqBuWABcxbGWVtMAiEnPEVjRrPHwmzcQgR4t3KH2DYm3fqZLioi2sFC3wbschwrBA4beKbH3JxjmDa8iQ==
   dependencies:
     "@rdfjs/data-model" "^1.1.0"
     "@types/asynciterator" "^1.1.0"
@@ -8385,7 +8385,7 @@ sparqlee@^1.2.1:
     decimal.js "^10.2.0"
     immutable "^3.8.2"
     rdf-string "^1.1.1"
-    sparqlalgebrajs "^1.1.0"
+    sparqlalgebrajs "^2.1.0"
     uri-js "^4.2.2"
     uuid "^3.3.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6539,6 +6539,11 @@ n3@^1.0.0, n3@^1.1.1:
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.1.1.tgz#9201cdec6d73f1089d6ee60386f25095c8a1a4ac"
   integrity sha512-GEJXn+wc0f4l2noP1N/rMUH9Gei1DQ8IDN03eBsH+uQKkNQUOLgL7ZJVaDjY+pP3LmbLxL1LpUg/AvZ7Kc7KVw==
 
+n3@^1.0.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.2.1.tgz#8350b68527e5d0768dc0f0bb6e4531b7f4f8bb2f"
+  integrity sha512-5va8zsh02owDul7+5bj35cGOzWU7DeJHwQK3F8NDKtiYqPgWcFTg/zLxJs1JeRF2n6j5PI/eR9DCokS7nLrevA==
+
 nan@^2.10.0, nan@^2.12.1:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -8357,6 +8362,17 @@ sparqlalgebrajs@^1.1.0, sparqlalgebrajs@^1.5.1, sparqlalgebrajs@^1.5.2:
     rdf-string "^1.3.1"
     sparqljs "^2.2.1"
 
+sparqlalgebrajs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-2.0.0.tgz#23ae1c15ac21f94d236fc43b1ae0292f60795a96"
+  integrity sha512-HcRm3A1v7mSXBSV89BWlhKNynUZVb0JauL8o43zYAMMigkGK6hnwKV/PIUJuJ1zoEpkPgKrTfsYMKcZmQb6KzA==
+  dependencies:
+    "@rdfjs/data-model" "^1.1.1"
+    fast-deep-equal "^2.0.1"
+    minimist "^1.2.0"
+    rdf-string "^1.3.1"
+    sparqljs "^3.0.0"
+
 sparqlee@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-1.2.1.tgz#17d5cc662fe9980583b8f354fc88040f5a40d843"
@@ -8373,10 +8389,17 @@ sparqlee@^1.2.1:
     uri-js "^4.2.2"
     uuid "^3.3.2"
 
-sparqljs@^2.0.3, sparqljs@^2.2.1, sparqljs@^2.2.3:
+sparqljs@^2.0.3, sparqljs@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-2.2.3.tgz#6eb7f5f69b27b99d3b646e89271c048bd61d9293"
   integrity sha512-lrzSQadbkiQk4O6RjXJjec/EevVIsnAfbNK3t8XJtocogNojfQM7KC/UttyRTAq4IOXa0vRVoFTRapcbgFVRWg==
+
+sparqljs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.0.0.tgz#bc1f8ba39084b3ed8bece27ef60e860fa989c451"
+  integrity sha512-uPlGML5IWfex1Up2YSA2LnvEJjyL87KCNXQ2vDnDbgraWKivy/pHxarlJA+6NUWFllNgN+1LmWFzanTRg8mhZg==
+  dependencies:
+    n3 "^1.0.4"
 
 sparqljson-parse@^1.5.0:
   version "1.5.0"
@@ -8539,7 +8562,7 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
-stream-to-string@^1.1.0:
+stream-to-string@^1.1.0, stream-to-string@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/stream-to-string/-/stream-to-string-1.2.0.tgz#3ca506a097ecbf78b0e0aee0b6fa5c4565412a15"
   integrity sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8362,10 +8362,10 @@ sparqlalgebrajs@^1.1.0, sparqlalgebrajs@^1.5.1, sparqlalgebrajs@^1.5.2:
     rdf-string "^1.3.1"
     sparqljs "^2.2.1"
 
-sparqlalgebrajs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-2.0.0.tgz#23ae1c15ac21f94d236fc43b1ae0292f60795a96"
-  integrity sha512-HcRm3A1v7mSXBSV89BWlhKNynUZVb0JauL8o43zYAMMigkGK6hnwKV/PIUJuJ1zoEpkPgKrTfsYMKcZmQb6KzA==
+sparqlalgebrajs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-2.0.1.tgz#1f1c7f42c11784226ebb6dc3cafe98415b82f71f"
+  integrity sha512-cZe2s5pUG7T9Z6YuL17RuL+mCD8o+WvBVHj1zlrHiVKA9Z4ykiQ9NjQVNARmQ7tk7eOz02CBeEyJJMPmPl4QTw==
   dependencies:
     "@rdfjs/data-model" "^1.1.1"
     fast-deep-equal "^2.0.1"


### PR DESCRIPTION
This should make Comunica support the new sparqlalgebra.js/sparql.js. There were two tests that were being annoying where I didn't find a better solution. Feel free to improve.