### PR TITLE
Add missing jsonld dependency to actor-rdf-serialize-jsonld

### DIFF
--- a/packages/actor-rdf-serialize-jsonld/lib/ActorRdfSerializeJsonLd.ts
+++ b/packages/actor-rdf-serialize-jsonld/lib/ActorRdfSerializeJsonLd.ts
@@ -17,11 +17,8 @@ export class ActorRdfSerializeJsonLd extends ActorRdfSerializeFixedMediaTypes {
    */
   public readonly jsonStringifyIndentSpaces: number;
 
-  private readonly jsonLd: any;
-
   constructor(args: IActorRdfSerializeJsonLdArgs) {
     super(args);
-    this.jsonLd = require('jsonld')();
   }
 
   public async runHandle(action: IActionRdfSerialize, mediaType: string, context: ActionContext)


### PR DESCRIPTION
It is `require`d in [ActorRdfSerializeJsonLd.ts:24](https://github.com/comunica/comunica/blob/master/packages/actor-rdf-serialize-jsonld/lib/ActorRdfSerializeJsonLd.ts#L24).