### PR TITLE
Scope blank nodes to each federated source

### DIFF
--- a/packages/actor-rdf-resolve-quad-pattern-federated/index.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/index.ts
@@ -1,3 +1,3 @@
 export * from './lib/ActorRdfResolveQuadPatternFederated';
-export * from './lib/BlankNodeSkolemizable';
+export * from './lib/BlankNodeScoped';
 export * from './lib/FederatedQuadSource';

--- a/packages/actor-rdf-resolve-quad-pattern-federated/index.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/index.ts
@@ -1,1 +1,3 @@
 export * from './lib/ActorRdfResolveQuadPatternFederated';
+export * from './lib/BlankNodeSkolemizable';
+export * from './lib/FederatedQuadSource';

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/BlankNodeScoped.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/BlankNodeScoped.ts
@@ -1,6 +1,9 @@
 import * as RDF from "rdf-js";
 
-export class BlankNodeSkolemizable implements RDF.BlankNode {
+/**
+ * A blank node that is scoped to a certain source.
+ */
+export class BlankNodeScoped implements RDF.BlankNode {
   public readonly termType: 'BlankNode' = 'BlankNode';
   public readonly value: string;
   /**

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/BlankNodeScoped.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/BlankNodeScoped.ts
@@ -19,7 +19,7 @@ export class BlankNodeScoped implements RDF.BlankNode {
   }
 
   public equals(other: RDF.Term | null | undefined): boolean {
-    return other && other.termType === 'BlankNode' && other.value === this.value;
+    return !!other && other.termType === 'BlankNode' && other.value === this.value;
   }
 
 }

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/BlankNodeSkolemizable.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/BlankNodeSkolemizable.ts
@@ -1,0 +1,22 @@
+import * as RDF from "rdf-js";
+
+export class BlankNodeSkolemizable implements RDF.BlankNode {
+  public readonly termType: 'BlankNode' = 'BlankNode';
+  public readonly value: string;
+  /**
+   * This value can be obtained by consumers in query results,
+   * so that this can be passed into another query as an IRI,
+   * in order to obtain more results relating to this (blank) node.
+   */
+  public readonly skolemized: RDF.NamedNode;
+
+  constructor(value: string, skolemized: RDF.NamedNode) {
+    this.value = value;
+    this.skolemized = skolemized;
+  }
+
+  public equals(other: RDF.Term | null | undefined): boolean {
+    return other && other.termType === 'BlankNode' && other.value === this.value;
+  }
+
+}

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -232,6 +232,7 @@ export class FederatedQuadSource implements ILazyQuadSource {
 
       return new PromiseProxyIterator(async () => {
         // Deskolemize terms, so we send the original blank nodes to each source.
+        // Note that some sources may not match bnodes by label. SPARQL endpoints for example consider them variables.
         const s = FederatedQuadSource.deskolemizeTerm(FederatedQuadSource.nullToVariable(subject, 's'), sourceId);
         const p = FederatedQuadSource.deskolemizeTerm(FederatedQuadSource.nullToVariable(predicate, 'p'), sourceId);
         const o = FederatedQuadSource.deskolemizeTerm(FederatedQuadSource.nullToVariable(object, 'o'), sourceId);

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -120,7 +120,7 @@ export class FederatedQuadSource implements ILazyQuadSource {
         const termSourceId = term.value.substr(FederatedQuadSource.SKOLEM_PREFIX.length, colonSeparator - FederatedQuadSource.SKOLEM_PREFIX.length);
         // We had a skolemized term
         if (termSourceId === sourceId) {
-          // It can from the correct source
+          // It came from the correct source
           const termLabel = term.value.substr(colonSeparator + 1, term.value.length);
           return DataFactory.blankNode(termLabel);
         } else {

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -78,20 +78,6 @@ export class FederatedQuadSource implements ILazyQuadSource {
   }
 
   /**
-   * Converts falsy terms to variables.
-   * This is the reverse operation of {@link ActorRdfResolveQuadPatternSource#variableToNull}.
-   * @param {Term} term A term or null.
-   * @param {string} label The label to use if we have a variable.
-   * @return {Term} A term.
-   */
-  public static nullToVariable(term: RDF.Term, label: string): RDF.Term {
-    if (!term) {
-      return DataFactory.variable('v' + label);
-    }
-    return term;
-  }
-
-  /**
    * If the given term is a blank node, return a deterministic named node for it
    * based on the source id and the blank node value.
    * @param term Any RDF term.
@@ -231,12 +217,13 @@ export class FederatedQuadSource implements ILazyQuadSource {
       sourcesCount++;
 
       return new PromiseProxyIterator(async () => {
+        // Convert falsy terms to variables, reverse operation of {@link ActorRdfResolveQuadPatternSource#variableToNull}.
         // Deskolemize terms, so we send the original blank nodes to each source.
         // Note that some sources may not match bnodes by label. SPARQL endpoints for example consider them variables.
-        const s = FederatedQuadSource.deskolemizeTerm(FederatedQuadSource.nullToVariable(subject, 's'), sourceId);
-        const p = FederatedQuadSource.deskolemizeTerm(FederatedQuadSource.nullToVariable(predicate, 'p'), sourceId);
-        const o = FederatedQuadSource.deskolemizeTerm(FederatedQuadSource.nullToVariable(object, 'o'), sourceId);
-        const g = FederatedQuadSource.deskolemizeTerm(FederatedQuadSource.nullToVariable(graph, 'g'), sourceId);
+        const s = !subject   ? DataFactory.variable('vs') : FederatedQuadSource.deskolemizeTerm(subject,   sourceId);
+        const p = !predicate ? DataFactory.variable('vp') : FederatedQuadSource.deskolemizeTerm(predicate, sourceId);
+        const o = !object    ? DataFactory.variable('vo') : FederatedQuadSource.deskolemizeTerm(object,    sourceId);
+        const g = !graph     ? DataFactory.variable('vg') : FederatedQuadSource.deskolemizeTerm(graph,     sourceId);
         let pattern: Algebra.Pattern;
 
         // Prepare the context for this specific source

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -98,8 +98,8 @@ export class FederatedQuadSource implements ILazyQuadSource {
    */
   public static skolemizeTerm(term: RDF.Term, sourceId: number): RDF.Term | BlankNodeScoped {
     if (term.termType === 'BlankNode') {
-      const skolemized = `urn:comunica_skolem:source_${sourceId}:${term.value}`;
-      return new BlankNodeScoped(skolemized, DataFactory.namedNode(skolemized));
+      return new BlankNodeScoped(`bc_${sourceId}_${term.value}`,
+        DataFactory.namedNode(`urn:comunica_skolem:source_${sourceId}:${term.value}`));
     }
     return term;
   }
@@ -123,7 +123,10 @@ export class FederatedQuadSource implements ILazyQuadSource {
    * @param sourceId A numerical source identifier.
    */
   public static deskolemizeTerm(term: RDF.Term, sourceId: number): RDF.Term | false {
-    if (term.termType === 'NamedNode' || term.termType === 'BlankNode') {
+    if (term.termType === 'BlankNode' && 'skolemized' in term) {
+      term = (<BlankNodeScoped> term).skolemized;
+    }
+    if (term.termType === 'NamedNode') {
       const match = /^urn:comunica_skolem:source_([0-9]+):(.+)$/.exec(term.value);
       if (match) {
         // We had a skolemized term

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -10,7 +10,7 @@ import {RoundRobinUnionIterator} from "asynciterator-union";
 import * as RDF from "rdf-js";
 import {mapTerms} from "rdf-terms";
 import {Algebra, Factory} from "sparqlalgebrajs";
-import {BlankNodeSkolemizable} from "./BlankNodeSkolemizable";
+import {BlankNodeScoped} from "./BlankNodeScoped";
 import {BaseQuad} from "rdf-js";
 import {Quad} from "rdf-js";
 
@@ -96,10 +96,10 @@ export class FederatedQuadSource implements ILazyQuadSource {
    * @param sourceId A numerical source identifier.
    * @return If the given term was a blank node, this will return a skolemized named node, otherwise the original term.
    */
-  public static skolemizeTerm(term: RDF.Term, sourceId: number): RDF.Term | BlankNodeSkolemizable {
+  public static skolemizeTerm(term: RDF.Term, sourceId: number): RDF.Term | BlankNodeScoped {
     if (term.termType === 'BlankNode') {
       const skolemized = `urn:comunica_skolem:source_${sourceId}:${term.value}`;
-      return new BlankNodeSkolemizable(skolemized, DataFactory.namedNode(skolemized));
+      return new BlankNodeScoped(skolemized, DataFactory.namedNode(skolemized));
     }
     return term;
   }

--- a/packages/actor-rdf-resolve-quad-pattern-federated/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/package.json
@@ -39,7 +39,8 @@
     "asynciterator": "^2.0.1",
     "asynciterator-promiseproxy": "^2.1.0",
     "asynciterator-union": "^2.1.2",
-    "lodash.omit": "^4.5.0"
+    "lodash.omit": "^4.5.0",
+    "rdf-terms": "^1.5.1"
   },
   "peerDependencies": {
     "@comunica/bus-rdf-resolve-quad-pattern": "^1.0.0",

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/BlankNodeScoped-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/BlankNodeScoped-test.ts
@@ -1,0 +1,26 @@
+import {blankNode, namedNode} from "@rdfjs/data-model";
+import {BlankNodeScoped} from "..";
+
+describe('BlankNodeScoped', () => {
+  describe('equals', () => {
+    it('should be false for a falsy term', () => {
+      return expect(new BlankNodeScoped('abc', namedNode('def')).equals(null))
+        .toBeFalsy();
+    });
+
+    it('should be false for a named node', () => {
+      return expect(new BlankNodeScoped('abc', namedNode('def')).equals(namedNode('abc')))
+        .toBeFalsy();
+    });
+
+    it('should be false for a blank node with another label', () => {
+      return expect(new BlankNodeScoped('abc', namedNode('def')).equals(blankNode('ABC')))
+        .toBeFalsy();
+    });
+
+    it('should be true for a blank node with the same label', () => {
+      return expect(new BlankNodeScoped('abc', namedNode('def')).equals(blankNode('abc')))
+        .toBeTruthy();
+    });
+  });
+});

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -68,29 +68,29 @@ describe('FederatedQuadSource', () => {
 
   describe('#skolemizeTerm', () => {
     it('should not change a variable', () => {
-      expect(FederatedQuadSource.skolemizeTerm(variable('abc'), 0))
+      expect(FederatedQuadSource.skolemizeTerm(variable('abc'), '0'))
         .toEqualRdfTerm(variable('abc'));
     });
 
     it('should not change a named node', () => {
-      expect(FederatedQuadSource.skolemizeTerm(namedNode('abc'), 0))
+      expect(FederatedQuadSource.skolemizeTerm(namedNode('abc'), '0'))
         .toEqualRdfTerm(namedNode('abc'));
     });
 
     it('should not change a literal', () => {
-      expect(FederatedQuadSource.skolemizeTerm(literal('abc'), 0))
+      expect(FederatedQuadSource.skolemizeTerm(literal('abc'), '0'))
         .toEqualRdfTerm(literal('abc'));
     });
 
     it('should not change a default graph', () => {
-      expect(FederatedQuadSource.skolemizeTerm(defaultGraph(), 0))
+      expect(FederatedQuadSource.skolemizeTerm(defaultGraph(), '0'))
         .toEqualRdfTerm(defaultGraph());
     });
 
     it('should change a blank node', () => {
-      expect(FederatedQuadSource.skolemizeTerm(blankNode('abc'), 0))
+      expect(FederatedQuadSource.skolemizeTerm(blankNode('abc'), '0'))
         .toEqualRdfTerm(blankNode('urn:comunica_skolem:source_0:abc'));
-      expect((<BlankNodeScoped> FederatedQuadSource.skolemizeTerm(blankNode('abc'), 0)).skolemized)
+      expect((<BlankNodeScoped> FederatedQuadSource.skolemizeTerm(blankNode('abc'), '0')).skolemized)
         .toEqualRdfTerm(namedNode('urn:comunica_skolem:source_0:abc'));
     });
   });
@@ -98,13 +98,13 @@ describe('FederatedQuadSource', () => {
   describe('#skolemizeQuad', () => {
     it('should not skolemize named nodes', () => {
       expect(FederatedQuadSource.skolemizeQuad(
-        quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')), 0))
+        quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')), '0'))
         .toEqualRdfQuad(quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')));
     });
 
     it('should not skolemize blank nodes', () => {
       expect(FederatedQuadSource.skolemizeQuad(
-        quad<RDF.BaseQuad>(blankNode('s'), blankNode('p'), blankNode('o'), blankNode('g')), 0))
+        quad<RDF.BaseQuad>(blankNode('s'), blankNode('p'), blankNode('o'), blankNode('g')), '0'))
         .toEqualRdfQuad(quad<RDF.BaseQuad>(
           blankNode('urn:comunica_skolem:source_0:s'),
           blankNode('urn:comunica_skolem:source_0:p'),
@@ -116,47 +116,47 @@ describe('FederatedQuadSource', () => {
 
   describe('#deskolemizeTerm', () => {
     it('should not change a variable', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(variable('abc'), 0))
+      expect(FederatedQuadSource.deskolemizeTerm(variable('abc'), '0'))
         .toEqual(variable('abc'));
     });
 
     it('should not change a non-skolemized named node', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(namedNode('abc'), 0))
+      expect(FederatedQuadSource.deskolemizeTerm(namedNode('abc'), '0'))
         .toEqual(namedNode('abc'));
     });
 
     it('should not change a literal', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(literal('abc'), 0))
+      expect(FederatedQuadSource.deskolemizeTerm(literal('abc'), '0'))
         .toEqual(literal('abc'));
     });
 
     it('should not change a default graph', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(defaultGraph(), 0))
+      expect(FederatedQuadSource.deskolemizeTerm(defaultGraph(), '0'))
         .toEqual(defaultGraph());
     });
 
     it('should not change a plain blank node', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(blankNode('abc'), 0))
+      expect(FederatedQuadSource.deskolemizeTerm(blankNode('abc'), '0'))
         .toEqual(blankNode('abc'));
     });
 
     it('should change a skolemized blank node in the proper source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), 0))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), '0'))
         .toEqual(blankNode('abc'));
     });
 
     it('should change a skolemized named node in the proper source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(namedNode('urn:comunica_skolem:source_0:abc'), 0))
+      expect(FederatedQuadSource.deskolemizeTerm(namedNode('urn:comunica_skolem:source_0:abc'), '0'))
         .toEqual(blankNode('abc'));
     });
 
     it('should change a skolemized blank node in the wrong source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), 1))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), '1'))
         .toBeFalsy();
     });
 
     it('should change a skolemized named node in the wrong source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), 1))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), '1'))
         .toBeFalsy();
     });
   });

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -1,9 +1,12 @@
 import {ActionContext} from "@comunica/core";
-import {blankNode, defaultGraph, literal, namedNode, variable} from "@rdfjs/data-model";
+import {blankNode, defaultGraph, literal, namedNode, quad, variable} from "@rdfjs/data-model";
 import {ArrayIterator, EmptyIterator} from "asynciterator";
 import {RoundRobinUnionIterator} from "asynciterator-union";
 import {AsyncReiterableArray} from "asyncreiterable";
+import "jest-rdf";
+import * as RDF from "rdf-js";
 import Factory from "sparqlalgebrajs/lib/factory";
+import {BlankNodeSkolemizable} from "../lib/BlankNodeSkolemizable";
 import {FederatedQuadSource} from "../lib/FederatedQuadSource";
 const squad = require('rdf-quad');
 const arrayifyStream = require('arrayify-stream');
@@ -33,6 +36,12 @@ describe('FederatedQuadSource', () => {
             squad('s1', 'p1', 'o2'),
           ]), metadata: () => Promise.resolve({ totalItems: Infinity }) });
         }
+        if (type === 'blankNodeSource') {
+          return Promise.resolve({ data: new ArrayIterator([
+            squad('_:s1', '_:p1', '_:o1'),
+            squad('_:s2', '_:p2', '_:o2'),
+          ]), metadata: () => Promise.resolve({ totalItems: Infinity }) });
+        }
         return Promise.resolve({ data: new ArrayIterator([
           squad('s1', 'p1', 'o1'),
           squad('s1', 'p1', 'o2'),
@@ -54,6 +63,96 @@ describe('FederatedQuadSource', () => {
 
     it('should be a FederatedQuadSource constructor with optional bufferSize argument', () => {
       expect(new FederatedQuadSource(mediator, context, new Map(), true)).toBeInstanceOf(FederatedQuadSource);
+    });
+  });
+
+  describe('#skolemizeTerm', () => {
+    it('should not change a variable', () => {
+      expect(FederatedQuadSource.skolemizeTerm(variable('abc'), 0))
+        .toEqualRdfTerm(variable('abc'));
+    });
+
+    it('should not change a named node', () => {
+      expect(FederatedQuadSource.skolemizeTerm(namedNode('abc'), 0))
+        .toEqualRdfTerm(namedNode('abc'));
+    });
+
+    it('should not change a literal', () => {
+      expect(FederatedQuadSource.skolemizeTerm(literal('abc'), 0))
+        .toEqualRdfTerm(literal('abc'));
+    });
+
+    it('should not change a default graph', () => {
+      expect(FederatedQuadSource.skolemizeTerm(defaultGraph(), 0))
+        .toEqualRdfTerm(defaultGraph());
+    });
+
+    it('should change a blank node', () => {
+      expect(FederatedQuadSource.skolemizeTerm(blankNode('abc'), 0))
+        .toEqualRdfTerm(blankNode('urn:comunica_skolem:source_0:abc'));
+      expect((<BlankNodeSkolemizable> FederatedQuadSource.skolemizeTerm(blankNode('abc'), 0)).skolemized)
+        .toEqualRdfTerm(namedNode('urn:comunica_skolem:source_0:abc'));
+    });
+  });
+
+  describe('#skolemizeQuad', () => {
+    it('should not skolemize named nodes', () => {
+      expect(FederatedQuadSource.skolemizeQuad(
+        quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')), 0))
+        .toEqualRdfQuad(quad(namedNode('s'), namedNode('p'), namedNode('o'), namedNode('g')));
+    });
+
+    it('should not skolemize blank nodes', () => {
+      expect(FederatedQuadSource.skolemizeQuad(
+        quad<RDF.BaseQuad>(blankNode('s'), blankNode('p'), blankNode('o'), blankNode('g')), 0))
+        .toEqualRdfQuad(quad<RDF.BaseQuad>(
+          blankNode('urn:comunica_skolem:source_0:s'),
+          blankNode('urn:comunica_skolem:source_0:p'),
+          blankNode('urn:comunica_skolem:source_0:o'),
+          blankNode('urn:comunica_skolem:source_0:g'),
+          ));
+    });
+  });
+
+  describe('#deskolemizeTerm', () => {
+    it('should not change a variable', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(variable('abc'), 0))
+        .toEqualRdfTerm(variable('abc'));
+    });
+
+    it('should not change a non-skolemized named node', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(namedNode('abc'), 0))
+        .toEqualRdfTerm(namedNode('abc'));
+    });
+
+    it('should not change a literal', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(literal('abc'), 0))
+        .toEqualRdfTerm(literal('abc'));
+    });
+
+    it('should not change a default graph', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(defaultGraph(), 0))
+        .toEqualRdfTerm(defaultGraph());
+    });
+
+    it('should change a skolemized blank node in the proper source', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(blankNode('urn:comunica_skolem:source_0:abc'), 0))
+        .toEqualRdfTerm(blankNode('abc'));
+    });
+
+    it('should change a skolemized named node in the proper source', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(namedNode('urn:comunica_skolem:source_0:abc'), 0))
+        .toEqualRdfTerm(blankNode('abc'));
+    });
+
+    it('should change a skolemized blank node in the wrong source', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(blankNode('urn:comunica_skolem:source_0:abc'), 1))
+        .toBeFalsy();
+    });
+
+    it('should change a skolemized named node in the wrong source', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(namedNode('urn:comunica_skolem:source_0:abc'), 1))
+        .toBeFalsy();
     });
   });
 
@@ -788,6 +887,238 @@ describe('FederatedQuadSource', () => {
         stream.on('metadata', resolve);
         stream.on('end', reject);
       })).resolves.toEqual({ totalItems: Infinity });
+    });
+  });
+
+  describe('A FederatedQuadSource instance over two non-empty sources with blank nodes', () => {
+    let subSource1;
+    let subSource2;
+    let source: FederatedQuadSource;
+    let emptyPatterns;
+    let contextSingleEmpty;
+
+    beforeEach(() => {
+      subSource1 = { type: 'blankNodeSource', value: 'I will contain blank nodes' };
+      subSource2 = { type: 'blankNodeSource', value: 'I will also contain blank nodes' };
+      emptyPatterns = new Map();
+      contextSingleEmpty = ActionContext({ '@comunica/bus-rdf-resolve-quad-pattern:sources':
+          AsyncReiterableArray.fromFixedData([
+            subSource1,
+            subSource2,
+          ]) });
+      source = new FederatedQuadSource(mediator, contextSingleEmpty, emptyPatterns, true);
+    });
+
+    it('should return a non-empty AsyncIterator', async () => {
+      const a = await arrayifyStream(source.match());
+      return expect(a).toEqual([
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+            namedNode('urn:comunica_skolem:source_0:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+            namedNode('urn:comunica_skolem:source_0:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+            namedNode('urn:comunica_skolem:source_0:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+            namedNode('urn:comunica_skolem:source_1:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+            namedNode('urn:comunica_skolem:source_1:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+            namedNode('urn:comunica_skolem:source_1:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+            namedNode('urn:comunica_skolem:source_0:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+            namedNode('urn:comunica_skolem:source_0:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+            namedNode('urn:comunica_skolem:source_0:o2')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+            namedNode('urn:comunica_skolem:source_1:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+            namedNode('urn:comunica_skolem:source_1:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+            namedNode('urn:comunica_skolem:source_1:o2')),
+        ),
+      ]);
+    });
+
+    it('should match will all sources for named nodes', async () => {
+      const a = await arrayifyStream(source.match(namedNode('abc')));
+      return expect(a).toEqual([
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+            namedNode('urn:comunica_skolem:source_0:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+            namedNode('urn:comunica_skolem:source_0:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+            namedNode('urn:comunica_skolem:source_0:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+            namedNode('urn:comunica_skolem:source_1:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+            namedNode('urn:comunica_skolem:source_1:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+            namedNode('urn:comunica_skolem:source_1:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+            namedNode('urn:comunica_skolem:source_0:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+            namedNode('urn:comunica_skolem:source_0:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+            namedNode('urn:comunica_skolem:source_0:o2')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+            namedNode('urn:comunica_skolem:source_1:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+            namedNode('urn:comunica_skolem:source_1:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+            namedNode('urn:comunica_skolem:source_1:o2')),
+        ),
+      ]);
+    });
+
+    it('should match will all sources for plain blank nodes', async () => {
+      const a = await arrayifyStream(source.match(blankNode('abc')));
+      return expect(a).toEqual([
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+            namedNode('urn:comunica_skolem:source_0:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+            namedNode('urn:comunica_skolem:source_0:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+            namedNode('urn:comunica_skolem:source_0:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+            namedNode('urn:comunica_skolem:source_1:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+            namedNode('urn:comunica_skolem:source_1:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+            namedNode('urn:comunica_skolem:source_1:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+            namedNode('urn:comunica_skolem:source_0:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+            namedNode('urn:comunica_skolem:source_0:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+            namedNode('urn:comunica_skolem:source_0:o2')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+            namedNode('urn:comunica_skolem:source_1:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+            namedNode('urn:comunica_skolem:source_1:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+            namedNode('urn:comunica_skolem:source_1:o2')),
+        ),
+      ]);
+    });
+
+    it('should match the first source for blank nodes coming from the first source', async () => {
+      const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_0:s1')));
+      return expect(a).toEqual([
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+            namedNode('urn:comunica_skolem:source_0:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+            namedNode('urn:comunica_skolem:source_0:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+            namedNode('urn:comunica_skolem:source_0:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+            namedNode('urn:comunica_skolem:source_0:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+            namedNode('urn:comunica_skolem:source_0:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+            namedNode('urn:comunica_skolem:source_0:o2')),
+        ),
+      ]);
+    });
+
+    it('should match the second source for blank nodes coming from the second source', async () => {
+      const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_1:s1')));
+      return expect(a).toEqual([
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+            namedNode('urn:comunica_skolem:source_1:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+            namedNode('urn:comunica_skolem:source_1:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+            namedNode('urn:comunica_skolem:source_1:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+            namedNode('urn:comunica_skolem:source_1:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+            namedNode('urn:comunica_skolem:source_1:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+            namedNode('urn:comunica_skolem:source_1:o2')),
+        ),
+      ]);
+    });
+
+    it('should match no source for blank nodes coming from an unknown source', async () => {
+      const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_2:s1')));
+      return expect(a).toEqual([]);
+    });
+
+    it('should match the first source for named nodes coming from the first source', async () => {
+      const a = await arrayifyStream(source.match(namedNode('urn:comunica_skolem:source_0:s1')));
+      return expect(a).toEqual([
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+            namedNode('urn:comunica_skolem:source_0:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+            namedNode('urn:comunica_skolem:source_0:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+            namedNode('urn:comunica_skolem:source_0:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+            namedNode('urn:comunica_skolem:source_0:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+            namedNode('urn:comunica_skolem:source_0:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+            namedNode('urn:comunica_skolem:source_0:o2')),
+        ),
+      ]);
+    });
+
+    it('should match the second source for named nodes coming from the second source', async () => {
+      const a = await arrayifyStream(source.match(namedNode('urn:comunica_skolem:source_1:s1')));
+      return expect(a).toEqual([
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+            namedNode('urn:comunica_skolem:source_1:s1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+            namedNode('urn:comunica_skolem:source_1:p1')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+            namedNode('urn:comunica_skolem:source_1:o1')),
+        ),
+        quad<RDF.BaseQuad>(
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+            namedNode('urn:comunica_skolem:source_1:s2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+            namedNode('urn:comunica_skolem:source_1:p2')),
+          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+            namedNode('urn:comunica_skolem:source_1:o2')),
+        ),
+      ]);
+    });
+
+    it('should match no source for named nodes coming from an unknown source', async () => {
+      const a = await arrayifyStream(source.match(namedNode('urn:comunica_skolem:source_2:s1')));
+      return expect(a).toEqual([]);
     });
   });
 

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -117,41 +117,46 @@ describe('FederatedQuadSource', () => {
   describe('#deskolemizeTerm', () => {
     it('should not change a variable', () => {
       expect(FederatedQuadSource.deskolemizeTerm(variable('abc'), 0))
-        .toEqualRdfTerm(variable('abc'));
+        .toEqual(variable('abc'));
     });
 
     it('should not change a non-skolemized named node', () => {
       expect(FederatedQuadSource.deskolemizeTerm(namedNode('abc'), 0))
-        .toEqualRdfTerm(namedNode('abc'));
+        .toEqual(namedNode('abc'));
     });
 
     it('should not change a literal', () => {
       expect(FederatedQuadSource.deskolemizeTerm(literal('abc'), 0))
-        .toEqualRdfTerm(literal('abc'));
+        .toEqual(literal('abc'));
     });
 
     it('should not change a default graph', () => {
       expect(FederatedQuadSource.deskolemizeTerm(defaultGraph(), 0))
-        .toEqualRdfTerm(defaultGraph());
+        .toEqual(defaultGraph());
+    });
+
+    it('should not change a plain blank node', () => {
+      expect(FederatedQuadSource.deskolemizeTerm(blankNode('abc'), 0))
+        .toEqual(blankNode('abc'));
     });
 
     it('should change a skolemized blank node in the proper source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(blankNode('urn:comunica_skolem:source_0:abc'), 0))
-        .toEqualRdfTerm(blankNode('abc'));
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), 0))
+        .toEqual(blankNode('abc'));
     });
 
     it('should change a skolemized named node in the proper source', () => {
       expect(FederatedQuadSource.deskolemizeTerm(namedNode('urn:comunica_skolem:source_0:abc'), 0))
-        .toEqualRdfTerm(blankNode('abc'));
+        .toEqual(blankNode('abc'));
     });
 
     it('should change a skolemized blank node in the wrong source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(blankNode('urn:comunica_skolem:source_0:abc'), 1))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), 1))
         .toBeFalsy();
     });
 
     it('should change a skolemized named node in the wrong source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(namedNode('urn:comunica_skolem:source_0:abc'), 1))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), 1))
         .toBeFalsy();
     });
   });
@@ -913,35 +918,35 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match());
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('bc_0_s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('bc_0_p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('bc_0_o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('bc_1_s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('bc_1_p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('bc_1_o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('bc_0_s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('bc_0_p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('bc_0_o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('bc_1_s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('bc_1_p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('bc_1_o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
@@ -951,124 +956,124 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(namedNode('abc')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('bc_0_s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('bc_0_p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('bc_0_o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('bc_1_s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('bc_1_p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('bc_1_o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('bc_0_s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('bc_0_p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('bc_0_o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('bc_1_s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('bc_1_p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('bc_1_o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
     });
 
     it('should match will all sources for plain blank nodes', async () => {
-      const a = await arrayifyStream(source.match(blankNode('abc')));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('abc'))));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('bc_0_s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('bc_0_p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('bc_0_o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('bc_1_s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('bc_1_p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('bc_1_o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('bc_0_s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('bc_0_p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('bc_0_o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('bc_1_s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('bc_1_p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('bc_1_o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
     });
 
     it('should match the first source for blank nodes coming from the first source', async () => {
-      const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_0:s1')));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:s1'))));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('bc_0_s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('bc_0_p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('bc_0_o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('bc_0_s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('bc_0_p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('bc_0_o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
       ]);
     });
 
     it('should match the second source for blank nodes coming from the second source', async () => {
-      const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_1:s1')));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_1:s1'))));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('bc_1_s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('bc_1_p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('bc_1_o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('bc_1_s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('bc_1_p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('bc_1_o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
     });
 
     it('should match no source for blank nodes coming from an unknown source', async () => {
-      const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_2:s1')));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_2:s1'))));
       return expect(a).toEqual([]);
     });
 
@@ -1076,19 +1081,19 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(namedNode('urn:comunica_skolem:source_0:s1')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('bc_0_s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('bc_0_p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('bc_0_o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('bc_0_s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('bc_0_p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('bc_0_o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
       ]);
@@ -1098,19 +1103,19 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(namedNode('urn:comunica_skolem:source_1:s1')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('bc_1_s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('bc_1_p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('bc_1_o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('bc_1_s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('bc_1_p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('bc_1_o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -141,7 +141,8 @@ describe('FederatedQuadSource', () => {
     });
 
     it('should change a skolemized blank node in the proper source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), '0'))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc',
+        namedNode('urn:comunica_skolem:source_0:abc')), '0'))
         .toEqual(blankNode('abc'));
     });
 
@@ -151,12 +152,14 @@ describe('FederatedQuadSource', () => {
     });
 
     it('should change a skolemized blank node in the wrong source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), '1'))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc',
+        namedNode('urn:comunica_skolem:source_0:abc')), '1'))
         .toBeFalsy();
     });
 
     it('should change a skolemized named node in the wrong source', () => {
-      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:abc')), '1'))
+      expect(FederatedQuadSource.deskolemizeTerm(new BlankNodeScoped('abc',
+        namedNode('urn:comunica_skolem:source_0:abc')), '1'))
         .toBeFalsy();
     });
   });
@@ -991,7 +994,8 @@ describe('FederatedQuadSource', () => {
     });
 
     it('should match will all sources for plain blank nodes', async () => {
-      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('abc'))));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc',
+        namedNode('abc'))));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
           new BlankNodeScoped('bc_0_s1',
@@ -1029,7 +1033,8 @@ describe('FederatedQuadSource', () => {
     });
 
     it('should match the first source for blank nodes coming from the first source', async () => {
-      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_0:s1'))));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc',
+        namedNode('urn:comunica_skolem:source_0:s1'))));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
           new BlankNodeScoped('bc_0_s1',
@@ -1051,7 +1056,8 @@ describe('FederatedQuadSource', () => {
     });
 
     it('should match the second source for blank nodes coming from the second source', async () => {
-      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_1:s1'))));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc',
+        namedNode('urn:comunica_skolem:source_1:s1'))));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
           new BlankNodeScoped('bc_1_s1',
@@ -1073,7 +1079,8 @@ describe('FederatedQuadSource', () => {
     });
 
     it('should match no source for blank nodes coming from an unknown source', async () => {
-      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc', namedNode('urn:comunica_skolem:source_2:s1'))));
+      const a = await arrayifyStream(source.match(new BlankNodeScoped('abc',
+        namedNode('urn:comunica_skolem:source_2:s1'))));
       return expect(a).toEqual([]);
     });
 

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -6,7 +6,7 @@ import {AsyncReiterableArray} from "asyncreiterable";
 import "jest-rdf";
 import * as RDF from "rdf-js";
 import Factory from "sparqlalgebrajs/lib/factory";
-import {BlankNodeSkolemizable} from "../lib/BlankNodeSkolemizable";
+import {BlankNodeScoped} from "../lib/BlankNodeScoped";
 import {FederatedQuadSource} from "../lib/FederatedQuadSource";
 const squad = require('rdf-quad');
 const arrayifyStream = require('arrayify-stream');
@@ -90,7 +90,7 @@ describe('FederatedQuadSource', () => {
     it('should change a blank node', () => {
       expect(FederatedQuadSource.skolemizeTerm(blankNode('abc'), 0))
         .toEqualRdfTerm(blankNode('urn:comunica_skolem:source_0:abc'));
-      expect((<BlankNodeSkolemizable> FederatedQuadSource.skolemizeTerm(blankNode('abc'), 0)).skolemized)
+      expect((<BlankNodeScoped> FederatedQuadSource.skolemizeTerm(blankNode('abc'), 0)).skolemized)
         .toEqualRdfTerm(namedNode('urn:comunica_skolem:source_0:abc'));
     });
   });
@@ -913,35 +913,35 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match());
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
@@ -951,35 +951,35 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(namedNode('abc')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
@@ -989,35 +989,35 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(blankNode('abc')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
@@ -1027,19 +1027,19 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_0:s1')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
       ]);
@@ -1049,19 +1049,19 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(blankNode('urn:comunica_skolem:source_1:s1')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);
@@ -1076,19 +1076,19 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(namedNode('urn:comunica_skolem:source_0:s1')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s1',
             namedNode('urn:comunica_skolem:source_0:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p1',
             namedNode('urn:comunica_skolem:source_0:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o1',
             namedNode('urn:comunica_skolem:source_0:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:s2',
             namedNode('urn:comunica_skolem:source_0:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:p2',
             namedNode('urn:comunica_skolem:source_0:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_0:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_0:o2',
             namedNode('urn:comunica_skolem:source_0:o2')),
         ),
       ]);
@@ -1098,19 +1098,19 @@ describe('FederatedQuadSource', () => {
       const a = await arrayifyStream(source.match(namedNode('urn:comunica_skolem:source_1:s1')));
       return expect(a).toEqual([
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s1',
             namedNode('urn:comunica_skolem:source_1:s1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p1',
             namedNode('urn:comunica_skolem:source_1:p1')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o1',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o1',
             namedNode('urn:comunica_skolem:source_1:o1')),
         ),
         quad<RDF.BaseQuad>(
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:s2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:s2',
             namedNode('urn:comunica_skolem:source_1:s2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:p2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:p2',
             namedNode('urn:comunica_skolem:source_1:p2')),
-          new BlankNodeSkolemizable('urn:comunica_skolem:source_1:o2',
+          new BlankNodeScoped('urn:comunica_skolem:source_1:o2',
             namedNode('urn:comunica_skolem:source_1:o2')),
         ),
       ]);


### PR DESCRIPTION
When federating over multiple sources,
the outcoming blank nodes coming from each source
will receive a distinct blank node,
so that they can not be joined across different sources,
even if they have the same blank node label.

A reverse translation also takes place for incoming queries with blank nodes,
so that these blank nodes will only match if they come from that source.

Blank nodes coming from sources will receive a .skolemized field
containing a named node.
This named node can be queried again as an IRI, and this will
be interpreted by Comunica as a blank node corresponding to the proper
source, assuming that the array of sources remains the same.

Closes #355
Required for solid/query-ldflex#34

While the implementation is quite trivial, the impact is quite major, so this deserves a detailed review.