### PR TITLE
Consider sources ending with '/sparql' as SPARQL endpoints, Closes #535

### DIFF
--- a/packages/actor-rdf-resolve-hypermedia-sparql/components/Actor/RdfResolveHypermedia/Sparql.jsonld
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/components/Actor/RdfResolveHypermedia/Sparql.jsonld
@@ -17,6 +17,14 @@
           "comment": "The HTTP mediator",
           "required": true,
           "unique": true
+        },
+        {
+          "@id": "carrhs:Actor/RdfResolveHypermedia/Sparql/checkUrlSuffix",
+          "comment": "If URLs ending with '/sparql' should also be considered SPARQL endpoints.",
+          "required": true,
+          "unique": true,
+          "range": "xsd:boolean",
+          "default": true
         }
       ],
       "constructorArguments": [
@@ -26,6 +34,10 @@
             {
               "keyRaw": "mediatorHttp",
               "value": "carrhs:Actor/RdfResolveHypermedia/Sparql/mediatorHttp"
+            },
+            {
+              "keyRaw": "checkUrlSuffix",
+              "value": "carrhs:Actor/RdfResolveHypermedia/Sparql/checkUrlSuffix"
             }
           ]
         }

--- a/packages/actor-rdf-resolve-hypermedia-sparql/lib/ActorRdfResolveHypermediaSparql.ts
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/lib/ActorRdfResolveHypermediaSparql.ts
@@ -12,14 +12,16 @@ export class ActorRdfResolveHypermediaSparql extends ActorRdfResolveHypermedia {
 
   public readonly mediatorHttp: Mediator<Actor<IActionHttp, IActorTest, IActorHttpOutput>,
     IActionHttp, IActorTest, IActorHttpOutput>;
+  public readonly checkUrlSuffix: boolean;
 
   constructor(args: IActorRdfResolveHypermediaSparqlArgs) {
     super(args, 'sparql');
   }
 
   public async testMetadata(action: IActionRdfResolveHypermedia): Promise<IActorRdfResolveHypermediaTest> {
-    if (!action.forceSourceType && !action.metadata.sparqlService) {
-      throw new Error(`Actor ${this.name} could not detect a SPARQL service description.`);
+    if (!action.forceSourceType && !action.metadata.sparqlService
+      && !(this.checkUrlSuffix && action.url.endsWith('/sparql'))) {
+      throw new Error(`Actor ${this.name} could not detect a SPARQL service description or URL ending on /sparql.`);
     }
     return { filterFactor: 1 };
   }
@@ -36,4 +38,5 @@ export interface IActorRdfResolveHypermediaSparqlArgs
   extends IActorArgs<IActionRdfResolveHypermedia, IActorRdfResolveHypermediaTest, IActorRdfResolveHypermediaOutput> {
   mediatorHttp: Mediator<Actor<IActionHttp, IActorTest, IActorHttpOutput>,
     IActionHttp, IActorTest, IActorHttpOutput>;
+  checkUrlSuffix: boolean;
 }

--- a/packages/actor-rdf-resolve-hypermedia-sparql/test/ActorRdfResolveHypermediaSparql-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/test/ActorRdfResolveHypermediaSparql-test.ts
@@ -31,7 +31,8 @@ describe('ActorRdfResolveHypermediaSparql', () => {
     let actor: ActorRdfResolveHypermediaSparql;
 
     beforeEach(() => {
-      actor = new ActorRdfResolveHypermediaSparql({ name: 'actor', bus, mediatorHttp: <any> 'mediator' });
+      actor = new ActorRdfResolveHypermediaSparql(
+        { name: 'actor', bus, mediatorHttp: <any> 'mediator', checkUrlSuffix: true });
     });
 
     describe('#test', () => {
@@ -52,7 +53,26 @@ describe('ActorRdfResolveHypermediaSparql', () => {
 
       it('should not test without a sparql service metadata', async () => {
         return expect(actor.test({ url: 'URL', metadata: {}, quads: null }))
-          .rejects.toThrow(new Error('Actor actor could not detect a SPARQL service description.'));
+          .rejects.toThrow(new Error('Actor actor could not detect a SPARQL service description or URL ending on /sparql.'));
+      });
+
+      it('should test with an URL ending with /sparql', async () => {
+        return expect(await actor.test({ url: 'URL/sparql', metadata: {}, quads: null }))
+          .toEqual({ filterFactor: 1 });
+      });
+
+      it('should not test with an URL ending with /sparql if checkUrlSuffix is false', async () => {
+        actor = new ActorRdfResolveHypermediaSparql(
+          { name: 'actor', bus, mediatorHttp: <any> 'mediator', checkUrlSuffix: false });
+        return expect(actor.test({ url: 'URL/sparql', metadata: {}, quads: null }))
+          .rejects.toThrow(new Error('Actor actor could not detect a SPARQL service description or URL ending on /sparql.'));
+      });
+
+      it('should not test with an URL ending with /sparql if the type is forced to something else', async () => {
+        actor = new ActorRdfResolveHypermediaSparql(
+          { name: 'actor', bus, mediatorHttp: <any> 'mediator', checkUrlSuffix: false });
+        return expect(actor.test({ url: 'URL/sparql', metadata: {}, quads: null, forceSourceType: 'file' }))
+          .rejects.toThrow(new Error('Actor actor is not able to handle source type file.'));
       });
     });
 


### PR DESCRIPTION
As discussed in #535, sources with URL ending with `/sparql` will be considered SPARQL endpoints.
Since this is a heuristic, this is disableable from the config.

Closes #535