### PR TITLE
Clarify dereferencing error message

### DIFF
--- a/packages/actor-rdf-dereference-http-parse/lib/ActorRdfDereferenceHttpParseBase.ts
+++ b/packages/actor-rdf-dereference-http-parse/lib/ActorRdfDereferenceHttpParseBase.ts
@@ -32,8 +32,8 @@ export abstract class ActorRdfDereferenceHttpParseBase extends ActorRdfDereferen
   }
 
   public async test(action: IActionRdfDereference): Promise<IActorTest> {
-    if (!action.url.startsWith("http:") && !action.url.startsWith("https:")) {
-      throw new Error('This actor can only handle URLs that start with \'http\' or \'https\'.');
+    if (!/^https?:/.test(action.url)) {
+      throw new Error(`Cannot retrieve ${action.url} because it is not an HTTP(S) URL.`);
     }
     return true;
   }


### PR DESCRIPTION
On several occasions, @james-martin-jd hit URLs that did not dereference, but it was hard to figure out what they were.