### PR TITLE
Manually load sources for federated metadata

### DIFF
--- a/packages/actor-query-operation-bgp-left-deep-smallest-sort/package.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest-sort/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "lodash.sortby": "^4.7.0",
     "lodash.uniq": "^4.5.0",
     "rdf-string": "^1.3.1",

--- a/packages/actor-query-operation-bgp-left-deep-smallest/package.json
+++ b/packages/actor-query-operation-bgp-left-deep-smallest/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "lodash.uniq": "^4.5.0",
     "rdf-string": "^1.3.1",
     "rdf-terms": "^1.4.0"

--- a/packages/actor-query-operation-describe-subject/package.json
+++ b/packages/actor-query-operation-describe-subject/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@comunica/actor-query-operation-union": "^1.9.3",
     "@rdfjs/data-model": "^1.1.1",
-    "asynciterator-union": "^2.1.1"
+    "asynciterator-union": "^2.1.2"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-minus/package.json
+++ b/packages/actor-query-operation-minus/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@comunica/actor-abstract-bindings-hash": "^1.9.3",
-    "asynciterator-promiseproxy": "^2.0.0"
+    "asynciterator-promiseproxy": "^2.1.0"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.2.0",

--- a/packages/actor-query-operation-path-alt/package.json
+++ b/packages/actor-query-operation-path-alt/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.3",
-    "asynciterator-union": "^2.1.1",
+    "asynciterator-union": "^2.1.2",
     "lodash.uniq": "^4.5.0",
     "sparqlalgebrajs": "^2.1.0"
   },

--- a/packages/actor-query-operation-path-one-or-more/package.json
+++ b/packages/actor-query-operation-path-one-or-more/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@comunica/actor-abstract-path": "^1.9.3",
     "asynciterator": "^2.0.1",
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "rdf-string": "^1.3.1",
     "sparqlalgebrajs": "^2.1.0"
   },

--- a/packages/actor-query-operation-quadpattern/package.json
+++ b/packages/actor-query-operation-quadpattern/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "rdf-string": "^1.3.1",
     "rdf-terms": "^1.4.0"
   },

--- a/packages/actor-query-operation-union/package.json
+++ b/packages/actor-query-operation-union/package.json
@@ -35,7 +35,7 @@
     "index.js"
   ],
   "dependencies": {
-    "asynciterator-union": "^2.1.1",
+    "asynciterator-union": "^2.1.2",
     "lodash.union": "^4.6.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-hypermedia-qpf/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@rdfjs/data-model": "^1.1.0",
     "asynciterator": "^2.0.1",
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "rdf-string": "^1.2.0",
     "rdf-terms": "^1.5.1"
   },

--- a/packages/actor-rdf-resolve-hypermedia-sparql/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@rdfjs/data-model": "^1.1.1",
     "asynciterator": "^2.0.1",
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "rdf-terms": "^1.4.0",
     "sparqlalgebrajs": "^2.1.0",
     "sparqljson-parse": "^1.5.0"

--- a/packages/actor-rdf-resolve-quad-pattern-federated/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "@rdfjs/data-model": "^1.1.1",
     "asynciterator": "^2.0.1",
-    "asynciterator-promiseproxy": "^2.0.0",
-    "asynciterator-union": "^2.1.1",
+    "asynciterator-promiseproxy": "^2.1.0",
+    "asynciterator-union": "^2.1.2",
     "lodash.omit": "^4.5.0"
   },
   "peerDependencies": {

--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@comunica/utils-datasource": "^1.9.2",
     "@rdfjs/data-model": "^1.1.1",
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "lru-cache": "^5.1.1",
     "rdf-string": "^1.3.1",
     "rdf-terms": "^1.5.1"

--- a/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-sparql-json/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@rdfjs/data-model": "^1.1.1",
     "asynciterator": "^2.0.1",
-    "asynciterator-promiseproxy": "^2.0.0",
+    "asynciterator-promiseproxy": "^2.1.0",
     "rdf-terms": "^1.4.0",
     "sparqlalgebrajs": "^2.1.0",
     "sparqljson-parse": "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,10 +2364,17 @@ asynciterator-promiseproxy@^2.0.0:
   dependencies:
     asynciterator "^2.0.0"
 
-asynciterator-union@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/asynciterator-union/-/asynciterator-union-2.1.1.tgz#0eb7f54af98259dfeb521695c17abfbb8190e9f2"
-  integrity sha512-GdBwEaTebKLHlHv6MgseEzmKmfpARlw53YV7tijxEkgsB7azlUpZoXg8FDRfCb1FkoHA2cN77mPPro26lKABCA==
+asynciterator-promiseproxy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/asynciterator-promiseproxy/-/asynciterator-promiseproxy-2.1.0.tgz#5a8f7378e7a0ba118577e35f0beb51f20e76615e"
+  integrity sha512-SIUlNe40pmPWDJ7N5yHK3ej694r90j0cblWAsh+8OBJLwlzGVdaehmAao2rgzjnzf1U3BhmEP9Fs4ddvDNoBTg==
+  dependencies:
+    asynciterator "^2.0.0"
+
+asynciterator-union@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/asynciterator-union/-/asynciterator-union-2.1.2.tgz#340da0c7b151325278abe94bb26217a10e244079"
+  integrity sha512-zCtGuL1LX5NTvsmk7YXL9OQ9RB/AcuhGGJMubs3n1pv9yDwK85jZHuUMkqGseO3sxjDs4/TEDqSqOXbMluaE9w==
   dependencies:
     asynciterator "^2.0.0"
 


### PR DESCRIPTION
As discussed in #553, this ensures that there are no possible timing issues when acquiring the metadata in a federated situation.