### PR TITLE
Fix blank node correlation (closes #795)

### DIFF
--- a/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
+++ b/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
@@ -75,9 +75,6 @@ export class BindingsToQuadsIterator extends MultiTransformIterator<Bindings, RD
   public static localizeBlankNode(blankNodeCounter: number,
     term: RDF.Term): RDF.Term {
     if (term.termType === 'BlankNode') {
-      if (term instanceof BlankNodeBindingsScoped) {
-        return new BlankNodeBindingsScoped(`${term.value}${blankNodeCounter}`);
-      }
       return DF.blankNode(`${term.value}${blankNodeCounter}`);
     }
     return term;

--- a/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
+++ b/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
@@ -1,4 +1,3 @@
-import { BlankNodeBindingsScoped } from '@comunica/data-factory';
 import type { Bindings, BindingsStream } from '@comunica/types';
 import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator, MultiTransformIterator } from 'asynciterator';

--- a/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
+++ b/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
@@ -1,10 +1,10 @@
+import { BlankNodeBindingsScoped } from '@comunica/data-factory';
 import type { Bindings, BindingsStream } from '@comunica/types';
 import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator, MultiTransformIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import type * as RDF from 'rdf-js';
 import { mapTerms } from 'rdf-terms';
-import {BlankNodeBindingsScoped} from '@comunica/data-factory';
 const DF = new DataFactory();
 
 /**

--- a/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
+++ b/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
@@ -4,6 +4,7 @@ import { ArrayIterator, MultiTransformIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import type * as RDF from 'rdf-js';
 import { mapTerms } from 'rdf-terms';
+import {BlankNodeBindingsScoped} from '@comunica/data-factory';
 const DF = new DataFactory();
 
 /**
@@ -74,6 +75,9 @@ export class BindingsToQuadsIterator extends MultiTransformIterator<Bindings, RD
   public static localizeBlankNode(blankNodeCounter: number,
     term: RDF.Term): RDF.Term {
     if (term.termType === 'BlankNode') {
+      if ((<RDF.BlankNode & { singleBindingsScope?: boolean }>term).singleBindingsScope) {
+        return new BlankNodeBindingsScoped(`${term.value}${blankNodeCounter}`);
+      }
       return DF.blankNode(`${term.value}${blankNodeCounter}`);
     }
     return term;

--- a/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
+++ b/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
@@ -75,7 +75,7 @@ export class BindingsToQuadsIterator extends MultiTransformIterator<Bindings, RD
   public static localizeBlankNode(blankNodeCounter: number,
     term: RDF.Term): RDF.Term {
     if (term.termType === 'BlankNode') {
-      if ((<RDF.BlankNode & { singleBindingsScope?: boolean }>term).singleBindingsScope) {
+      if (term instanceof BlankNodeBindingsScoped) {
         return new BlankNodeBindingsScoped(`${term.value}${blankNodeCounter}`);
       }
       return DF.blankNode(`${term.value}${blankNodeCounter}`);

--- a/packages/actor-query-operation-construct/package.json
+++ b/packages/actor-query-operation-construct/package.json
@@ -32,6 +32,7 @@
     "index.js"
   ],
   "dependencies": {
+    "@comunica/data-factory": "1.17.0",
     "@comunica/types": "^1.19.2",
     "@types/rdf-js": "*",
     "asynciterator": "^3.0.3",

--- a/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
+++ b/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
@@ -1,9 +1,10 @@
 import { Bindings } from '@comunica/bus-query-operation';
+import { BlankNodeBindingsScoped } from '@comunica/data-factory';
 import { ArrayIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 
 import { BindingsToQuadsIterator } from '../lib/BindingsToQuadsIterator';
-import {BlankNodeBindingsScoped} from '@comunica/data-factory';
+
 const DF = new DataFactory();
 
 const arrayifyStream = require('arrayify-stream');

--- a/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
+++ b/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
@@ -3,6 +3,7 @@ import { ArrayIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 
 import { BindingsToQuadsIterator } from '../lib/BindingsToQuadsIterator';
+import {BlankNodeBindingsScoped} from '@comunica/data-factory';
 const DF = new DataFactory();
 
 const arrayifyStream = require('arrayify-stream');
@@ -277,6 +278,11 @@ describe('BindingsToQuadsIterator', () => {
         .toEqual(DF.blankNode('abc1'));
       expect(BindingsToQuadsIterator.localizeBlankNode(1, DF.blankNode('abc')))
         .toEqual(DF.blankNode('abc1'));
+    });
+
+    it('should localize a blank node scoped to a single set of bindings', () => {
+      expect(BindingsToQuadsIterator.localizeBlankNode(0, new BlankNodeBindingsScoped('abc')))
+        .toEqual(new BlankNodeBindingsScoped('abc0'));
     });
   });
 

--- a/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
+++ b/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
@@ -283,7 +283,7 @@ describe('BindingsToQuadsIterator', () => {
 
     it('should localize a blank node scoped to a single set of bindings', () => {
       expect(BindingsToQuadsIterator.localizeBlankNode(0, new BlankNodeBindingsScoped('abc')))
-        .toEqual(new BlankNodeBindingsScoped('abc0'));
+        .toEqual(DF.blankNode('abc0'));
     });
   });
 

--- a/packages/actor-query-operation-extend/lib/ActorQueryOperationExtend.ts
+++ b/packages/actor-query-operation-extend/lib/ActorQueryOperationExtend.ts
@@ -33,7 +33,7 @@ export class ActorQueryOperationExtend extends ActorQueryOperationTypedMediated<
     );
 
     const extendKey = termToString(variable);
-    const config = { ...ActorQueryOperation.getExpressionContext(context, this.mediatorQueryOperation) };
+    const config = { ...ActorQueryOperation.getAsyncExpressionContext(context, this.mediatorQueryOperation) };
     const evaluator = new AsyncEvaluator(expression, config);
 
     // Transform the stream by extending each Bindings with the expression result

--- a/packages/actor-query-operation-extend/package.json
+++ b/packages/actor-query-operation-extend/package.json
@@ -35,7 +35,7 @@
     "@comunica/types": "^1.19.2",
     "rdf-string": "^1.5.0",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.1"
+    "sparqlee": "^1.6.2"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.4.0",

--- a/packages/actor-query-operation-extend/package.json
+++ b/packages/actor-query-operation-extend/package.json
@@ -35,7 +35,7 @@
     "@comunica/types": "^1.19.2",
     "rdf-string": "^1.5.0",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.0"
+    "sparqlee": "^1.6.1"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.4.0",

--- a/packages/actor-query-operation-filter-sparqlee/lib/ActorQueryOperationFilterSparqlee.ts
+++ b/packages/actor-query-operation-filter-sparqlee/lib/ActorQueryOperationFilterSparqlee.ts
@@ -18,8 +18,8 @@ export class ActorQueryOperationFilterSparqlee extends ActorQueryOperationTypedM
 
   public async testOperation(pattern: Algebra.Filter, context: ActionContext): Promise<IActorTest> {
     // Will throw error for unsupported operators
-    const _ = new AsyncEvaluator(pattern.expression,
-      ActorQueryOperation.getExpressionContext(context, this.mediatorQueryOperation));
+    const config = { ...ActorQueryOperation.getAsyncExpressionContext(context, this.mediatorQueryOperation) };
+    const _ = new AsyncEvaluator(pattern.expression, config);
     return true;
   }
 
@@ -30,7 +30,7 @@ export class ActorQueryOperationFilterSparqlee extends ActorQueryOperationTypedM
     ActorQueryOperation.validateQueryOutput(output, 'bindings');
     const { variables, metadata } = output;
 
-    const config = ActorQueryOperation.getExpressionContext(context, this.mediatorQueryOperation);
+    const config = { ...ActorQueryOperation.getAsyncExpressionContext(context, this.mediatorQueryOperation) };
     const evaluator = new AsyncEvaluator(pattern.expression, config);
 
     const transform = async(item: Bindings, next: any, push: (bindings: Bindings) => void): Promise<void> => {

--- a/packages/actor-query-operation-filter-sparqlee/package.json
+++ b/packages/actor-query-operation-filter-sparqlee/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/types": "^1.19.2",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.0"
+    "sparqlee": "^1.6.1"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.4.0",

--- a/packages/actor-query-operation-filter-sparqlee/package.json
+++ b/packages/actor-query-operation-filter-sparqlee/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/types": "^1.19.2",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.1"
+    "sparqlee": "^1.6.2"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.4.0",

--- a/packages/actor-query-operation-group/package.json
+++ b/packages/actor-query-operation-group/package.json
@@ -37,7 +37,7 @@
     "asynciterator": "^3.0.3",
     "rdf-string": "^1.5.0",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.1"
+    "sparqlee": "^1.6.2"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.6.0",

--- a/packages/actor-query-operation-group/package.json
+++ b/packages/actor-query-operation-group/package.json
@@ -37,7 +37,7 @@
     "asynciterator": "^3.0.3",
     "rdf-string": "^1.5.0",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.0"
+    "sparqlee": "^1.6.1"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.6.0",

--- a/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
@@ -29,7 +29,7 @@ export class ActorQueryOperationLeftJoinNestedLoop extends ActorQueryOperationTy
     const right = ActorQueryOperation.getSafeBindings(rightRaw);
 
     // TODO: refactor custom handling of pattern.expression. Should be pushed on the bus instead as a filter operation.
-    const config = { ...ActorQueryOperation.getExpressionContext(context) };
+    const config = { ...ActorQueryOperation.getAsyncExpressionContext(context) };
     const evaluator = pattern.expression ?
       new AsyncEvaluator(pattern.expression, config) :
       null;

--- a/packages/actor-query-operation-leftjoin-nestedloop/package.json
+++ b/packages/actor-query-operation-leftjoin-nestedloop/package.json
@@ -36,7 +36,7 @@
     "@comunica/types": "^1.19.2",
     "asynciterator": "^3.0.3",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.1"
+    "sparqlee": "^1.6.2"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-leftjoin-nestedloop/package.json
+++ b/packages/actor-query-operation-leftjoin-nestedloop/package.json
@@ -36,7 +36,7 @@
     "@comunica/types": "^1.19.2",
     "asynciterator": "^3.0.3",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.0"
+    "sparqlee": "^1.6.1"
   },
   "peerDependencies": {
     "@comunica/bus-query-operation": "^1.0.0",

--- a/packages/actor-query-operation-orderby-sparqlee/lib/ActorQueryOperationOrderBySparqlee.ts
+++ b/packages/actor-query-operation-orderby-sparqlee/lib/ActorQueryOperationOrderBySparqlee.ts
@@ -36,7 +36,7 @@ export class ActorQueryOperationOrderBySparqlee extends ActorQueryOperationTyped
     const output = ActorQueryOperation.getSafeBindings(outputRaw);
 
     const options = { window: this.window };
-    const sparqleeConfig = { ...ActorQueryOperation.getExpressionContext(context) };
+    const sparqleeConfig = { ...ActorQueryOperation.getAsyncExpressionContext(context) };
     let { bindingsStream } = output;
 
     // Sorting backwards since the first one is the most important therefore should be ordered last.

--- a/packages/actor-query-operation-orderby-sparqlee/package.json
+++ b/packages/actor-query-operation-orderby-sparqlee/package.json
@@ -41,7 +41,7 @@
     "asynciterator": "^3.0.3",
     "rdf-string": "^1.5.0",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.1"
+    "sparqlee": "^1.6.2"
   },
   "devDependencies": {
     "@comunica/actor-query-operation-filter-direct": "^1.19.2",

--- a/packages/actor-query-operation-orderby-sparqlee/package.json
+++ b/packages/actor-query-operation-orderby-sparqlee/package.json
@@ -41,7 +41,7 @@
     "asynciterator": "^3.0.3",
     "rdf-string": "^1.5.0",
     "sparqlalgebrajs": "^2.4.0",
-    "sparqlee": "^1.6.0"
+    "sparqlee": "^1.6.1"
   },
   "devDependencies": {
     "@comunica/actor-query-operation-filter-direct": "^1.19.2",

--- a/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
+++ b/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
@@ -1,9 +1,10 @@
 import type { IActorQueryOperationTypedMediatedArgs } from '@comunica/bus-query-operation';
 import { ActorQueryOperation, ActorQueryOperationTypedMediated } from '@comunica/bus-query-operation';
 import type { ActionContext, IActorTest } from '@comunica/core';
-import { BlankNodeScoped } from '@comunica/data-factory';
+import { BlankNodeBindingsScoped, BlankNodeScoped } from '@comunica/data-factory';
 import type { Bindings, BindingsStream, IActorQueryOperationOutputBindings } from '@comunica/types';
-import { DataFactory } from 'rdf-data-factory';
+import {BlankNode, DataFactory} from 'rdf-data-factory';
+import type * as RDF from 'rdf-js';
 import { termToString } from 'rdf-string';
 import type { Algebra } from 'sparqlalgebrajs';
 const DF = new DataFactory();
@@ -57,12 +58,16 @@ export class ActorQueryOperationProject extends ActorQueryOperationTypedMediated
     bindingsStream = bindingsStream.transform({
       map(bindings: Bindings) {
         blankNodeCounter++;
+        const scopedBlankNodesCache = new Map<string, RDF.BlankNode>();
         return <Bindings> bindings.map(term => {
-          if (term && term.termType === 'BlankNode') {
-            if (term instanceof BlankNodeScoped) {
-              return new BlankNodeScoped(`${term.value}${blankNodeCounter}`, term.skolemized);
+          if (term && term.termType === 'BlankNode' &&
+          (<RDF.BlankNode & { singleBindingsScope?: boolean }>term).singleBindingsScope) {
+            let scopedBlankNode = scopedBlankNodesCache.get(term.value);
+            if (!scopedBlankNode) {
+              scopedBlankNode = DF.blankNode(`${term.value}${blankNodeCounter}`);
+              scopedBlankNodesCache.set(term.value, scopedBlankNode);
             }
-            return DF.blankNode(`${term.value}${blankNodeCounter}`);
+            return scopedBlankNode;
           }
           return term;
         });

--- a/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
+++ b/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
@@ -1,6 +1,7 @@
 import type { IActorQueryOperationTypedMediatedArgs } from '@comunica/bus-query-operation';
 import { ActorQueryOperation, ActorQueryOperationTypedMediated } from '@comunica/bus-query-operation';
 import type { ActionContext, IActorTest } from '@comunica/core';
+import { BlankNodeBindingsScoped } from '@comunica/data-factory';
 import type { Bindings, BindingsStream, IActorQueryOperationOutputBindings } from '@comunica/types';
 import { DataFactory } from 'rdf-data-factory';
 import type * as RDF from 'rdf-js';
@@ -59,8 +60,7 @@ export class ActorQueryOperationProject extends ActorQueryOperationTypedMediated
         blankNodeCounter++;
         const scopedBlankNodesCache = new Map<string, RDF.BlankNode>();
         return <Bindings> bindings.map(term => {
-          if (term && term.termType === 'BlankNode' &&
-          (<RDF.BlankNode & { singleBindingsScope?: boolean }>term).singleBindingsScope) {
+          if (term instanceof BlankNodeBindingsScoped) {
             let scopedBlankNode = scopedBlankNodesCache.get(term.value);
             if (!scopedBlankNode) {
               scopedBlankNode = DF.blankNode(`${term.value}${blankNodeCounter}`);

--- a/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
+++ b/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
@@ -1,9 +1,8 @@
 import type { IActorQueryOperationTypedMediatedArgs } from '@comunica/bus-query-operation';
 import { ActorQueryOperation, ActorQueryOperationTypedMediated } from '@comunica/bus-query-operation';
 import type { ActionContext, IActorTest } from '@comunica/core';
-import { BlankNodeBindingsScoped, BlankNodeScoped } from '@comunica/data-factory';
 import type { Bindings, BindingsStream, IActorQueryOperationOutputBindings } from '@comunica/types';
-import {BlankNode, DataFactory} from 'rdf-data-factory';
+import { DataFactory } from 'rdf-data-factory';
 import type * as RDF from 'rdf-js';
 import { termToString } from 'rdf-string';
 import type { Algebra } from 'sparqlalgebrajs';

--- a/packages/actor-query-operation-project/test/ActorQueryOperationProject-test.ts
+++ b/packages/actor-query-operation-project/test/ActorQueryOperationProject-test.ts
@@ -143,5 +143,32 @@ describe('ActorQueryOperationProject', () => {
         ]);
       });
     });
+
+    it('should run on a stream with equal scoped blank nodes across bindings', () => {
+      mediatorQueryOperation.mediate = (arg: any) => Promise.resolve({
+        bindingsStream: new ArrayIterator([
+          Bindings({ '?a': new BlankNodeScoped('a', DF.namedNode('A')), '?b': DF.literal('b') }),
+          Bindings({ '?a': new BlankNodeScoped('a', DF.namedNode('B')), '?b': DF.literal('b') }),
+          Bindings({ '?a': new BlankNodeScoped('a', DF.namedNode('C')), '?b': DF.literal('b') }),
+        ]),
+        metadata: () => 'M',
+        operated: arg,
+        type: 'bindings',
+        variables: [ '?a' ],
+        canContainUndefs: true,
+      });
+      const op = { operation: { type: 'project', input: 'in', variables: [ DF.variable('a') ]}};
+      return actor.run(op).then(async(output: IActorQueryOperationOutputBindings) => {
+        expect((<any> output).metadata()).toEqual('M');
+        expect(output.variables).toEqual([ '?a' ]);
+        expect(output.type).toEqual('bindings');
+        expect(output.canContainUndefs).toEqual(true);
+        expect(await arrayifyStream(output.bindingsStream)).toEqual([
+          Bindings({ '?a': new BlankNodeScoped('a1', DF.namedNode('A')), '?b': DF.literal('b') }),
+          Bindings({ '?a': new BlankNodeScoped('a2', DF.namedNode('B')), '?b': DF.literal('b') }),
+          Bindings({ '?a': new BlankNodeScoped('a3', DF.namedNode('C')), '?b': DF.literal('b') }),
+        ]);
+      });
+    });
   });
 });

--- a/packages/actor-query-operation-project/test/ActorQueryOperationProject-test.ts
+++ b/packages/actor-query-operation-project/test/ActorQueryOperationProject-test.ts
@@ -1,6 +1,6 @@
 import { ActorQueryOperation, Bindings } from '@comunica/bus-query-operation';
 import { Bus } from '@comunica/core';
-import {BlankNodeBindingsScoped, BlankNodeScoped} from '@comunica/data-factory';
+import { BlankNodeBindingsScoped, BlankNodeScoped } from '@comunica/data-factory';
 import type { IActorQueryOperationOutputBindings } from '@comunica/types';
 import { ArrayIterator, SingletonIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';

--- a/packages/bus-query-operation/lib/ActorQueryOperation.ts
+++ b/packages/bus-query-operation/lib/ActorQueryOperation.ts
@@ -1,6 +1,7 @@
 import { KeysInitSparql, KeysQueryOperation } from '@comunica/context-entries';
 import type { ActionContext, IActorArgs, IActorTest, Mediator } from '@comunica/core';
 import { Actor } from '@comunica/core';
+import { BlankNodeBindingsScoped } from '@comunica/data-factory';
 import type {
   IActionQueryOperation,
   IActorQueryOperationOutput,
@@ -11,7 +12,9 @@ import type {
   Bindings,
   PatternBindings,
 } from '@comunica/types';
+import type * as RDF from 'rdf-js';
 import type { Algebra } from 'sparqlalgebrajs';
+import * as uuid from 'uuid';
 import { materializeOperation } from './Bindings';
 
 /**
@@ -167,8 +170,17 @@ export abstract class ActorQueryOperation extends Actor<IActionQueryOperation, I
     }
   }
 
+  protected static getBaseExpressionContext(context: ActionContext): IBaseExpressionContext {
+    if (context) {
+      const now: Date = context.get(KeysInitSparql.queryTimestamp);
+      const baseIRI: string = context.get(KeysInitSparql.baseIRI);
+      return { now, baseIRI };
+    }
+    return {};
+  }
+
   /**
-   * Create an options object that can be used to construct a sparqlee evaluator.
+   * Create an options object that can be used to construct a sparqlee synchronous evaluator.
    * @param context An action context.
    * @param mediatorQueryOperation An optional query query operation mediator.
    *                               If defined, the existence resolver will be defined as `exists`.
@@ -176,20 +188,29 @@ export abstract class ActorQueryOperation extends Actor<IActionQueryOperation, I
   public static getExpressionContext(context: ActionContext, mediatorQueryOperation?: Mediator<
   Actor<IActionQueryOperation, IActorTest, IActorQueryOperationOutput>,
   IActionQueryOperation, IActorTest, IActorQueryOperationOutput>): IExpressionContext {
-    if (context) {
-      const now: Date = context.get(KeysInitSparql.queryTimestamp);
-      const baseIRI: string = context.get(KeysInitSparql.baseIRI);
-      return {
-        now,
-        baseIRI,
-        ...mediatorQueryOperation ?
-          {
-            exists: ActorQueryOperation.createExistenceResolver(context, mediatorQueryOperation),
-          } :
-          {},
-      };
+    return {
+      ...this.getBaseExpressionContext(context),
+      bnode: (input?: string) => new BlankNodeBindingsScoped(input || uuid.v4()),
+    };
+  }
+
+  /**
+   * Create an options object that can be used to construct a sparqlee asynchronous evaluator.
+   * @param context An action context.
+   * @param mediatorQueryOperation An optional query query operation mediator.
+   *                               If defined, the existence resolver will be defined as `exists`.
+   */
+  public static getAsyncExpressionContext(context: ActionContext, mediatorQueryOperation?: Mediator<
+  Actor<IActionQueryOperation, IActorTest, IActorQueryOperationOutput>,
+  IActionQueryOperation, IActorTest, IActorQueryOperationOutput>): IAsyncExpressionContext {
+    const expressionContext: IAsyncExpressionContext = {
+      ...this.getBaseExpressionContext(context),
+      bnode: (input?: string) => Promise.resolve(new BlankNodeBindingsScoped(input || uuid.v4())),
+    };
+    if (context && mediatorQueryOperation) {
+      expressionContext.exists = ActorQueryOperation.createExistenceResolver(context, mediatorQueryOperation);
     }
-    return {};
+    return expressionContext;
   }
 
   /**
@@ -238,9 +259,17 @@ export function getMetadata(actionOutput: IActorQueryOperationOutputStream): Pro
   return actionOutput.metadata();
 }
 
-export interface IExpressionContext {
+interface IBaseExpressionContext {
   now?: Date;
   baseIRI?: string;
-  // Exists?: (expr: Algebra.ExistenceExpression, bindings: Bindings) => Promise<boolean>;
-  // bnode?: (input?: string) => Promise<RDF.BlankNode>;
+}
+
+// TODO: rename to ISyncExpressionContext in next major version
+export interface IExpressionContext extends IBaseExpressionContext {
+  bnode: (input?: string | undefined) => RDF.BlankNode;
+}
+
+export interface IAsyncExpressionContext extends IBaseExpressionContext {
+  bnode: (input?: string | undefined) => Promise<RDF.BlankNode>;
+  exists?: (expr: Algebra.ExistenceExpression, bindings: Bindings) => Promise<boolean>;
 }

--- a/packages/bus-query-operation/lib/ActorQueryOperation.ts
+++ b/packages/bus-query-operation/lib/ActorQueryOperation.ts
@@ -14,7 +14,6 @@ import type {
 } from '@comunica/types';
 import type * as RDF from 'rdf-js';
 import type { Algebra } from 'sparqlalgebrajs';
-import * as uuid from 'uuid';
 import { materializeOperation } from './Bindings';
 
 /**
@@ -97,6 +96,14 @@ export const KEY_CONTEXT_BASEIRI = KeysInitSparql.baseIRI;
  * @deprecated Import this constant from @comunica/context-entries.
  */
 export const KEY_CONTEXT_QUERY_TIMESTAMP = KeysInitSparql.queryTimestamp;
+
+/**
+ * A counter that keeps track blank node generated through BNODE() SPARQL
+ * expressions.
+ *
+ * @type {number}
+ */
+let bnodeCounter = 0;
 
 /**
  * A comunica actor for query-operation events.
@@ -190,7 +197,7 @@ export abstract class ActorQueryOperation extends Actor<IActionQueryOperation, I
   IActionQueryOperation, IActorTest, IActorQueryOperationOutput>): IExpressionContext {
     return {
       ...this.getBaseExpressionContext(context),
-      bnode: (input?: string) => new BlankNodeBindingsScoped(input || uuid.v4()),
+      bnode: (input?: string) => new BlankNodeBindingsScoped(input || `BNODE_${bnodeCounter++}`),
     };
   }
 
@@ -205,7 +212,7 @@ export abstract class ActorQueryOperation extends Actor<IActionQueryOperation, I
   IActionQueryOperation, IActorTest, IActorQueryOperationOutput>): IAsyncExpressionContext {
     const expressionContext: IAsyncExpressionContext = {
       ...this.getBaseExpressionContext(context),
-      bnode: (input?: string) => Promise.resolve(new BlankNodeBindingsScoped(input || uuid.v4())),
+      bnode: (input?: string) => Promise.resolve(new BlankNodeBindingsScoped(input || `BNODE_${bnodeCounter++}`)),
     };
     if (context && mediatorQueryOperation) {
       expressionContext.exists = ActorQueryOperation.createExistenceResolver(context, mediatorQueryOperation);

--- a/packages/bus-query-operation/package.json
+++ b/packages/bus-query-operation/package.json
@@ -38,8 +38,7 @@
     "asynciterator": "^3.0.3",
     "immutable": "^3.8.2",
     "rdf-string": "^1.5.0",
-    "sparqlalgebrajs": "^2.4.0",
-    "uuid": "^8.0.0"
+    "sparqlalgebrajs": "^2.4.0"
   },
   "peerDependencies": {
     "@comunica/core": "^1.0.0"

--- a/packages/bus-query-operation/package.json
+++ b/packages/bus-query-operation/package.json
@@ -32,12 +32,14 @@
   ],
   "dependencies": {
     "@comunica/context-entries": "^1.0.0",
+    "@comunica/data-factory": "^1.17.0",
     "@comunica/types": "^1.19.2",
     "@types/rdf-js": "*",
     "asynciterator": "^3.0.3",
     "immutable": "^3.8.2",
     "rdf-string": "^1.5.0",
-    "sparqlalgebrajs": "^2.4.0"
+    "sparqlalgebrajs": "^2.4.0",
+    "uuid": "^8.0.0"
   },
   "peerDependencies": {
     "@comunica/core": "^1.0.0"

--- a/packages/bus-query-operation/test/ActorQueryOperation-test.ts
+++ b/packages/bus-query-operation/test/ActorQueryOperation-test.ts
@@ -3,7 +3,6 @@ import { ActionContext, Bus } from '@comunica/core';
 import { ArrayIterator } from 'asynciterator';
 import type { Algebra } from 'sparqlalgebrajs';
 import { Factory } from 'sparqlalgebrajs';
-import * as uuid from 'uuid';
 import { ActorQueryOperation, Bindings, getMetadata } from '..';
 
 describe('ActorQueryOperation', () => {
@@ -166,5 +165,4 @@ describe('ActorQueryOperation', () => {
         .toEqual({ bla: true });
     });
   });
-
 });

--- a/packages/bus-query-operation/test/ActorQueryOperation-test.ts
+++ b/packages/bus-query-operation/test/ActorQueryOperation-test.ts
@@ -3,6 +3,7 @@ import { ActionContext, Bus } from '@comunica/core';
 import { ArrayIterator } from 'asynciterator';
 import type { Algebra } from 'sparqlalgebrajs';
 import { Factory } from 'sparqlalgebrajs';
+import * as uuid from 'uuid';
 import { ActorQueryOperation, Bindings, getMetadata } from '..';
 
 describe('ActorQueryOperation', () => {
@@ -73,18 +74,18 @@ describe('ActorQueryOperation', () => {
     });
   });
 
-  describe('#getExpressionContext', () => {
+  describe('#getAsyncExpressionContext', () => {
     describe('without mediatorQueryOperation', () => {
       it('should create an empty object for an empty context', () => {
-        expect(ActorQueryOperation.getExpressionContext(ActionContext({}))).toEqual({});
+        expect(ActorQueryOperation.getAsyncExpressionContext(ActionContext({}))).toEqual({});
       });
 
       it('should create an non-empty object for a filled context', () => {
         const date = new Date();
-        expect(ActorQueryOperation.getExpressionContext(ActionContext({
+        expect(ActorQueryOperation.getAsyncExpressionContext(ActionContext({
           [KeysInitSparql.queryTimestamp]: date,
           [KeysInitSparql.baseIRI]: 'http://base.org/',
-        }))).toEqual({
+        }))).toContain({
           now: date,
           baseIRI: 'http://base.org/',
         });
@@ -108,13 +109,13 @@ describe('ActorQueryOperation', () => {
 
       it('should create an object with a resolver', () => {
         const resolver = (<any> ActorQueryOperation
-          .getExpressionContext(ActionContext({}), mediatorQueryOperation)).exists;
+          .getAsyncExpressionContext(ActionContext({}), mediatorQueryOperation)).exists;
         expect(resolver).toBeTruthy();
       });
 
       it('should allow a resolver to be invoked', async() => {
         const resolver = (<any> ActorQueryOperation
-          .getExpressionContext(ActionContext({}), mediatorQueryOperation)).exists;
+          .getAsyncExpressionContext(ActionContext({}), mediatorQueryOperation)).exists;
         const factory = new Factory();
         const expr: Algebra.ExistenceExpression = factory.createExistenceExpression(
           true,
@@ -136,4 +137,5 @@ describe('ActorQueryOperation', () => {
         .toEqual({ bla: true });
     });
   });
+
 });

--- a/packages/bus-query-operation/test/ActorQueryOperation-test.ts
+++ b/packages/bus-query-operation/test/ActorQueryOperation-test.ts
@@ -74,10 +74,38 @@ describe('ActorQueryOperation', () => {
     });
   });
 
+  describe('#getExpressionContext', () => {
+    describe('without mediatorQueryOperation', () => {
+      it('should create an empty object for an empty contexts save for the bnode function', () => {
+        expect(ActorQueryOperation.getExpressionContext(ActionContext({})))
+          .toEqual({ bnode: expect.any(Function) });
+      });
+
+      it('the bnode function should synchronously return a blank node', () => {
+        const context = ActorQueryOperation.getExpressionContext(ActionContext({}));
+        const blankNode = context.bnode();
+        expect(blankNode).toBeDefined();
+        expect(blankNode).toHaveProperty('termType');
+        expect(blankNode.termType).toEqual('BlankNode');
+      });
+    });
+  });
+
   describe('#getAsyncExpressionContext', () => {
     describe('without mediatorQueryOperation', () => {
-      it('should create an empty object for an empty context', () => {
-        expect(ActorQueryOperation.getAsyncExpressionContext(ActionContext({}))).toEqual({});
+      it('should create an empty object for an empty contexts save for the bnode function', () => {
+        expect(ActorQueryOperation.getAsyncExpressionContext(ActionContext({})))
+          .toEqual({ bnode: expect.any(Function) });
+      });
+
+      it('the bnode function should asynchronously return a blank node', async() => {
+        const context = ActorQueryOperation.getAsyncExpressionContext(ActionContext({}));
+        const blankNodePromise = context.bnode();
+        expect(blankNodePromise).toBeInstanceOf(Promise);
+        const blankNode = await blankNodePromise;
+        expect(blankNode).toBeDefined();
+        expect(blankNode).toHaveProperty('termType');
+        expect(blankNode.termType).toEqual('BlankNode');
       });
 
       it('should create an non-empty object for a filled context', () => {
@@ -85,8 +113,9 @@ describe('ActorQueryOperation', () => {
         expect(ActorQueryOperation.getAsyncExpressionContext(ActionContext({
           [KeysInitSparql.queryTimestamp]: date,
           [KeysInitSparql.baseIRI]: 'http://base.org/',
-        }))).toContain({
+        }))).toEqual({
           now: date,
+          bnode: expect.any(Function),
           baseIRI: 'http://base.org/',
         });
       });

--- a/packages/data-factory/README.md
+++ b/packages/data-factory/README.md
@@ -18,4 +18,4 @@ $ yarn add @comunica/data-factory
 ## Exposed classes
 
 * [`BlankNodeScoped`](https://comunica.github.io/comunica/classes/data_factory.blanknodescoped-1.html): A blank node that is scoped to a certain source, and exposes a skolemized named node.
-* [`BlankNodeScoped`](https://comunica.github.io/comunica/classes/data_factory.blanknodescoped-1.html): A blank node that is scoped to a certain set of bindings.
+* [`BlankNodeBindingsScoped`](https://comunica.github.io/comunica/classes/data_factory.blanknodebindingsscoped-1.html): A blank node that is scoped to a certain set of bindings.

--- a/packages/data-factory/README.md
+++ b/packages/data-factory/README.md
@@ -18,3 +18,4 @@ $ yarn add @comunica/data-factory
 ## Exposed classes
 
 * [`BlankNodeScoped`](https://comunica.github.io/comunica/classes/data_factory.blanknodescoped-1.html): A blank node that is scoped to a certain source, and exposes a skolemized named node.
+* [`BlankNodeScoped`](https://comunica.github.io/comunica/classes/data_factory.blanknodescoped-1.html): A blank node that is scoped to a certain set of bindings.

--- a/packages/data-factory/index.ts
+++ b/packages/data-factory/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/BlankNodeScoped';
+export * from './lib/BlankNodeBindingsScoped';

--- a/packages/data-factory/lib/BlankNodeBindingsScoped.ts
+++ b/packages/data-factory/lib/BlankNodeBindingsScoped.ts
@@ -1,0 +1,20 @@
+import type * as RDF from 'rdf-js';
+
+/**
+ * A blank node that is scoped to a set of bindings.
+ */
+export class BlankNodeBindingsScoped implements RDF.BlankNode {
+  public readonly termType: 'BlankNode' = 'BlankNode';
+  public readonly singleBindingsScope: true = true;
+  public readonly value: string;
+
+  public constructor(value: string) {
+    this.value = value;
+  }
+
+  public equals(other: RDF.Term | null | undefined): boolean {
+    // TODO: should we always return false given the nature of this class?
+    // eslint-disable-next-line no-implicit-coercion
+    return !!other && other.termType === 'BlankNode' && other.value === this.value;
+  }
+}

--- a/packages/data-factory/lib/BlankNodeBindingsScoped.ts
+++ b/packages/data-factory/lib/BlankNodeBindingsScoped.ts
@@ -13,7 +13,6 @@ export class BlankNodeBindingsScoped implements RDF.BlankNode {
   }
 
   public equals(other: RDF.Term | null | undefined): boolean {
-    // TODO: should we always return false given the nature of this class?
     // eslint-disable-next-line no-implicit-coercion
     return !!other && other.termType === 'BlankNode' && other.value === this.value;
   }

--- a/packages/data-factory/test/BlankNodeBindingsScoped-test.ts
+++ b/packages/data-factory/test/BlankNodeBindingsScoped-test.ts
@@ -1,0 +1,31 @@
+import { DataFactory } from 'rdf-data-factory';
+import { BlankNodeBindingsScoped } from '..';
+const DF = new DataFactory();
+
+describe('BlankNodeBindingsScoped', () => {
+  describe('equals', () => {
+    it('should be false for a falsy term', () => {
+      const bn = new BlankNodeBindingsScoped('abc');
+      expect(bn.equals(null)).toBeFalsy();
+      expect(bn.singleBindingsScope).toBeTruthy();
+    });
+
+    it('should be false for a named node', () => {
+      const bn = new BlankNodeBindingsScoped('abc');
+      expect(bn.equals(DF.namedNode('abc'))).toBeFalsy();
+      expect(bn.singleBindingsScope).toBeTruthy();
+    });
+
+    it('should be false for a blank node with another label', () => {
+      const bn = new BlankNodeBindingsScoped('abc');
+      expect(bn.equals(DF.blankNode('ABC'))).toBeFalsy();
+      expect(bn.singleBindingsScope).toBeTruthy();
+    });
+
+    it('should be true for a blank node with the same label', () => {
+      const bn = new BlankNodeBindingsScoped('abc');
+      expect(bn.equals(DF.blankNode('abc'))).toBeTruthy();
+      expect(bn.singleBindingsScope).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
This PR (~~which depends on https://github.com/comunica/sparqlee/pull/81~~ MERGED) fixes the blank node correlation issue raised in issue https://github.com/comunica/comunica/issues/795 (and may fix other similar issues). 

#### TODO

- [x] modify unit tests to match the new behavior of `packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts`
- [x] modify `ActorQueryOperation` tests to account for the `bnode` functions in expression contexts
- [x] add a test to verify blank node correlation
- [x] update to new version of `sparqlee` once https://github.com/comunica/sparqlee/pull/81 is merged and published to NPM
- [x] general cleanup and linting
