### PR TITLE
send http requests with credentials by default

### DIFF
--- a/packages/actor-http-native/lib/Requester-browser.ts
+++ b/packages/actor-http-native/lib/Requester-browser.ts
@@ -33,6 +33,7 @@ export default class Requester {
     const reqHeaders = settings.headers;
     request.open(settings.method, settings.url, true);
     request.timeout = settings.timeout;
+    request.withCredentials = settings.withCredentials ? settings.withCredentials : true;
 
     for (const header of reqHeaders) {
       if (!(header[0] in UNSAFE_REQUEST_HEADERS) && header[1]) {


### PR DESCRIPTION
modify actor-http-native to send requests initiated from a browser with credentials by default

see also: https://github.com/comunica/comunica/issues/613