### PR TITLE
Allow hypermedia links to define custom context entries

### DIFF
--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/MediatedLinkedRdfSourcesAsyncRdfIterator.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/MediatedLinkedRdfSourcesAsyncRdfIterator.ts
@@ -73,8 +73,13 @@ export class MediatedLinkedRdfSourcesAsyncRdfIterator extends LinkedRdfSourcesAs
   }
 
   protected async getSource(link: ILink, handledDatasets: Record<string, boolean>): Promise<ISourceState> {
+    // Include context entries from link
+    let context = this.context;
+    if (link.context) {
+      context = context.merge(link.context);
+    }
+
     // Get the RDF representation of the given document
-    const context = this.context;
     let url = link.url;
     const rdfDereferenceOutput: IActorRdfDereferenceOutput = await this.mediatorRdfDereference
       .mediate({ context, url });

--- a/packages/bus-rdf-resolve-hypermedia-links/lib/ActorRdfResolveHypermediaLinks.ts
+++ b/packages/bus-rdf-resolve-hypermedia-links/lib/ActorRdfResolveHypermediaLinks.ts
@@ -1,4 +1,4 @@
-import type { IAction, IActorArgs, IActorOutput, IActorTest } from '@comunica/core';
+import type { IAction, IActorArgs, IActorOutput, IActorTest, ActionContext } from '@comunica/core';
 import { Actor } from '@comunica/core';
 import type * as RDF from 'rdf-js';
 
@@ -50,4 +50,9 @@ export interface ILink {
    * @returns The stream of data quads to be used for this link instead of the given stream.
    */
   transform?: (input: RDF.Stream) => Promise<RDF.Stream>;
+  /**
+   * Optional context to apply onto mediators when handling this link as source.
+   * All entries of this context will be added (or overwritten) into the existing context.
+   */
+  context?: ActionContext;
 }


### PR DESCRIPTION
This is needed for handling content policies during link traversal.