### PR TITLE
pure-js hash operators

### DIFF
--- a/packages/actor-abstract-bindings-hash/components/Actor/AbstractBindingsHash.jsonld
+++ b/packages/actor-abstract-bindings-hash/components/Actor/AbstractBindingsHash.jsonld
@@ -11,14 +11,7 @@
       "extends": "caabh:Actor/AbstractFilterHash",
       "requireElement": "AbstractBindingsHash",
       "comment": "An abstract comunica actor for handling binding query operators.",
-      "parameters": [
-        {
-          "@id": "caabh:Actor/AbstractFilterHash/hashAlgorithm"
-        },
-        {
-          "@id": "caabh:Actor/AbstractFilterHash/digestAlgorithm"
-        }
-      ],
+      "parameters": [],
       "constructorArguments": [
         {
           "extends": "caabh:Actor/AbstractFilterHash/constructorArgumentsObject"

--- a/packages/actor-abstract-bindings-hash/components/Actor/AbstractFilterHash.jsonld
+++ b/packages/actor-abstract-bindings-hash/components/Actor/AbstractFilterHash.jsonld
@@ -11,34 +11,12 @@
       "extends": "cbqo:Actor/QueryOperationTypedMediated",
       "requireElement": "AbstractFilterHash",
       "comment": "An abstract comunica actor for operators that require hashing functionality.",
-      "parameters": [
-        {
-          "@id": "caabh:Actor/AbstractFilterHash/hashAlgorithm",
-          "comment": "The algorithm used for hashing",
-          "required": true,
-          "unique": true
-        },
-        {
-          "@id": "caabh:Actor/AbstractFilterHash/digestAlgorithm",
-          "comment": "The algorithm used for digesting",
-          "required": true,
-          "unique": true
-        }
-      ],
+      "parameters": [],
       "constructorArguments": [
         {
           "@id": "caabh:Actor/AbstractFilterHash/constructorArgumentsObject",
           "extends": "cbqo:Actor/QueryOperationTypedMediated/constructorArgumentsObject",
-          "fields": [
-            {
-              "keyRaw": "hashAlgorithm",
-              "value": "caabh:Actor/AbstractFilterHash/hashAlgorithm"
-            },
-            {
-              "keyRaw": "digestAlgorithm",
-              "value": "caabh:Actor/AbstractFilterHash/digestAlgorithm"
-            }
-          ]
+          "fields": []
         }
       ]
     }

--- a/packages/actor-abstract-bindings-hash/components/context.jsonld
+++ b/packages/actor-abstract-bindings-hash/components/context.jsonld
@@ -6,9 +6,7 @@
       "files-caabh": "caabh:^1.0.0/",
 
       "AbstractBindingsHash": "caabh:Actor/AbstractBindingsHash",
-      "AbstractFilterHash": "caabh:Actor/AbstractFilterHash",
-      "hashAlgorithm": "caabh:Actor/AbstractFilterHash/hashAlgorithm",
-      "digestAlgorithm": "caabh:Actor/AbstractFilterHash/digestAlgorithm"
+      "AbstractFilterHash": "caabh:Actor/AbstractFilterHash"
     }
   ]
 }

--- a/packages/actor-abstract-bindings-hash/lib/AbstractBindingsHash.ts
+++ b/packages/actor-abstract-bindings-hash/lib/AbstractBindingsHash.ts
@@ -8,34 +8,22 @@ import {
 import type { ActionContext, IActorTest } from '@comunica/core';
 import type { Algebra } from 'sparqlalgebrajs';
 import type { IActorInitRdfDereferencePagedArgs } from './AbstractFilterHash';
-import { AbstractFilterHash } from './AbstractFilterHash';
 
 /**
  * A comunica Hash Query Operation Actor.
  */
 export abstract class AbstractBindingsHash<T extends Algebra.Operation> extends ActorQueryOperationTypedMediated<T>
   implements IActorInitRdfDereferencePagedArgs {
-  public readonly hashAlgorithm: string;
-  public readonly digestAlgorithm: string;
-
   public constructor(args: IActorInitRdfDereferencePagedArgs, operator: string) {
     super(args, operator);
-    if (!AbstractFilterHash.doesHashAlgorithmExist(this.hashAlgorithm)) {
-      throw new Error(`The given hash algorithm is not present in this version of Node: ${this.hashAlgorithm}`);
-    }
-    if (!AbstractFilterHash.doesDigestAlgorithmExist(this.digestAlgorithm)) {
-      throw new Error(`The given digest algorithm is not present in this version of Node: ${this.digestAlgorithm}`);
-    }
   }
 
   /**
      * Create a new filter function for the given hash algorithm and digest algorithm.
      * The given filter depends on the Algebraic operation
-     *  @param {string} hashAlgorithm A hash algorithm.
-     * @param {string} digestAlgorithm A digest algorithm.
      * @return {(bindings: Bindings) => boolean} A distinct filter for bindings.
      */
-  public abstract newHashFilter(hashAlgorithm: string, digestAlgorithm: string): (bindings: Bindings) => boolean;
+  public abstract newHashFilter(): (bindings: Bindings) => boolean;
 
   public async testOperation(pattern: T, context: ActionContext): Promise<IActorTest> {
     return true;
@@ -46,7 +34,7 @@ export abstract class AbstractBindingsHash<T extends Algebra.Operation> extends 
       await this.mediatorQueryOperation.mediate({ operation: pattern.input, context }),
     );
     const bindingsStream: BindingsStream = output.bindingsStream.filter(
-      this.newHashFilter(this.hashAlgorithm, this.digestAlgorithm),
+      this.newHashFilter(),
     );
     return {
       type: 'bindings',

--- a/packages/actor-abstract-bindings-hash/lib/AbstractFilterHash.ts
+++ b/packages/actor-abstract-bindings-hash/lib/AbstractFilterHash.ts
@@ -1,5 +1,3 @@
-import type { Hash } from 'crypto';
-import { createHash, getHashes } from 'crypto';
 import type { Bindings, IActorQueryOperationOutputBindings,
   IActorQueryOperationTypedMediatedArgs } from '@comunica/bus-query-operation';
 import {
@@ -7,6 +5,7 @@ import {
 } from '@comunica/bus-query-operation';
 import type { ActionContext } from '@comunica/core';
 import { termToString } from 'rdf-string';
+import { createHash } from 'rusha';
 import type { Algebra } from 'sparqlalgebrajs';
 
 /**
@@ -33,7 +32,7 @@ export abstract class AbstractFilterHash<T extends Algebra.Operation> extends Ac
      * @return {boolean} If it exists.
      */
   public static doesHashAlgorithmExist(hashAlgorithm: string): boolean {
-    return getHashes().includes(hashAlgorithm);
+    return [ 'sha1' ].includes(hashAlgorithm);
   }
 
   /**
@@ -42,7 +41,7 @@ export abstract class AbstractFilterHash<T extends Algebra.Operation> extends Ac
      * @return {boolean} If it exists.
      */
   public static doesDigestAlgorithmExist(digestAlgorithm: string): boolean {
-    return [ 'latin1', 'hex', 'base64' ].includes(digestAlgorithm);
+    return [ 'hex' ].includes(digestAlgorithm);
   }
 
   /**
@@ -53,7 +52,13 @@ export abstract class AbstractFilterHash<T extends Algebra.Operation> extends Ac
      * @return {string} The object's hash.
      */
   public static hash(hashAlgorithm: string, digestAlgorithm: string, bindings: Bindings): string {
-    const hash: Hash = createHash(hashAlgorithm);
+    if (hashAlgorithm !== 'sha1') {
+      throw new Error(`Unsupported hashAlgorithm "${hashAlgorithm}"`);
+    }
+    if (digestAlgorithm !== 'hex') {
+      throw new Error(`Unsupported digestAlgorithm "${digestAlgorithm}"`);
+    }
+    const hash = createHash();
     hash.update(require('canonicalize')(bindings.map(x => termToString(x))));
     return hash.digest(<any> digestAlgorithm);
   }

--- a/packages/actor-abstract-bindings-hash/lib/AbstractFilterHash.ts
+++ b/packages/actor-abstract-bindings-hash/lib/AbstractFilterHash.ts
@@ -13,60 +13,24 @@ import type { Algebra } from 'sparqlalgebrajs';
  */
 export abstract class AbstractFilterHash<T extends Algebra.Operation> extends ActorQueryOperationTypedMediated<T>
   implements IActorInitRdfDereferencePagedArgs {
-  public readonly hashAlgorithm: string;
-  public readonly digestAlgorithm: string;
-
   public constructor(args: IActorInitRdfDereferencePagedArgs, operator: string) {
     super(args, operator);
-    if (!AbstractFilterHash.doesHashAlgorithmExist(this.hashAlgorithm)) {
-      throw new Error(`The given hash algorithm is not present in this version of Node: ${this.hashAlgorithm}`);
-    }
-    if (!AbstractFilterHash.doesDigestAlgorithmExist(this.digestAlgorithm)) {
-      throw new Error(`The given digest algorithm is not present in this version of Node: ${this.digestAlgorithm}`);
-    }
   }
 
   /**
-     * Check if the given hash algorithm (such as sha1) exists.
-     * @param {string} hashAlgorithm A hash algorithm.
-     * @return {boolean} If it exists.
-     */
-  public static doesHashAlgorithmExist(hashAlgorithm: string): boolean {
-    return [ 'sha1' ].includes(hashAlgorithm);
-  }
-
-  /**
-     * Check if the given digest (such as base64) algorithm exists.
-     * @param {string} digestAlgorithm A digest algorithm.
-     * @return {boolean} If it exists.
-     */
-  public static doesDigestAlgorithmExist(digestAlgorithm: string): boolean {
-    return [ 'hex' ].includes(digestAlgorithm);
-  }
-
-  /**
-     * Create a string-based hash of the given object.
-     * @param {string} hashAlgorithm A hash algorithm.
-     * @param {string} digestAlgorithm A digest algorithm.
-     * @param bindings The bindings to hash.
-     * @return {string} The object's hash.
-     */
-  public static hash(hashAlgorithm: string, digestAlgorithm: string, bindings: Bindings): string {
-    if (hashAlgorithm !== 'sha1') {
-      throw new Error(`Unsupported hashAlgorithm "${hashAlgorithm}"`);
-    }
-    if (digestAlgorithm !== 'hex') {
-      throw new Error(`Unsupported digestAlgorithm "${digestAlgorithm}"`);
-    }
-    const hash = createHash();
-    hash.update(require('canonicalize')(bindings.map(x => termToString(x))));
-    return hash.digest(<any> digestAlgorithm);
+   * Create a string-based hash of the given object.
+   * @param bindings The bindings to hash.
+   * @return {string} The object's hash.
+   */
+  public static hash(bindings: Bindings): string {
+    return createHash()
+      .update(require('canonicalize')(bindings.map(x => termToString(x))))
+      .digest('hex');
   }
 
   public abstract async runOperation(pattern: T, context: ActionContext): Promise<IActorQueryOperationOutputBindings>;
 }
 
 export interface IActorInitRdfDereferencePagedArgs extends IActorQueryOperationTypedMediatedArgs {
-  hashAlgorithm: string;
-  digestAlgorithm: string;
+
 }

--- a/packages/actor-abstract-bindings-hash/package-lock.json
+++ b/packages/actor-abstract-bindings-hash/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "@comunica/actor-abstract-bindings-hash",
+  "version": "1.17.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
+    },
+    "@types/rusha": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@types/rusha/-/rusha-0.8.0.tgz",
+      "integrity": "sha512-t+rdR1Ptj6/gIUBW4wVDjUj29sE9Sd5TnHCQhbMiFAdeuh9niJuEMuVd4X+rxyfNEqkF+X4vfiAMxrjQgG2klg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "rusha": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.13.tgz",
+      "integrity": "sha1-mghOe4YLF7/zAVuSxnpqM2GRUTo="
+    }
+  }
+}

--- a/packages/actor-abstract-bindings-hash/package.json
+++ b/packages/actor-abstract-bindings-hash/package.json
@@ -70,8 +70,10 @@
     "validate": "npm ls"
   },
   "dependencies": {
+    "@types/rusha": "^0.8.0",
     "canonicalize": "^1.0.1",
     "rdf-string": "^1.5.0",
+    "rusha": "^0.8.13",
     "sparqlalgebrajs": "^2.4.0"
   }
 }

--- a/packages/actor-abstract-bindings-hash/test/AbstractBindingsHash-test.ts
+++ b/packages/actor-abstract-bindings-hash/test/AbstractBindingsHash-test.ts
@@ -35,8 +35,6 @@ describe('AbstractBindingsHash', () => {
         canContainUndefs: false,
       }),
     };
-    hashAlgorithm = 'sha1';
-    digestAlgorithm = 'hex';
   });
 
   describe('The AbstractBindingsHash module', () => {
@@ -47,29 +45,15 @@ describe('AbstractBindingsHash', () => {
     it('should be a AbstractBindingsHash constructor', () => {
       // eslint-disable-next-line @typescript-eslint/func-call-spacing
       expect(new (<any> AbstractBindingsHash)
-      ({ bus: new Bus({ name: 'bus' }), name: 'actor', hashAlgorithm, digestAlgorithm }, 'distinct'))
+      ({ bus: new Bus({ name: 'bus' }), name: 'actor' }, 'distinct'))
         .toBeInstanceOf(AbstractBindingsHash);
       // eslint-disable-next-line @typescript-eslint/func-call-spacing
       expect(new (<any> AbstractBindingsHash)
-      ({ bus: new Bus({ name: 'bus' }), name: 'actor', hashAlgorithm, digestAlgorithm }, 'distinct'))
+      ({ bus: new Bus({ name: 'bus' }), name: 'actor' }, 'distinct'))
         .toBeInstanceOf(Actor);
     });
     it('should not be able to create new AbstractBindingsHash objects without \'new\'', () => {
       expect(() => { (<any> AbstractBindingsHash)(); }).toThrow();
-    });
-
-    it('should not be able to create new AbstractBindingsHash objects with an invalid hash algo', () => {
-      expect(() => { new (<any> AbstractBindingsHash)(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm: 'abc', digestAlgorithm }, 'distinct',
-      ); })
-        .toThrow();
-    });
-
-    it('should not be able to create new AbstractBindingsHash objects with an invalid digest algo', () => {
-      expect(() => { new (<any> AbstractBindingsHash)(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm: 'abc' }, 'distinct',
-      ); })
-        .toThrow();
     });
   });
 
@@ -82,7 +66,7 @@ describe('AbstractBindingsHash', () => {
             return true;
           };
         }
-      }({ name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm }, 'distinct');
+      }({ name: 'actor', bus, mediatorQueryOperation }, 'distinct');
     });
 
     it('should run', () => {

--- a/packages/actor-abstract-bindings-hash/test/AbstractBindingsHash-test.ts
+++ b/packages/actor-abstract-bindings-hash/test/AbstractBindingsHash-test.ts
@@ -36,7 +36,7 @@ describe('AbstractBindingsHash', () => {
       }),
     };
     hashAlgorithm = 'sha1';
-    digestAlgorithm = 'base64';
+    digestAlgorithm = 'hex';
   });
 
   describe('The AbstractBindingsHash module', () => {

--- a/packages/actor-abstract-bindings-hash/test/AbstractFilterHash-test.ts
+++ b/packages/actor-abstract-bindings-hash/test/AbstractFilterHash-test.ts
@@ -30,8 +30,6 @@ describe('AbstractFilterHash', () => {
         variables: [ 'a' ],
       }),
     };
-    hashAlgorithm = 'sha1';
-    digestAlgorithm = 'hex';
   });
 
   describe('The AbstractFilterHash module', () => {
@@ -42,79 +40,31 @@ describe('AbstractFilterHash', () => {
     it('should be a AbstractFilterHash constructor', () => {
       // eslint-disable-next-line @typescript-eslint/func-call-spacing
       expect(new (<any> AbstractFilterHash)
-      ({ bus: new Bus({ name: 'bus' }), name: 'actor', hashAlgorithm, digestAlgorithm }, 'distinct'))
+      ({ bus: new Bus({ name: 'bus' }), name: 'actor' }, 'distinct'))
         .toBeInstanceOf(AbstractFilterHash);
       // eslint-disable-next-line @typescript-eslint/func-call-spacing
       expect(new (<any> AbstractFilterHash)
-      ({ bus: new Bus({ name: 'bus' }), name: 'actor', hashAlgorithm, digestAlgorithm }, 'distinct'))
+      ({ bus: new Bus({ name: 'bus' }), name: 'actor' }, 'distinct'))
         .toBeInstanceOf(Actor);
     });
     it('should not be able to create new AbstractFilterHash objects without \'new\'', () => {
       expect(() => { (<any> AbstractFilterHash)(); }).toThrow();
     });
-
-    it('should not be able to create new AbstractFilterHash objects with an invalid hash algo', () => {
-      expect(() => { new (<any> AbstractFilterHash)(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm: 'abc', digestAlgorithm }, 'distinct',
-      ); })
-        .toThrow();
-    });
-
-    it('should not be able to create new AbstractFilterHash objects with an invalid digest algo', () => {
-      expect(() => { new (<any> AbstractFilterHash)(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm: 'abc' }, 'distinct',
-      ); })
-        .toThrow();
-    });
-  });
-
-  describe('#doesHashAlgorithmExist', () => {
-    it('should be true on sha1', () => {
-      return expect(AbstractFilterHash.doesHashAlgorithmExist('sha1')).toBeTruthy();
-    });
-
-    it('should be false on md5', () => {
-      return expect(AbstractFilterHash.doesHashAlgorithmExist('md5')).toBeFalsy();
-    });
-
-    it('should not be true on something that does not exist', () => {
-      return expect(AbstractFilterHash.doesHashAlgorithmExist('somethingthatdoesnotexist'))
-        .toBeFalsy();
-    });
-  });
-
-  describe('#doesDigestAlgorithmExist', () => {
-    it('should be false on latin1', () => {
-      return expect(AbstractFilterHash.doesDigestAlgorithmExist('latin1')).toBeFalsy();
-    });
-
-    it('should be true on hex', () => {
-      return expect(AbstractFilterHash.doesDigestAlgorithmExist('hex')).toBeTruthy();
-    });
-
-    it('should be false on base64', () => {
-      return expect(AbstractFilterHash.doesDigestAlgorithmExist('base64')).toBeFalsy();
-    });
-
-    it('should not be true on something that does not exist', () => {
-      return expect(AbstractFilterHash.doesDigestAlgorithmExist('somethingthatdoesnotexist'))
-        .toBeFalsy();
-    });
   });
 
   describe('#hash', () => {
     it('should return the same hash for equal objects', () => {
-      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })))
-        .toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })));
-      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.namedNode('c') })))
-        .toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.namedNode('c') })));
+      expect(AbstractFilterHash.hash(Bindings({ a: DF.literal('b') })))
+        .toEqual(AbstractFilterHash.hash(Bindings({ a: DF.literal('b') })));
+      expect(AbstractFilterHash.hash(Bindings({ a: DF.namedNode('c') })))
+        .toEqual(AbstractFilterHash.hash(Bindings({ a: DF.namedNode('c') })));
     });
 
     it('should return a different hash for non-equal objects', () => {
-      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })))
-        .not.toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('c') })));
-      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })))
-        .not.toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.namedNode('b') })));
+      expect(AbstractFilterHash.hash(Bindings({ a: DF.literal('b') })))
+        .not.toEqual(AbstractFilterHash.hash(Bindings({ a: DF.literal('c') })));
+      expect(AbstractFilterHash.hash(Bindings({ a: DF.literal('b') })))
+        .not.toEqual(AbstractFilterHash.hash(Bindings({ a: DF.namedNode('b') })));
     });
   });
 });

--- a/packages/actor-abstract-bindings-hash/test/AbstractFilterHash-test.ts
+++ b/packages/actor-abstract-bindings-hash/test/AbstractFilterHash-test.ts
@@ -31,7 +31,7 @@ describe('AbstractFilterHash', () => {
       }),
     };
     hashAlgorithm = 'sha1';
-    digestAlgorithm = 'base64';
+    digestAlgorithm = 'hex';
   });
 
   describe('The AbstractFilterHash module', () => {
@@ -73,8 +73,8 @@ describe('AbstractFilterHash', () => {
       return expect(AbstractFilterHash.doesHashAlgorithmExist('sha1')).toBeTruthy();
     });
 
-    it('should be true on md5', () => {
-      return expect(AbstractFilterHash.doesHashAlgorithmExist('md5')).toBeTruthy();
+    it('should be false on md5', () => {
+      return expect(AbstractFilterHash.doesHashAlgorithmExist('md5')).toBeFalsy();
     });
 
     it('should not be true on something that does not exist', () => {
@@ -84,16 +84,16 @@ describe('AbstractFilterHash', () => {
   });
 
   describe('#doesDigestAlgorithmExist', () => {
-    it('should be true on latin1', () => {
-      return expect(AbstractFilterHash.doesDigestAlgorithmExist('latin1')).toBeTruthy();
+    it('should be false on latin1', () => {
+      return expect(AbstractFilterHash.doesDigestAlgorithmExist('latin1')).toBeFalsy();
     });
 
     it('should be true on hex', () => {
       return expect(AbstractFilterHash.doesDigestAlgorithmExist('hex')).toBeTruthy();
     });
 
-    it('should be true on base64', () => {
-      return expect(AbstractFilterHash.doesDigestAlgorithmExist('base64')).toBeTruthy();
+    it('should be false on base64', () => {
+      return expect(AbstractFilterHash.doesDigestAlgorithmExist('base64')).toBeFalsy();
     });
 
     it('should not be true on something that does not exist', () => {
@@ -104,17 +104,17 @@ describe('AbstractFilterHash', () => {
 
   describe('#hash', () => {
     it('should return the same hash for equal objects', () => {
-      expect(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.literal('b') })))
-        .toEqual(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.literal('b') })));
-      expect(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.namedNode('c') })))
-        .toEqual(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.namedNode('c') })));
+      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })))
+        .toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })));
+      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.namedNode('c') })))
+        .toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.namedNode('c') })));
     });
 
     it('should return a different hash for non-equal objects', () => {
-      expect(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.literal('b') })))
-        .not.toEqual(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.literal('c') })));
-      expect(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.literal('b') })))
-        .not.toEqual(AbstractFilterHash.hash('sha1', 'base64', Bindings({ a: DF.namedNode('b') })));
+      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })))
+        .not.toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('c') })));
+      expect(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.literal('b') })))
+        .not.toEqual(AbstractFilterHash.hash('sha1', 'hex', Bindings({ a: DF.namedNode('b') })));
     });
   });
 });

--- a/packages/actor-query-operation-distinct-hash/README.md
+++ b/packages/actor-query-operation-distinct-hash/README.md
@@ -39,5 +39,3 @@ After installing, this package can be added to your engine's configuration as fo
 ### Config Parameters
 
 * `cbqo:mediatorQueryOperation`: A mediator over the [Query Operation bus](https://github.com/comunica/comunica/tree/master/packages/bus-query-operation).
-* `caabh:Actor/AbstractFilterHash/hashAlgorithm`: An optional hash algorithm, defaults to `sha1`.
-* `caabh:Actor/AbstractFilterHash/digestAlgorithm`: An optional hash algorithm, defaults to `base64`.

--- a/packages/actor-query-operation-distinct-hash/components/Actor/QueryOperation/DistinctHash.jsonld
+++ b/packages/actor-query-operation-distinct-hash/components/Actor/QueryOperation/DistinctHash.jsonld
@@ -24,7 +24,7 @@
           "@id": "caabh:Actor/AbstractFilterHash/digestAlgorithm",
           "defaultScoped": {
             "defaultScope": "caqodh:Actor/QueryOperation/DistinctHash",
-            "defaultScopedValue": "base64"
+            "defaultScopedValue": "hex"
           }
         }
       ],

--- a/packages/actor-query-operation-distinct-hash/components/Actor/QueryOperation/DistinctHash.jsonld
+++ b/packages/actor-query-operation-distinct-hash/components/Actor/QueryOperation/DistinctHash.jsonld
@@ -12,22 +12,7 @@
       "extends": "caabh:Actor/AbstractFilterHash",
       "requireElement": "ActorQueryOperationDistinctHash",
       "comment": "A comunica Distinct Hash Query Operation Actor.",
-      "parameters": [
-        {
-          "@id": "caabh:Actor/AbstractFilterHash/hashAlgorithm",
-          "defaultScoped": {
-            "defaultScope": "caqodh:Actor/QueryOperation/DistinctHash",
-            "defaultScopedValue": "sha1"
-          }
-        },
-        {
-          "@id": "caabh:Actor/AbstractFilterHash/digestAlgorithm",
-          "defaultScoped": {
-            "defaultScope": "caqodh:Actor/QueryOperation/DistinctHash",
-            "defaultScopedValue": "hex"
-          }
-        }
-      ],
+      "parameters": [],
       "constructorArguments": [
         {
           "extends": "caabh:Actor/AbstractFilterHash/constructorArgumentsObject"

--- a/packages/actor-query-operation-distinct-hash/lib/ActorQueryOperationDistinctHash.ts
+++ b/packages/actor-query-operation-distinct-hash/lib/ActorQueryOperationDistinctHash.ts
@@ -15,14 +15,12 @@ export class ActorQueryOperationDistinctHash extends AbstractBindingsHash<Algebr
   /**
      * Create a new distinct filter function for the given hash algorithm and digest algorithm.
      * This will maintain an internal hash datastructure so that every bindings object only returns true once.
-     * @param {string} hashAlgorithm A hash algorithm.
-     * @param {string} digestAlgorithm A digest algorithm.
      * @return {(bindings: Bindings) => boolean} A distinct filter for bindings.
      */
-  public newHashFilter(hashAlgorithm: string, digestAlgorithm: string): (bindings: Bindings) => boolean {
+  public newHashFilter(): (bindings: Bindings) => boolean {
     const hashes: Record<string, boolean> = {};
     return (bindings: Bindings) => {
-      const hash: string = AbstractFilterHash.hash(hashAlgorithm, digestAlgorithm, bindings);
+      const hash: string = AbstractFilterHash.hash(bindings);
       // eslint-disable-next-line no-return-assign
       return !(hash in hashes) && (hashes[hash] = true);
     };

--- a/packages/actor-query-operation-distinct-hash/test/ActorQueryOperationDistinctHash-test.ts
+++ b/packages/actor-query-operation-distinct-hash/test/ActorQueryOperationDistinctHash-test.ts
@@ -31,7 +31,7 @@ describe('ActorQueryOperationDistinctHash', () => {
       }),
     };
     hashAlgorithm = 'sha1';
-    digestAlgorithm = 'base64';
+    digestAlgorithm = 'hex';
   });
 
   describe('#newDistinctHashFilter', () => {
@@ -43,17 +43,17 @@ describe('ActorQueryOperationDistinctHash', () => {
       );
     });
     it('should create a filter', () => {
-      return expect(actor.newHashFilter('sha1', 'base64'))
+      return expect(actor.newHashFilter('sha1', 'hex'))
         .toBeInstanceOf(Function);
     });
 
     it('should create a filter that is a predicate', () => {
-      const filter = actor.newHashFilter('sha1', 'base64');
+      const filter = actor.newHashFilter('sha1', 'hex');
       return expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
     });
 
     it('should create a filter that only returns true once for equal objects', () => {
-      const filter = actor.newHashFilter('sha1', 'base64');
+      const filter = actor.newHashFilter('sha1', 'hex');
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
@@ -66,9 +66,9 @@ describe('ActorQueryOperationDistinctHash', () => {
     });
 
     it('should create a filters that are independent', () => {
-      const filter1 = actor.newHashFilter('sha1', 'base64');
-      const filter2 = actor.newHashFilter('sha1', 'base64');
-      const filter3 = actor.newHashFilter('sha1', 'base64');
+      const filter1 = actor.newHashFilter('sha1', 'hex');
+      const filter2 = actor.newHashFilter('sha1', 'hex');
+      const filter3 = actor.newHashFilter('sha1', 'hex');
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(true);
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(false);
 

--- a/packages/actor-query-operation-distinct-hash/test/ActorQueryOperationDistinctHash-test.ts
+++ b/packages/actor-query-operation-distinct-hash/test/ActorQueryOperationDistinctHash-test.ts
@@ -10,8 +10,6 @@ const DF = new DataFactory();
 describe('ActorQueryOperationDistinctHash', () => {
   let bus: any;
   let mediatorQueryOperation: any;
-  let hashAlgorithm: any;
-  let digestAlgorithm: any;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
@@ -30,8 +28,6 @@ describe('ActorQueryOperationDistinctHash', () => {
         variables: [ 'a' ],
       }),
     };
-    hashAlgorithm = 'sha1';
-    digestAlgorithm = 'hex';
   });
 
   describe('#newDistinctHashFilter', () => {
@@ -39,21 +35,21 @@ describe('ActorQueryOperationDistinctHash', () => {
 
     beforeEach(() => {
       actor = new ActorQueryOperationDistinctHash(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm },
+        { name: 'actor', bus, mediatorQueryOperation },
       );
     });
     it('should create a filter', () => {
-      return expect(actor.newHashFilter('sha1', 'hex'))
+      return expect(actor.newHashFilter())
         .toBeInstanceOf(Function);
     });
 
     it('should create a filter that is a predicate', () => {
-      const filter = actor.newHashFilter('sha1', 'hex');
+      const filter = actor.newHashFilter();
       return expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
     });
 
     it('should create a filter that only returns true once for equal objects', () => {
-      const filter = actor.newHashFilter('sha1', 'hex');
+      const filter = actor.newHashFilter();
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
@@ -66,9 +62,9 @@ describe('ActorQueryOperationDistinctHash', () => {
     });
 
     it('should create a filters that are independent', () => {
-      const filter1 = actor.newHashFilter('sha1', 'hex');
-      const filter2 = actor.newHashFilter('sha1', 'hex');
-      const filter3 = actor.newHashFilter('sha1', 'hex');
+      const filter1 = actor.newHashFilter();
+      const filter2 = actor.newHashFilter();
+      const filter3 = actor.newHashFilter();
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(true);
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(false);
 
@@ -84,7 +80,7 @@ describe('ActorQueryOperationDistinctHash', () => {
     let actor: ActorQueryOperationDistinctHash;
     beforeEach(() => {
       actor = new ActorQueryOperationDistinctHash(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm },
+        { name: 'actor', bus, mediatorQueryOperation },
       );
     });
 

--- a/packages/actor-query-operation-group/lib/GroupsState.ts
+++ b/packages/actor-query-operation-group/lib/GroupsState.ts
@@ -135,6 +135,6 @@ export class GroupsState {
    * @param {Bindings} bindings - Bindings to hash
    */
   private hashBindings(bindings: Bindings): BindingsHash {
-    return AbstractFilterHash.hash('sha1', 'hex', bindings);
+    return AbstractFilterHash.hash(bindings);
   }
 }

--- a/packages/actor-query-operation-reduced-hash/README.md
+++ b/packages/actor-query-operation-reduced-hash/README.md
@@ -39,6 +39,4 @@ After installing, this package can be added to your engine's configuration as fo
 ### Config Parameters
 
 * `cbqo:mediatorQueryOperation`: A mediator over the [Query Operation bus](https://github.com/comunica/comunica/tree/master/packages/bus-query-operation).
-* `caabh:Actor/AbstractFilterHash/hashAlgorithm`: An optional hash algorithm, defaults to `sha1`.
-* `caabh:Actor/AbstractFilterHash/digestAlgorithm`: An optional hash algorithm, defaults to `base64`.
 * `caqorh:Actor/QueryOperation/ReducedHash/cacheSize`: An optional cache size, defaults to `100`.

--- a/packages/actor-query-operation-reduced-hash/components/Actor/QueryOperation/ReducedHash.jsonld
+++ b/packages/actor-query-operation-reduced-hash/components/Actor/QueryOperation/ReducedHash.jsonld
@@ -14,20 +14,6 @@
       "comment": "A comunica Reduced Hash Query Operation Actor.",
       "parameters": [
         {
-          "@id": "caabh:Actor/AbstractFilterHash/hashAlgorithm",
-          "defaultScoped": {
-            "defaultScope": "caqorh:Actor/QueryOperation/ReducedHash",
-            "defaultScopedValue": "sha1"
-          }
-        },
-        {
-          "@id": "caabh:Actor/AbstractFilterHash/digestAlgorithm",
-          "defaultScoped": {
-            "defaultScope": "caqorh:Actor/QueryOperation/ReducedHash",
-            "defaultScopedValue": "hex"
-          }
-        },
-        {
           "@id": "caqorh:Actor/QueryOperation/ReducedHash/cacheSize",
           "range": "xsd:integer",
           "required": true,
@@ -39,14 +25,6 @@
         {
           "extends": "caabh:Actor/AbstractFilterHash/constructorArgumentsObject",
           "fields": [
-            {
-              "keyRaw": "hashAlgorithm",
-              "value": "caabh:Actor/AbstractFilterHash/hashAlgorithm"
-            },
-            {
-              "keyRaw": "digestAlgorithm",
-              "value": "caabh:Actor/AbstractFilterHash/digestAlgorithm"
-            },
             {
               "keyRaw": "cacheSize",
               "value": "caqorh:Actor/QueryOperation/ReducedHash/cacheSize"

--- a/packages/actor-query-operation-reduced-hash/components/Actor/QueryOperation/ReducedHash.jsonld
+++ b/packages/actor-query-operation-reduced-hash/components/Actor/QueryOperation/ReducedHash.jsonld
@@ -24,7 +24,7 @@
           "@id": "caabh:Actor/AbstractFilterHash/digestAlgorithm",
           "defaultScoped": {
             "defaultScope": "caqorh:Actor/QueryOperation/ReducedHash",
-            "defaultScopedValue": "base64"
+            "defaultScopedValue": "hex"
           }
         },
         {

--- a/packages/actor-query-operation-reduced-hash/lib/ActorQueryOperationReducedHash.ts
+++ b/packages/actor-query-operation-reduced-hash/lib/ActorQueryOperationReducedHash.ts
@@ -17,21 +17,17 @@ export class ActorQueryOperationReducedHash extends AbstractBindingsHash<Algebra
   /**
    * Create a new distinct filter function for the given hash algorithm and digest algorithm.
    * This will maintain an internal hash datastructure so that every bindings object only returns true once.
-   * @param {string} hashAlgorithm A hash algorithm.
-   * @param {string} digestAlgorithm A digest algorithm.
    * @return {(bindings: Bindings) => boolean} A distinct filter for bindings.
    */
-  public newHashFilter(hashAlgorithm: string, digestAlgorithm: string): (bindings: Bindings) => boolean {
+  public newHashFilter(): (bindings: Bindings) => boolean {
     const hashes = new LRU<string, boolean>({ max: this.cacheSize });
     return (bindings: Bindings) => {
-      const hash: string = AbstractFilterHash.hash(hashAlgorithm, digestAlgorithm, bindings);
+      const hash: string = AbstractFilterHash.hash(bindings);
       return !hashes.has(hash) && hashes.set(hash, true);
     };
   }
 }
 
 export interface IActorInitRdfBindingHashArgs extends IActorInitRdfDereferencePagedArgs {
-  hashAlgorithm: string;
-  digestAlgorithm: string;
   cacheSize: number;
 }

--- a/packages/actor-query-operation-reduced-hash/test/ActorQueryOperationReducedHash-test.ts
+++ b/packages/actor-query-operation-reduced-hash/test/ActorQueryOperationReducedHash-test.ts
@@ -32,7 +32,7 @@ describe('ActorQueryOperationReducedHash', () => {
       }),
     };
     hashAlgorithm = 'sha1';
-    digestAlgorithm = 'base64';
+    digestAlgorithm = 'hex';
     cacheSize = 20;
   });
 
@@ -45,17 +45,17 @@ describe('ActorQueryOperationReducedHash', () => {
       );
     });
     it('should create a filter', () => {
-      return expect(actor.newHashFilter('sha1', 'base64'))
+      return expect(actor.newHashFilter('sha1', 'hex'))
         .toBeInstanceOf(Function);
     });
 
     it('should create a filter that is a predicate', () => {
-      const filter = actor.newHashFilter('sha1', 'base64');
+      const filter = actor.newHashFilter('sha1', 'hex');
       return expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
     });
 
     it('should create a filter that only returns true once for equal objects', () => {
-      const filter = actor.newHashFilter('sha1', 'base64');
+      const filter = actor.newHashFilter('sha1', 'hex');
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
@@ -68,9 +68,9 @@ describe('ActorQueryOperationReducedHash', () => {
     });
 
     it('should create a filters that are independent', () => {
-      const filter1 = actor.newHashFilter('sha1', 'base64');
-      const filter2 = actor.newHashFilter('sha1', 'base64');
-      const filter3 = actor.newHashFilter('sha1', 'base64');
+      const filter1 = actor.newHashFilter('sha1', 'hex');
+      const filter2 = actor.newHashFilter('sha1', 'hex');
+      const filter3 = actor.newHashFilter('sha1', 'hex');
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(true);
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(false);
 
@@ -129,7 +129,7 @@ describe('Smaller cache than number of queries', () => {
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     hashAlgorithm = 'sha1';
-    digestAlgorithm = 'base64';
+    digestAlgorithm = 'hex';
     cacheSize = 1;
     mediatorQueryOperation = {
       mediate: (arg: any) => Promise.resolve({

--- a/packages/actor-query-operation-reduced-hash/test/ActorQueryOperationReducedHash-test.ts
+++ b/packages/actor-query-operation-reduced-hash/test/ActorQueryOperationReducedHash-test.ts
@@ -10,8 +10,6 @@ const DF = new DataFactory();
 describe('ActorQueryOperationReducedHash', () => {
   let bus: any;
   let mediatorQueryOperation: any;
-  let hashAlgorithm: any;
-  let digestAlgorithm: any;
   let cacheSize: any;
 
   beforeEach(() => {
@@ -31,8 +29,6 @@ describe('ActorQueryOperationReducedHash', () => {
         variables: [ 'a' ],
       }),
     };
-    hashAlgorithm = 'sha1';
-    digestAlgorithm = 'hex';
     cacheSize = 20;
   });
 
@@ -41,21 +37,21 @@ describe('ActorQueryOperationReducedHash', () => {
 
     beforeEach(() => {
       actor = new ActorQueryOperationReducedHash(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm, cacheSize },
+        { name: 'actor', bus, mediatorQueryOperation, cacheSize },
       );
     });
     it('should create a filter', () => {
-      return expect(actor.newHashFilter('sha1', 'hex'))
+      return expect(actor.newHashFilter())
         .toBeInstanceOf(Function);
     });
 
     it('should create a filter that is a predicate', () => {
-      const filter = actor.newHashFilter('sha1', 'hex');
+      const filter = actor.newHashFilter();
       return expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
     });
 
     it('should create a filter that only returns true once for equal objects', () => {
-      const filter = actor.newHashFilter('sha1', 'hex');
+      const filter = actor.newHashFilter();
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(true);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
       expect(filter(Bindings({ a: DF.literal('a') }))).toBe(false);
@@ -68,9 +64,9 @@ describe('ActorQueryOperationReducedHash', () => {
     });
 
     it('should create a filters that are independent', () => {
-      const filter1 = actor.newHashFilter('sha1', 'hex');
-      const filter2 = actor.newHashFilter('sha1', 'hex');
-      const filter3 = actor.newHashFilter('sha1', 'hex');
+      const filter1 = actor.newHashFilter();
+      const filter2 = actor.newHashFilter();
+      const filter3 = actor.newHashFilter();
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(true);
       expect(filter1(Bindings({ a: DF.literal('b') }))).toBe(false);
 
@@ -87,7 +83,7 @@ describe('ActorQueryOperationReducedHash', () => {
 
     beforeEach(() => {
       actor = new ActorQueryOperationReducedHash(
-        { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm, cacheSize },
+        { name: 'actor', bus, mediatorQueryOperation, cacheSize },
       );
     });
 
@@ -122,14 +118,10 @@ describe('Smaller cache than number of queries', () => {
   let actor: ActorQueryOperationReducedHash;
   let bus: any;
   let mediatorQueryOperation: any;
-  let hashAlgorithm: any;
-  let digestAlgorithm: any;
   let cacheSize: any;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
-    hashAlgorithm = 'sha1';
-    digestAlgorithm = 'hex';
     cacheSize = 1;
     mediatorQueryOperation = {
       mediate: (arg: any) => Promise.resolve({
@@ -149,7 +141,7 @@ describe('Smaller cache than number of queries', () => {
       }),
     };
     actor = new ActorQueryOperationReducedHash(
-      { name: 'actor', bus, mediatorQueryOperation, hashAlgorithm, digestAlgorithm, cacheSize },
+      { name: 'actor', bus, mediatorQueryOperation, cacheSize },
     );
   });
   it('should run', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,6 +2587,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/rusha@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@types/rusha/-/rusha-0.8.0.tgz#5d5c364560c1676fc225f9c7ee0170930e64cc41"
+  integrity sha512-t+rdR1Ptj6/gIUBW4wVDjUj29sE9Sd5TnHCQhbMiFAdeuh9niJuEMuVd4X+rxyfNEqkF+X4vfiAMxrjQgG2klg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/sax@^1.0.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.1.tgz#e0248be936ece791a82db1a57f3fb5f7c87e8172"
@@ -11039,6 +11046,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rusha@^0.8.13:
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/rusha/-/rusha-0.8.13.tgz#9a084e7b860b17bff3015b92c67a6a336191513a"
+  integrity sha1-mghOe4YLF7/zAVuSxnpqM2GRUTo=
 
 rxjs@^6.4.0, rxjs@^6.6.0:
   version "6.6.3"


### PR DESCRIPTION
This PR, which is still a WIP, introduces pure-js implementations of 

- `actor-query-operation-reduced-hash` (`actor-query-operation-reduced-purejs-hash`)
- `actor-query-operation-distinct-hash` (`actor-query-operation-distinct-purejs-hash`)
- `actor-abstract-bindings-hash` (`and actor-abstract-bindings-purejs-hash`)

The motivation behind this PR is that the `actor-abstract-bindings-hash` causes Webpack to shim the entire `crypto` module, which is not available in browsers, as it allows to use any hash that is available in Node.js. This leads to browser-side having a ton of crypto-related code for no good reason, given that everything seems to be using the default hash algorithm `sha1`. See the attached screenshot of Webpack's bundle analyzer.

I've worked on this after talking about it with @rubensworks on Gitter. I sort of rushed into a solution while it could have done with a few more exchanges but I'm going to have limited time next week and I have wanted to get my hands on Comunica for a while. Hopefully this stands a chance of being merged but even if it doesn't, it was well worth the time. ~~All tests are passing~~ but this is my first PR to Comunica and also my first time working with dependency injection in JS-land and with a RDF-based framework: there's no way I can get it right on the first try. I look forward to your feedback!

EDIT: actually no, not all tests are passing. All `yarn run test` tests are passing, yes, but [Travis points out that other tests are not passing](https://travis-ci.org/github/comunica/comunica/jobs/738779252). I'll try to figure out what's going over the next few days... 

As for the choice of which library to use for the pre-js operators, [rusha](https://www.npmjs.com/package/rusha) seemed to be a good compromise between size (no dependencies), speed (it is said to be one of the faster implementations of `sha1` in pure Javascript) and the fact that it implements the algorithm that is used by default in the crypto-based, already-present operators. We could also add `md5` as an alternative via [spark-md5](https://www.npmjs.com/package/spark-md5). 

I've defaulted to `hex` as the digest algorithm instead of `base64` because most pure-js libraries seem to only support `hex` and `ArrayBuffer` (I have not investigated why).

![Screen Shot 2020-10-23 at 22 56 08](https://user-images.githubusercontent.com/3322119/97116077-16335f80-16fb-11eb-9943-a53265c169d3.png)
