### PR TITLE
Performance/optional

### DIFF
--- a/packages/actor-init-sparql/config/sets/sparql-queryoperators.json
+++ b/packages/actor-init-sparql/config/sets/sparql-queryoperators.json
@@ -17,7 +17,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-from-quad/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-group/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-join/^1.0.0/components/context.jsonld",
-    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-leftjoin-nestedloop/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-leftjoin-left-deep/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-orderby-sparqlee/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-project/^1.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-quadpattern/^1.0.0/components/context.jsonld",
@@ -139,7 +139,7 @@
 
     {
       "@id": "config-sets:sparql-queryoperators.json#myLeftJoinQueryOperator",
-      "@type": "ActorQueryOperationLeftJoinNestedLoop",
+      "@type": "ActorQueryOperationLeftJoinLeftDeep",
       "cbqo:mediatorQueryOperation": { "@id": "config-sets:sparql-queryoperators.json#mediatorQueryOperation" }
     },
 

--- a/packages/actor-init-sparql/package.json
+++ b/packages/actor-init-sparql/package.json
@@ -65,6 +65,7 @@
     "@comunica/actor-query-operation-from-quad": "^1.9.3",
     "@comunica/actor-query-operation-group": "^1.9.3",
     "@comunica/actor-query-operation-join": "^1.10.0",
+    "@comunica/actor-query-operation-leftjoin-left-deep": "^1.0.0",
     "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.10.0",
     "@comunica/actor-query-operation-minus": "^1.10.0",
     "@comunica/actor-query-operation-orderby-sparqlee": "^1.9.3",

--- a/packages/actor-query-operation-leftjoin-left-deep/README.md
+++ b/packages/actor-query-operation-leftjoin-left-deep/README.md
@@ -1,0 +1,17 @@
+# Comunica LeftJoin left-deep Query Operation Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-query-operation-leftjoin-left-deep.svg)](https://www.npmjs.com/package/@comunica/actor-query-operation-leftjoin-left-deep)
+
+A comunica LeftJoin left-deep Query Operation Actor.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-query-operation-leftjoin-left-deep
+```
+
+## Usage
+
+TODO

--- a/packages/actor-query-operation-leftjoin-left-deep/components/Actor/QueryOperation/LeftJoinLeftDeep.jsonld
+++ b/packages/actor-query-operation-leftjoin-left-deep/components/Actor/QueryOperation/LeftJoinLeftDeep.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-leftjoin-left-deep/^1.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-query-operation/^1.0.0/components/context.jsonld"
+  ],
+  "@id": "npmd:@comunica/actor-query-operation-leftjoin-left-deep",
+  "components": [
+    {
+      "@id": "caqolld:Actor/QueryOperation/LeftJoinLeftDeep",
+      "@type": "Class",
+      "extends": "cbqo:Actor/QueryOperationTypedMediated",
+      "requireElement": "ActorQueryOperationLeftJoinLeftDeep",
+      "comment": "A comunica LeftJoin left-deep Query Operation Actor.",
+      "constructorArguments": [
+        {
+          "extends": "cbqo:Actor/QueryOperationTypedMediated/constructorArgumentsObject"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/actor-query-operation-leftjoin-left-deep/components/components.jsonld
+++ b/packages/actor-query-operation-leftjoin-left-deep/components/components.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-leftjoin-left-deep/^1.0.0/components/context.jsonld",
+  "@id": "npmd:@comunica/actor-query-operation-leftjoin-left-deep",
+  "@type": "Module",
+  "requireName": "@comunica/actor-query-operation-leftjoin-left-deep",
+  "import": [
+    "files-caqolld:components/Actor/QueryOperation/LeftJoinLeftDeep.jsonld"
+  ]
+}

--- a/packages/actor-query-operation-leftjoin-left-deep/components/context.jsonld
+++ b/packages/actor-query-operation-leftjoin-left-deep/components/context.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^1.0.0/components/context.jsonld",
+    {
+      "npmd": "https://linkedsoftwaredependencies.org/bundles/npm/",
+      "caqolld": "npmd:@comunica/actor-query-operation-leftjoin-left-deep/",
+      "files-caqolld": "caqolld:^1.0.0/",
+
+      "ActorQueryOperationLeftJoinLeftDeep": "caqolld:Actor/QueryOperation/LeftJoinLeftDeep"
+    }
+  ]
+}

--- a/packages/actor-query-operation-leftjoin-left-deep/index.ts
+++ b/packages/actor-query-operation-leftjoin-left-deep/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/ActorQueryOperationLeftJoinLeftDeep';

--- a/packages/actor-query-operation-leftjoin-left-deep/lib/ActorQueryOperationLeftJoinLeftDeep.ts
+++ b/packages/actor-query-operation-leftjoin-left-deep/lib/ActorQueryOperationLeftJoinLeftDeep.ts
@@ -1,0 +1,142 @@
+import {
+  ActorQueryOperation,
+  ActorQueryOperationTypedMediated,
+  Bindings,
+  BindingsStream,
+  IActorQueryOperationOutputBindings,
+  IActorQueryOperationTypedMediatedArgs,
+} from "@comunica/bus-query-operation";
+import {ActorRdfJoin} from "@comunica/bus-rdf-join";
+import {ActionContext, IActorTest} from "@comunica/core";
+import {MultiTransformIterator} from "asynciterator";
+import {Algebra, Factory, Util} from "sparqlalgebrajs";
+import {PromiseProxyIterator} from "asynciterator-promiseproxy";
+import * as RDF from "rdf-js";
+import {termToString} from "rdf-string";
+
+/**
+ * A comunica LeftJoin left-deep Query Operation Actor.
+ */
+export class ActorQueryOperationLeftJoinLeftDeep extends ActorQueryOperationTypedMediated<Algebra.LeftJoin> {
+
+  private static readonly FACTORY = new Factory();
+
+  constructor(args: IActorQueryOperationTypedMediatedArgs) {
+    super(args, 'leftjoin');
+  }
+
+  /**
+   * Create a new bindings stream
+   * that takes every binding of the base stream,
+   * materializes the remaining patterns with it,
+   * and emits all bindings from this new set of patterns.
+   * @param {BindingsStream} leftStream The base stream.
+   * @param {Algebra.Operation} rightOperation The operation to materialize with each binding of the base stream.
+   * @param {Algebra.Operation => Promise<BindingsStream>} operationBinder A callback to retrieve the bindings stream
+   *                                                                       of an operation.
+   * @return {BindingsStream}
+   */
+  public static createLeftDeepStream(leftStream: BindingsStream, rightOperation: Algebra.Operation,
+                                     operationBinder: (operation: Algebra.Operation) => Promise<BindingsStream>)
+    : BindingsStream {
+    const bindingsStream: MultiTransformIterator<Bindings, Bindings> = new MultiTransformIterator(leftStream,
+      { optional: true });
+    bindingsStream._createTransformer = (bindings: Bindings) => {
+      const bindingsMerger = (subBindings: Bindings) => subBindings.merge(bindings);
+      return new PromiseProxyIterator(
+        async () => (await operationBinder(ActorQueryOperationLeftJoinLeftDeep.materializeOperation(
+          rightOperation, bindings))).map(bindingsMerger), { autoStart: true, maxBufferSize: 128 });
+    };
+    return bindingsStream;
+  }
+
+  /**
+   * Materialize the given operation with the given bindings.
+   * @param {Operation} operation SPARQL algebra operation.
+   * @param {Bindings} bindings A bindings object.
+   * @return Algebra.Operation A new operation materialized with the given bindings.
+   */
+  public static materializeOperation(operation: Algebra.Operation, bindings: Bindings): Algebra.Operation {
+    return Util.mapOperation(operation, {
+      path: (op: Algebra.Path, factory: Factory) => {
+        return {
+          recurse: false,
+          result: factory.createPath(
+            ActorQueryOperationLeftJoinLeftDeep.materializeTerm(op.subject, bindings),
+            op.predicate,
+            ActorQueryOperationLeftJoinLeftDeep.materializeTerm(op.object, bindings),
+            ActorQueryOperationLeftJoinLeftDeep.materializeTerm(op.graph, bindings),
+          ),
+        };
+      },
+      pattern: (op: Algebra.Pattern, factory: Factory) => {
+        return {
+          recurse: false,
+          result: factory.createPattern(
+            ActorQueryOperationLeftJoinLeftDeep.materializeTerm(op.subject, bindings),
+            ActorQueryOperationLeftJoinLeftDeep.materializeTerm(op.predicate, bindings),
+            ActorQueryOperationLeftJoinLeftDeep.materializeTerm(op.object, bindings),
+            ActorQueryOperationLeftJoinLeftDeep.materializeTerm(op.graph, bindings),
+          ),
+        };
+      },
+    });
+  }
+
+  /**
+   * Materialize a term with the given binding.
+   *
+   * If the given term is a variable (or blank node)
+   * and that variable exist in the given bindings object,
+   * the value of that binding is returned.
+   * In all other cases, the term itself is returned.
+   *
+   * @param {RDF.Term} term A term.
+   * @param {Bindings} bindings A bindings object.
+   * @return {RDF.Term} The materialized term.
+   */
+  public static materializeTerm(term: RDF.Term, bindings: Bindings): RDF.Term {
+    if (term.termType === 'Variable') {
+      const value: RDF.Term = bindings.get(termToString(term));
+      if (value) {
+        return value;
+      }
+    }
+    return term;
+  }
+
+  public async testOperation(pattern: Algebra.LeftJoin, context: ActionContext): Promise<IActorTest> {
+    return true;
+  }
+
+  public async runOperation(pattern: Algebra.LeftJoin, context: ActionContext)
+    : Promise<IActorQueryOperationOutputBindings> {
+    // Initiate left and right operations
+    // Only the left stream will be used.
+    // The right stream is ignored and only its metadata and variables are used.
+    const left = ActorQueryOperation.getSafeBindings(await this.mediatorQueryOperation
+      .mediate({ operation: pattern.left, context }));
+    const right = ActorQueryOperation.getSafeBindings(await this.mediatorQueryOperation
+      .mediate({ operation: pattern.right, context }));
+
+    // If an expression was defined, wrap the right operation in a filter expression.
+    const rightOperation = pattern.expression
+      ? ActorQueryOperationLeftJoinLeftDeep.FACTORY.createFilter(pattern.right, pattern.expression)
+      : pattern.right;
+
+    // Create a left-deep stream with left and right.
+    const bindingsStream = ActorQueryOperationLeftJoinLeftDeep.createLeftDeepStream(left.bindingsStream, rightOperation,
+      async (operation: Algebra.Operation) => ActorQueryOperation.getSafeBindings(
+        await this.mediatorQueryOperation.mediate({ operation, context })).bindingsStream);
+
+    // Determine variables and metadata
+    const variables = ActorRdfJoin.joinVariables({ entries: [left, right] });
+    const metadata = () => Promise.all([left, right].map((entry) => entry.metadata()))
+      .then((metadatas) => metadatas.reduce((acc, val) => acc * val.totalItems, 1))
+      .catch(() => Infinity)
+      .then((totalItems) => ({ totalItems }));
+
+    return { type: 'bindings', bindingsStream, metadata, variables };
+  }
+
+}

--- a/packages/actor-query-operation-leftjoin-left-deep/package.json
+++ b/packages/actor-query-operation-leftjoin-left-deep/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@comunica/actor-query-operation-leftjoin-left-deep",
+  "version": "1.0.0",
+  "description": "A leftjoin-left-deep query-operation actor",
+  "lsd:module": "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-leftjoin-left-deep",
+  "lsd:components": "components/components.jsonld",
+  "lsd:contexts": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-leftjoin-left-deep/^1.0.0/components/context.jsonld": "components/context.jsonld"
+  },
+  "lsd:importPaths": {
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-operation-leftjoin-left-deep/^1.0.0/components/": "components/"
+  },
+  "main": "index.js",
+  "typings": "index",
+  "repository": "https://github.com/comunica/comunica/tree/master/packages/actor-query-operation-leftjoin-left-deep",
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "comunica",
+    "actor",
+    "query-operation",
+    "leftjoin-left-deep"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://github.com/comunica/comunica#readme",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "index.d.ts",
+    "index.js"
+  ],
+  "peerDependencies": {
+    "@comunica/core": "^1.9.2",
+    "@comunica/bus-query-operation": "^1.9.3"
+  },
+  "devDependencies": {
+    "@comunica/core": "^1.9.2",
+    "@comunica/bus-query-operation": "^1.9.3"
+  },
+  "jest": {
+    "globals": {
+      "ts-jest": {
+        "tsConfig": "test/tsconfig.json"
+      }
+    },
+    "transform": {
+      "^.+\\.ts$": "ts-jest"
+    },
+    "testRegex": "(/test/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "collectCoverage": true
+  },
+  "scripts": {
+    "test": "node \"../../node_modules/jest/bin/jest.js\" ${1}",
+    "test-watch": "node \"../../node_modules/jest/bin/jest.js\" ${1} --watch",
+    "lint": "node \"../../node_modules/tslint/bin/tslint\" lib/**/*.ts test/**/*.ts --exclude '**/*.d.ts'",
+    "build": "node \"../../node_modules/typescript/bin/tsc\"",
+    "validate": "npm ls"
+  }
+}

--- a/packages/actor-query-operation-leftjoin-left-deep/test/ActorQueryOperationLeftJoinLeftDeep-test.ts
+++ b/packages/actor-query-operation-leftjoin-left-deep/test/ActorQueryOperationLeftJoinLeftDeep-test.ts
@@ -1,0 +1,438 @@
+// tslint:disable:object-literal-sort-keys
+import {blankNode, defaultGraph, literal, namedNode, variable} from "@rdfjs/data-model";
+import {ArrayIterator, EmptyIterator, SingletonIterator} from "asynciterator";
+import {forEachTerms} from "rdf-terms";
+import {ActorQueryOperation, Bindings, IActorQueryOperationOutputBindings} from "@comunica/bus-query-operation";
+import {ActionContext, Bus} from "@comunica/core";
+import {ActorQueryOperationLeftJoinLeftDeep} from "../lib/ActorQueryOperationLeftJoinLeftDeep";
+import {Factory} from "sparqlalgebrajs";
+import {termToString} from "rdf-string";
+
+const arrayifyStream = require('arrayify-stream');
+const factory = new Factory();
+
+describe('ActorQueryOperationLeftJoinLeftDeep', () => {
+  let bus;
+  let mediatorQueryOperation;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+    mediatorQueryOperation = {
+      mediate: (arg) => {
+        let filter = false;
+        if (arg.operation.type === 'filter') {
+          filter = true;
+          arg.operation = arg.operation.input;
+        }
+
+        const bindings = {};
+        let amount = 1;
+        forEachTerms(arg.operation, (term) => {
+          if (term.termType === 'Variable') {
+            if (term.value.startsWith('+')) {
+              amount = 2;
+            } else if (term.value.startsWith('-')) {
+              amount = 0;
+            }
+            bindings[termToString(term)] = namedNode('bound-' + term.value + (filter ? '-FILTERED' : ''));
+          }
+        });
+
+        let bindingsStream;
+        if (amount === 0) {
+          bindingsStream = new EmptyIterator();
+        } else if (amount === 1) {
+          bindingsStream = new SingletonIterator(Bindings(bindings));
+        } else {
+          bindingsStream = new ArrayIterator([
+            Bindings(bindings).map((v) => namedNode(v.value + '1')),
+            Bindings(bindings).map((v) => namedNode(v.value + '2')),
+          ]);
+        }
+
+        return Promise.resolve({
+          bindingsStream,
+          metadata: () => arg.operation.rejectMetadata
+            ? Promise.reject(new Error('fail'))
+            : Promise.resolve({ totalItems: (arg.context || ActionContext({})).get('totalItems') }),
+          type: 'bindings',
+          variables: (arg.context || ActionContext({})).get('variables') || [],
+        });
+      },
+    };
+  });
+
+  describe('The ActorQueryOperationLeftJoinLeftDeep module', () => {
+    it('should be a function', () => {
+      expect(ActorQueryOperationLeftJoinLeftDeep).toBeInstanceOf(Function);
+    });
+
+    it('should be a ActorQueryOperationLeftJoinLeftDeep constructor', () => {
+      expect(new (ActorQueryOperationLeftJoinLeftDeep as any)({ name: 'actor', bus, mediatorQueryOperation }))
+        .toBeInstanceOf(ActorQueryOperationLeftJoinLeftDeep);
+      expect(new (ActorQueryOperationLeftJoinLeftDeep as any)({ name: 'actor', bus, mediatorQueryOperation }))
+        .toBeInstanceOf(ActorQueryOperation);
+    });
+
+    it('should not be able to create new ActorQueryOperationLeftJoinLeftDeep objects without \'new\'', () => {
+      expect(() => { (ActorQueryOperationLeftJoinLeftDeep as any)(); }).toThrow();
+    });
+  });
+
+  describe('Static methods', () => {
+    const termNamedNode = namedNode('a');
+    const termLiteral = literal('b');
+    const termVariableA = variable('a');
+    const termVariableB = variable('b');
+    const termVariableC = blankNode('c');
+    const termVariableD = blankNode('d');
+    const termDefaultGraph = defaultGraph();
+
+    const valueA = literal('A');
+    const valueC = literal('C');
+
+    const bindingsEmpty = Bindings({});
+    const bindingsA = Bindings({'?a': literal('A')});
+    const bindingsC = Bindings({'_:c': literal('C')});
+    const bindingsAC = Bindings({'?a': valueA, '_:c': valueC});
+
+    describe('materializeTerm', () => {
+      it('should not materialize a named node with empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termNamedNode, bindingsEmpty))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a named node with bindings for a', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termNamedNode, bindingsA))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a named node with bindings for c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termNamedNode, bindingsC))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a named node with bindings for a and c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termNamedNode, bindingsAC))
+          .toEqual(termNamedNode);
+      });
+
+      it('should not materialize a literal with empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termLiteral, bindingsEmpty))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a literal with bindings for a', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termLiteral, bindingsA))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a literal with bindings for c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termLiteral, bindingsC))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a literal with bindings for a and c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termLiteral, bindingsAC))
+          .toEqual(termLiteral);
+      });
+
+      it('should not materialize a variable with empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termVariableC, bindingsEmpty))
+          .toEqual(termVariableC);
+      });
+
+      it('should not materialize a variable with bindings for a', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termVariableC, bindingsA))
+          .toEqual(termVariableC);
+      });
+
+      it('should not materialize a blank node with bindings for c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termVariableC, bindingsC))
+          .toEqual(termVariableC);
+      });
+
+      it('should not materialize a blank node with bindings for a and c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termVariableC, bindingsAC))
+          .toEqual(termVariableC);
+      });
+
+      it('should not materialize a default graph with empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termDefaultGraph, bindingsEmpty))
+          .toEqual(termDefaultGraph);
+      });
+
+      it('should not materialize a default graph with bindings for a', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termDefaultGraph, bindingsA))
+          .toEqual(termDefaultGraph);
+      });
+
+      it('should not materialize a default graph with bindings for c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termDefaultGraph, bindingsC))
+          .toEqual(termDefaultGraph);
+      });
+
+      it('should not materialize a default graph with bindings for a and c', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeTerm(termDefaultGraph, bindingsAC))
+          .toEqual(termDefaultGraph);
+      });
+    });
+
+    describe('materializeOperation', () => {
+      it('should materialize a quad pattern with empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeOperation(
+          factory.createPattern(termVariableA, termNamedNode, termVariableC, termNamedNode),
+          bindingsEmpty))
+          .toEqual(factory.createPattern(termVariableA, termNamedNode, termVariableC, termNamedNode));
+      });
+
+      it('should materialize a quad pattern with non-empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeOperation(
+          factory.createPattern(termVariableA, termNamedNode, termVariableC, termNamedNode),
+          bindingsA))
+          .toEqual(factory.createPattern(valueA, termNamedNode, termVariableC, termNamedNode));
+      });
+
+      it('should materialize a BGP with non-empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeOperation(
+          factory.createBgp([
+            factory.createPattern(termVariableA, termNamedNode, termVariableC, termNamedNode),
+            factory.createPattern(termNamedNode, termVariableB, termVariableC, termNamedNode),
+          ]),
+          bindingsA))
+          .toEqual(factory.createBgp([
+            factory.createPattern(valueA, termNamedNode, termVariableC, termNamedNode),
+            factory.createPattern(termNamedNode, termVariableB, termVariableC, termNamedNode),
+          ]));
+      });
+
+      it('should materialize a path expression with non-empty bindings', () => {
+        return expect(ActorQueryOperationLeftJoinLeftDeep.materializeOperation(
+          factory.createPath(termVariableA, null, termVariableC, termNamedNode),
+          bindingsA))
+          .toEqual(factory.createPath(valueA, null, termVariableC, termNamedNode));
+      });
+    });
+
+  });
+
+  describe('An ActorQueryOperationLeftJoinLeftDeep instance', () => {
+    let actor: ActorQueryOperationLeftJoinLeftDeep;
+
+    beforeEach(() => {
+      actor = new ActorQueryOperationLeftJoinLeftDeep({ name: 'actor', bus, mediatorQueryOperation });
+    });
+
+    it('should test on leftjoin', () => {
+      const op = { operation: { type: 'leftjoin' } };
+      return expect(actor.test(op)).resolves.toBeTruthy();
+    });
+
+    it('should not test on non-leftjoin', () => {
+      const op = { operation: { type: 'some-other-type' } };
+      return expect(actor.test(op)).rejects.toBeTruthy();
+    });
+
+    it('should run for one binding in left and right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('a'), variable('b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            '?a': namedNode('bound-a'),
+            '?b': namedNode('bound-b'),
+          }),
+        ]);
+      });
+    });
+
+    it('should run for multiple bindings in left and one binding in right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('+a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('+a'), variable('b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            '?+a': namedNode('bound-+a1'),
+            '?b': namedNode('bound-b'),
+          }),
+          Bindings({
+            '?+a': namedNode('bound-+a2'),
+            '?b': namedNode('bound-b'),
+          }),
+        ]);
+      });
+    });
+
+    it('should run for one binding in left and multiple bindings in right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('a'), variable('+b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            '?a': namedNode('bound-a'),
+            '?+b': namedNode('bound-+b1'),
+          }),
+          Bindings({
+            '?a': namedNode('bound-a'),
+            '?+b': namedNode('bound-+b2'),
+          }),
+        ]);
+      });
+    });
+
+    it('should run for multiple binding in left and multiple bindings in right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('+a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('+a'), variable('+b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            '?+a': namedNode('bound-+a1'),
+            '?+b': namedNode('bound-+b1'),
+          }),
+          Bindings({
+            '?+a': namedNode('bound-+a1'),
+            '?+b': namedNode('bound-+b2'),
+          }),
+          Bindings({
+            '?+a': namedNode('bound-+a2'),
+            '?+b': namedNode('bound-+b1'),
+          }),
+          Bindings({
+            '?+a': namedNode('bound-+a2'),
+            '?+b': namedNode('bound-+b2'),
+          }),
+        ]);
+      });
+    });
+
+    it('should run for one binding in left and no bindings in right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('a'), variable('-b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            '?a': namedNode('bound-a'),
+          }),
+        ]);
+      });
+    });
+
+    it('should run for multiple bindings in left and no bindings in right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('+a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('+a'), variable('-b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            '?+a': namedNode('bound-+a1'),
+          }),
+          Bindings({
+            '?+a': namedNode('bound-+a2'),
+          }),
+        ]);
+      });
+    });
+
+    it('should correctly handle rejecting metadata in left', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('+a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('+a'), variable('-b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      operation.left.rejectMetadata = true;
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(await output.metadata()).toMatchObject({ totalItems: Infinity });
+      });
+    });
+
+    it('should correctly handle rejecting metadata in right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('+a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('+a'), variable('-b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      operation.right.rejectMetadata = true;
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(await output.metadata()).toMatchObject({ totalItems: Infinity });
+      });
+    });
+
+    it('should correctly handle rejecting metadata in left and right', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('+a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('+a'), variable('-b'), namedNode('2'), namedNode('b')),
+        null,
+      );
+      operation.left.rejectMetadata = true;
+      operation.right.rejectMetadata = true;
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(await output.metadata()).toMatchObject({ totalItems: Infinity });
+      });
+    });
+
+    it('should run for one binding in left and right with an expression', () => {
+      const operation = factory.createLeftJoin(
+        factory.createPattern(variable('a'), namedNode('1'), namedNode('1'), namedNode('1')),
+        factory.createPattern(variable('a'), variable('b'), namedNode('2'), namedNode('b')),
+        factory.createTermExpression(namedNode('EXPRESSION')),
+      );
+      const op = { operation, context: ActionContext({ totalItems: 10, variables: ['a'] }) };
+      return actor.run(op).then(async (output: IActorQueryOperationOutputBindings) => {
+        expect(output.variables).toEqual(['a']);
+        expect(output.type).toEqual('bindings');
+        expect(await output.metadata()).toEqual({ totalItems: 100 });
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({
+            '?a': namedNode('bound-a'),
+            '?b': namedNode('bound-b-FILTERED'),
+          }),
+        ]);
+      });
+    });
+
+  });
+});

--- a/packages/actor-query-operation-leftjoin-left-deep/test/tsconfig.json
+++ b/packages/actor-query-operation-leftjoin-left-deep/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": false
+  }
+}
+

--- a/packages/actor-query-operation-leftjoin-left-deep/test/tslint.json
+++ b/packages/actor-query-operation-leftjoin-left-deep/test/tslint.json
@@ -1,0 +1,11 @@
+{
+  "defaultSeverity": "error",
+  "extends": [
+    "../tslint.json"
+  ],
+  "rules": {
+    "no-var-requires": false,
+    "no-unused-expression": false
+  }
+}
+

--- a/packages/actor-query-operation-leftjoin-left-deep/tsconfig.json
+++ b/packages/actor-query-operation-leftjoin-left-deep/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "index.ts",
+    "lib/**/*"
+  ]
+}

--- a/packages/actor-query-operation-leftjoin-left-deep/tslint.json
+++ b/packages/actor-query-operation-leftjoin-left-deep/tslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "../../tslint.json"
+  ]
+}

--- a/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
@@ -29,6 +29,7 @@ export class ActorQueryOperationLeftJoinNestedLoop extends ActorQueryOperationTy
     const rightRaw = await this.mediatorQueryOperation.mediate({ operation: pattern.right, context });
     const right = ActorQueryOperation.getSafeBindings(rightRaw);
 
+    // TODO: refactor custom handling of pattern.expression. Should be pushed on the bus instead as a filter operation.
     const config = { ...ActorQueryOperation.getExpressionContext(context) };
     const evaluator = (pattern.expression)
       ? new AsyncEvaluator(pattern.expression, config)


### PR DESCRIPTION
Instead of resolving the left and right streams separately,
and joining the right with the left in an optional manner,
this actor functions in a left-deep manner.

Concretely, it will resolve the left stream,
and materialize+execute the right operation
with each binding.

This makes this actor significantly faster for larger streams.

Closes #583
Closes #496
Closes rubensworks/GraphQL-LD.js#13

Side-note: this PR shows the need for some kind of additional abstraction layer for left-deep joins (#427), as quite a bit of logic is duplicated from our left-deep-smallest BGP actor. Since this abstraction is not trivial, I did not make it part of this PR.