### PR TITLE
Document internally why some errors are silent in Filter, OrderBy and LeftJoin

### DIFF
--- a/packages/actor-query-operation-filter-sparqlee/lib/ActorQueryOperationFilterSparqlee.ts
+++ b/packages/actor-query-operation-filter-sparqlee/lib/ActorQueryOperationFilterSparqlee.ts
@@ -40,6 +40,15 @@ export class ActorQueryOperationFilterSparqlee extends ActorQueryOperationTypedM
           push(item);
         }
       } catch (error: unknown) {
+        // We ignore all Expression errors.
+        // Other errors (likely programming mistakes) are still propagated.
+        //
+        // > Specifically, FILTERs eliminate any solutions that,
+        // > when substituted into the expression, either result in
+        // > an effective boolean value of false or produce an error.
+        // > ...
+        // > These errors have no effect outside of FILTER evaluation.
+        // https://www.w3.org/TR/sparql11-query/#expressions
         if (!isExpressionError(<Error> error)) {
           bindingsStream.emit('error', error);
         }

--- a/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
+++ b/packages/actor-query-operation-leftjoin-nestedloop/lib/ActorQueryOperationLeftJoinNestedLoop.ts
@@ -52,6 +52,10 @@ export class ActorQueryOperationLeftJoinNestedLoop extends ActorQueryOperationTy
           const result = await evaluator.evaluateAsEBV(joinedBindings);
           push({ joinedBindings, result });
         } catch (error: unknown) {
+          // We ignore all Expression errors.
+          // Other errors (likely programming mistakes) are still propagated.
+          // Left Join is defined in terms of Filter (https://www.w3.org/TR/sparql11-query/#defn_algJoin),
+          // and Filter requires this (https://www.w3.org/TR/sparql11-query/#expressions).
           if (!isExpressionError(<Error> error)) {
             bindingsStream.emit('error', error);
           }

--- a/packages/actor-query-operation-orderby-sparqlee/lib/ActorQueryOperationOrderBySparqlee.ts
+++ b/packages/actor-query-operation-orderby-sparqlee/lib/ActorQueryOperationOrderBySparqlee.ts
@@ -56,6 +56,9 @@ export class ActorQueryOperationOrderBySparqlee extends ActorQueryOperationTyped
           const result = await evaluator.evaluate(bindings);
           push({ bindings, result });
         } catch (error: unknown) {
+          // We ignore all Expression errors.
+          // Other errors (likely programming mistakes) are still propagated.
+          // I can't recall where this is defined in the spec.
           if (!isExpressionError(<Error> error)) {
             bindingsStream.emit('error', error);
           }


### PR DESCRIPTION
I still had this one stashed. Felt it couldn't hurt.