### PR TITLE
Fixes missing context for actors called by MediatorCombinePipeline

### DIFF
--- a/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
+++ b/packages/actor-init-sparql/lib/ActorInitSparql-browser.ts
@@ -199,7 +199,9 @@ export class ActorInitSparql extends ActorInit implements IActorInitSparqlArgs, 
     }
 
     // Optimize the query operation
-    operation = (await this.mediatorOptimizeQueryOperation.mediate({ context, operation })).operation;
+    const mediatorResult = await this.mediatorOptimizeQueryOperation.mediate({ context, operation });
+    operation = mediatorResult.operation;
+    context = mediatorResult.context || context;
 
     // Pre-processing the context, this time with the operation
     context = (await this.mediatorContextPreprocess.mediate({ context, operation })).context;

--- a/packages/actor-init-sparql/test/ActorInitSparql-test.ts
+++ b/packages/actor-init-sparql/test/ActorInitSparql-test.ts
@@ -623,21 +623,15 @@ describe('ActorInitSparql', () => {
       });
 
       it('should allow optimize actors to modify the context', async() => {
-        const optimizeMediate = mediatorOptimizeQueryOperation.mediate;
         mediatorOptimizeQueryOperation.mediate = (action: any) => {
-          action = {
+          return Promise.resolve({
             ...action,
             context: action.context.set('the-answer', 42),
-          };
-          return optimizeMediate(action);
+          });
         };
-        const queryMediate = mediatorQueryOperation.mediate;
-        mediatorQueryOperation.mediate = (action: any) => {
-          expect(action.context.get('the-answer')).toBe(42);
-          return queryMediate(action);
-        };
-        await expect(actor.query('SELECT * WHERE { ?s ?p ?o }'))
-          .resolves.toBeTruthy();
+        const result = await actor.query('SELECT * WHERE { ?s ?p ?o }');
+        expect(result).toHaveProperty('context');
+        expect(result.context!.get('the-answer')).toEqual(42);
       });
     });
 

--- a/packages/actor-init-sparql/test/ActorInitSparql-test.ts
+++ b/packages/actor-init-sparql/test/ActorInitSparql-test.ts
@@ -622,6 +622,15 @@ describe('ActorInitSparql', () => {
           });
       });
 
+      it('should pass down the provided context if optimize actors do not return one', async() => {
+        mediatorOptimizeQueryOperation.mediate = (action: any) => {
+          return Promise.resolve({ ...action, context: undefined });
+        };
+        const result = await actor.query('SELECT * WHERE { ?s ?p ?o }', { 'the-answer': 42 });
+        expect(result).toHaveProperty('context');
+        expect(result.context!.get('the-answer')).toEqual(42);
+      });
+
       it('should allow optimize actors to modify the context', async() => {
         mediatorOptimizeQueryOperation.mediate = (action: any) => {
           return Promise.resolve({

--- a/packages/actor-init-sparql/test/ActorInitSparql-test.ts
+++ b/packages/actor-init-sparql/test/ActorInitSparql-test.ts
@@ -621,6 +621,24 @@ describe('ActorInitSparql', () => {
             '@comunica/actor-init-sparql:baseIRI': 'myBaseIRI',
           });
       });
+
+      it('should allow optimize actors to modify the context', async() => {
+        const optimizeMediate = mediatorOptimizeQueryOperation.mediate;
+        mediatorOptimizeQueryOperation.mediate = (action: any) => {
+          action = {
+            ...action,
+            context: action.context.set('the-answer', 42),
+          };
+          return optimizeMediate(action);
+        };
+        const queryMediate = mediatorQueryOperation.mediate;
+        mediatorQueryOperation.mediate = (action: any) => {
+          expect(action.context.get('the-answer')).toBe(42);
+          return queryMediate(action);
+        };
+        await expect(actor.query('SELECT * WHERE { ?s ?p ?o }'))
+          .resolves.toBeTruthy();
+      });
     });
 
     it('bindings() should collect all bindings until "end" event occurs on triples', async() => {

--- a/packages/bus-http-invalidate/lib/ActorHttpInvalidateListenable.ts
+++ b/packages/bus-http-invalidate/lib/ActorHttpInvalidateListenable.ts
@@ -27,7 +27,7 @@ export class ActorHttpInvalidateListenable extends ActorHttpInvalidate {
     for (const listener of this.invalidateListeners) {
       listener(action);
     }
-    return true;
+    return {};
   }
 }
 

--- a/packages/bus-optimize-query-operation/lib/ActorOptimizeQueryOperation.ts
+++ b/packages/bus-optimize-query-operation/lib/ActorOptimizeQueryOperation.ts
@@ -1,5 +1,6 @@
 import type { IAction, IActorArgs, IActorOutput, IActorTest } from '@comunica/core';
 import { Actor } from '@comunica/core';
+import type { ActionContext } from '@comunica/types';
 import type { Algebra } from 'sparqlalgebrajs';
 
 /**
@@ -26,4 +27,5 @@ export interface IActionOptimizeQueryOperation extends IAction {
 
 export interface IActorOptimizeQueryOperationOutput extends IActorOutput {
   operation: Algebra.Operation;
+  context?: ActionContext;
 }

--- a/packages/bus-optimize-query-operation/package.json
+++ b/packages/bus-optimize-query-operation/package.json
@@ -31,6 +31,7 @@
     "index.js"
   ],
   "dependencies": {
+    "@comunica/types": "^1.20.0",
     "sparqlalgebrajs": "^2.5.5"
   },
   "peerDependencies": {

--- a/packages/core/lib/Actor.ts
+++ b/packages/core/lib/Actor.ts
@@ -222,5 +222,5 @@ export interface IActorTest {
  * Data interface for the type of an actor run result.
  */
 export interface IActorOutput {
-
+  context?: ActionContext;
 }

--- a/packages/core/lib/Actor.ts
+++ b/packages/core/lib/Actor.ts
@@ -222,5 +222,5 @@ export interface IActorTest {
  * Data interface for the type of an actor run result.
  */
 export interface IActorOutput {
-  context?: ActionContext;
+
 }

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -27,7 +27,7 @@ export class MediatorCombinePipeline<A extends Actor<H, T, H>, H extends IAction
     // and each actor output as input to the following actor.
     let handle: H = action;
     for (const actor of testResults.map(result => result.actor)) {
-      handle = await actor.runObservable(handle);
+      handle = { ...handle, ...await actor.runObservable(handle) };
     }
 
     // Return the final actor output


### PR DESCRIPTION
While working on https://github.com/beautifulinteractions/node-quadstore/issues/115 I noticed that my custom optimizer actor had no `context` entry in its `action` argument. I tracked the issue to the fact that, while `MediatorCombinePipeline` does pass the output of one actor to the next one, the output of each actor is not guaranteed to have the `context` property in it and therefore only the first actor in a chain of mediated actors is guaranteed to receive the context.

This fix is backward-compatible and ensures that the properties of the original action are always preserved unless they are overwritten by one of the actors mediated over.  

Furthermore, this fix also modifies how the return value of the optimize mediator is handled. If the mediator returns a context, then the original context is replaced with the mediator's; if the mediator doesn't return a context, then the original context is used. This allows optimize actors to use the context to propagate information to other actors in Comunica.