### PR TITLE
Discover and handle default graph overrides

### DIFF
--- a/packages/actor-rdf-metadata-extract-sparql-service/lib/ActorRdfMetadataExtractSparqlService.ts
+++ b/packages/actor-rdf-metadata-extract-sparql-service/lib/ActorRdfMetadataExtractSparqlService.ts
@@ -22,22 +22,21 @@ export class ActorRdfMetadataExtractSparqlService extends ActorRdfMetadataExtrac
       action.metadata.on('error', reject);
 
       // Immediately resolve when a SPARQL service endpoint URL has been found
+      const metadata: any = {};
       action.metadata.on('data', (quad) => {
         if (quad.predicate.value === 'http://www.w3.org/ns/sparql-service-description#endpoint'
           && (quad.subject.termType === 'BlankNode' || quad.subject.value === action.url)) {
-          resolve({
-            metadata: {
-              sparqlService: quad.object.termType === 'Literal'
+          metadata.sparqlService = quad.object.termType === 'Literal'
                 ? resolveIri(quad.object.value, action.url)
-                : quad.object.value
-            },
-          });
+                : quad.object.value;
+        } else if (quad.predicate.value === 'http://www.w3.org/ns/sparql-service-description#defaultGraph') {
+          metadata.defaultGraph = quad.object.value;
         }
       });
 
       // If no value has been found, emit nothing.
       action.metadata.on('end', () => {
-        resolve({ metadata: {} });
+        resolve({ metadata });
       });
     });
   }

--- a/packages/actor-rdf-metadata-extract-sparql-service/test/ActorRdfMetadataExtractSparqlService-test.ts
+++ b/packages/actor-rdf-metadata-extract-sparql-service/test/ActorRdfMetadataExtractSparqlService-test.ts
@@ -32,6 +32,8 @@ describe('ActorRdfMetadataExtractSparqlService', () => {
   describe('An ActorRdfMetadataExtractSparqlService instance', () => {
     let actor: ActorRdfMetadataExtractSparqlService;
     let input: Readable;
+    let inputDefaultGraph: Readable;
+    let inputAll: Readable;
     let inputNone: Readable;
     let inputRelativeLiteral: Readable;
     let inputRelativeIri: Readable;
@@ -43,6 +45,19 @@ describe('ActorRdfMetadataExtractSparqlService', () => {
         quad('s1', 'p1', 'o1', ''),
         quad('http://example.org/', 'http://www.w3.org/ns/sparql-service-description#endpoint', 'http://example2.org/ENDPOINT', ''),
         quad('s2', 'px', '5678', ''),
+        quad('s3', 'p3', 'o3', ''),
+      ]);
+      inputDefaultGraph = stream([
+        quad('s1', 'p1', 'o1', ''),
+        quad('URL', 'http://www.w3.org/ns/sparql-service-description#defaultGraph', 'GRAPH', ''),
+        quad('s2', 'px', '5678', ''),
+        quad('s3', 'p3', 'o3', ''),
+      ]);
+      inputAll = stream([
+        quad('s1', 'p1', 'o1', ''),
+        quad('URL', 'http://www.w3.org/ns/sparql-service-description#defaultGraph', 'GRAPH', ''),
+        quad('s2', 'px', '5678', ''),
+        quad('URL', 'http://www.w3.org/ns/sparql-service-description#endpoint', 'ENDPOINT', ''),
         quad('s3', 'p3', 'o3', ''),
       ]);
       inputNone = stream([
@@ -80,6 +95,16 @@ describe('ActorRdfMetadataExtractSparqlService', () => {
     it('should run on a stream where an endpoint is defined, but for another URL', () => {
       return expect(actor.run({ url: 'http://example2.org/', metadata: input })).resolves
         .toEqual({ metadata: {}});
+    });
+
+    it('should run on a stream where a default graph is defined', () => {
+      return expect(actor.run({ url: 'URL', metadata: inputDefaultGraph })).resolves
+        .toEqual({ metadata: { defaultGraph: 'GRAPH' }});
+    });
+
+    it('should run on a stream where an endpoint and default graph is defined', () => {
+      return expect(actor.run({ url: 'URL', metadata: inputAll })).resolves
+        .toEqual({ metadata: { sparqlService: 'ENDPOINT', defaultGraph: 'GRAPH' }});
     });
 
     it('should run on a stream where an endpoint is not given', () => {

--- a/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
@@ -7,7 +7,8 @@ import {AsyncIterator} from "asynciterator";
 import {PromiseProxyIterator} from "asynciterator-promiseproxy";
 import * as RDF from "rdf-js";
 import {termToString} from "rdf-string";
-import {matchPattern, TRIPLE_TERM_NAMES} from "rdf-terms";
+import {mapTerms, matchPattern} from "rdf-terms";
+import {namedNode, defaultGraph} from "@rdfjs/data-model";
 
 /**
  * An RDF source that executes a quad pattern over a QPF interface and fetches its first page.
@@ -26,6 +27,7 @@ export class RdfSourceQpf implements RDF.Source {
   private readonly predicateUri: string;
   private readonly objectUri: string;
   private readonly graphUri?: string;
+  private readonly defaultGraph?: RDF.NamedNode;
   private readonly context: ActionContext;
   private readonly cachedQuads: {[patternId: string]: AsyncIterator<RDF.Quad>};
 
@@ -47,8 +49,12 @@ export class RdfSourceQpf implements RDF.Source {
     this.context = context;
     this.cachedQuads = {};
     this.searchForm = this.getSearchForm(metadata);
+    this.defaultGraph = metadata.defaultGraph ? namedNode(metadata.defaultGraph) : null;
     if (initialQuads) {
-      const wrappedQuads = (<any> AsyncIterator).wrap(initialQuads);
+      let wrappedQuads = (<any> AsyncIterator).wrap(initialQuads);
+      if (this.defaultGraph) {
+        wrappedQuads = this.reverseMapQuadsToDefaultGraph(wrappedQuads);
+      }
       wrappedQuads.setProperty('metadata', metadata);
       this.cacheQuads(wrappedQuads);
     }
@@ -125,6 +131,15 @@ export class RdfSourceQpf implements RDF.Source {
       throw new Error("RdfSourceQpf does not support matching by regular expressions.");
     }
 
+    // If we are querying the default graph,
+    // and the source has an overridden value for the default graph (such as QPF can provide),
+    // we override the graph parameter with that value.
+    let modifiedGraph = false;
+    if (this.defaultGraph && graph && graph.termType === 'DefaultGraph') {
+      modifiedGraph = true;
+      graph = this.defaultGraph;
+    }
+
     // Try to emit from cache
     const cached = this.getCachedQuads(subject, predicate, object, graph);
     if (cached) {
@@ -132,7 +147,7 @@ export class RdfSourceQpf implements RDF.Source {
     }
 
     const quads = new PromiseProxyIterator(async () => {
-      let url: string = await this.createFragmentUri(this.searchForm, subject, predicate, object, graph);
+      let url: string = await this.createFragmentUri(this.searchForm, subject, predicate, object, <RDF.Term> graph);
       const rdfDereferenceOutput = await this.mediatorRdfDereference.mediate({ context: this.context, url });
       url = rdfDereferenceOutput.url;
 
@@ -149,14 +164,32 @@ export class RdfSourceQpf implements RDF.Source {
       // The server is free to send any data in its response (such as metadata),
       // including quads that do not match the given matter.
       // Therefore, we have to filter away all non-matching quads here.
-      const filteredOutput: AsyncIterator<RDF.Quad> = (<any> AsyncIterator).wrap(rdfMetadataOuput.data)
-        .filter((quad: RDF.Quad) => matchPattern(quad, subject, predicate, object, graph));
+      const actualDefaultGraph = defaultGraph();
+      let filteredOutput: AsyncIterator<RDF.Quad> = (<any> AsyncIterator).wrap(rdfMetadataOuput.data)
+        .filter((quad: RDF.Quad) => {
+          if (matchPattern(quad, subject, predicate, object, <RDF.Term> graph)) {
+            return true;
+          }
+          // Special case: if we are querying in the default graph, and we had an overridden default graph,
+          // also accept that incoming triples may be defined in the actual default graph
+          return modifiedGraph && matchPattern(quad, subject, predicate, object, actualDefaultGraph);
+        });
+      if (modifiedGraph || !graph) {
+        // Reverse-map the overridden default graph back to the actual default graph
+        filteredOutput = this.reverseMapQuadsToDefaultGraph(filteredOutput);
+      }
 
       return filteredOutput;
     });
 
     this.cacheQuads(quads, subject, predicate, object, graph);
     return this.getCachedQuads(subject, predicate, object, graph);
+  }
+
+  protected reverseMapQuadsToDefaultGraph(quads: AsyncIterator<RDF.Quad>): AsyncIterator<RDF.Quad> {
+    const actualDefaultGraph = defaultGraph();
+    return quads.map(
+      (quad) => mapTerms(quad, (term, key) => key === 'graph' && term.equals(this.defaultGraph) ? actualDefaultGraph : term));
   }
 
   protected getPatternId(subject?: RDF.Term, predicate?: RDF.Term, object?: RDF.Term, graph?: RDF.Term): string {


### PR DESCRIPTION
This is applicable for QPF interfaces.

This fixes the problem where SPO queries over QPF
endpoints containing many triples in the non-default graph
was slow due to inefficient filtering.

Closes #623