### PR TITLE
Only overwrite error function for tests

### DIFF
--- a/packages/logger-pretty/test/LoggerPretty-test.ts
+++ b/packages/logger-pretty/test/LoggerPretty-test.ts
@@ -4,7 +4,7 @@ import {LoggerPretty} from "../lib/LoggerPretty";
 describe('LoggerPretty', () => {
 
   beforeEach(() => {
-    (<any> global).console = { error: jest.fn() };
+    console.error = jest.fn();
   });
 
   describe('a LoggerPretty instance on trace level', () => {


### PR DESCRIPTION
This is related to #537 . I'm not gonna say it fixes it yet because there seem to be several problems there. This should fix the "Call retries were exceeded" error such as [here](https://travis-ci.org/comunica/comunica/jobs/617728041#L333) . Fortunately this error appears consistently when using the latest version of node. Not sure why though, maybe something changed to the console object and overwriting it entirely causes issues. Fun fact: the problem is also solved by removing a certain amount of tests from that file, no idea why.