### PR TITLE
feat: Filter combine pipeline

### DIFF
--- a/packages/mediator-combine-pipeline/README.md
+++ b/packages/mediator-combine-pipeline/README.md
@@ -42,4 +42,4 @@ After installing, this mediator can be instantiated as follows:
 ### Config Parameters
 
 * `bus`: Identifier of the bus to mediate over.
-
+* `filterErrors`: Optional flag to indicate if actors that throw test errors should be filtered out of the pipeline, defaults to false.

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -28,7 +28,7 @@ export class MediatorCombinePipeline
     // Pass action to first actor,
     // and each actor output as input to the following actor.
     let handle: H = action;
-    for (const actor of testResults.map(result => result.actor)) {
+    for (const { actor } of testResults) {
       handle = { ...handle, ...await actor.runObservable(handle) };
     }
 

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -31,9 +31,8 @@ export class MediatorCombinePipeline
         try {
           await result.reply;
           _testResults.push(result);
-          // eslint-disable-next-line no-empty
         } catch {
-          // ignore errors
+          // Ignore errors
         }
       }
       testResults = _testResults;

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -24,19 +24,18 @@ export class MediatorCombinePipeline
       return action;
     }
 
+    // Delegate test errors.
     if (this.filterErrors) {
-      let _testResults: IActorReply<A, H, T, H>[] = [];
-      for (const result of testResults) {
-        try {
-          await result.reply;
-          _testResults.push(result);
-        } catch (e) {};
+      const _testResults: IActorReply<A, H, T, H>[] = [];
+      for (const result of await Promise.allSettled(testResults)) {
+        if (result.status === 'fulfilled') {
+          _testResults.push(result.value);
+        }
       }
       testResults = _testResults;
     }
 
-    // Delegate test errors.
-    await Promise.all(testResults.map(({ reply }) => reply))
+    await Promise.all(testResults.map(({ reply }) => reply));
 
     // Pass action to first actor,
     // and each actor output as input to the following actor.

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -32,7 +32,9 @@ export class MediatorCombinePipeline
           await result.reply;
           _testResults.push(result);
           // eslint-disable-next-line no-empty
-        } catch {}
+        } catch {
+          // ignore errors
+        }
       }
       testResults = _testResults;
     }

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -26,16 +26,17 @@ export class MediatorCombinePipeline
 
     // Delegate test errors.
     if (this.filterErrors) {
-      const _testResults: IActorReply<A, H, T, H>[] = [];
-      for (const result of await Promise.allSettled(testResults)) {
-        if (result.status === 'fulfilled') {
-          _testResults.push(result.value);
-        }
+      let _testResults: IActorReply<A, H, T, H>[] = [];
+      for (const result of testResults) {
+        try {
+          await result.reply;
+          _testResults.push(result);
+        } catch {};
       }
       testResults = _testResults;
     }
 
-    await Promise.all(testResults.map(({ reply }) => reply));
+    await Promise.all(testResults.map(({ reply }) => reply))
 
     // Pass action to first actor,
     // and each actor output as input to the following actor.

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -26,17 +26,18 @@ export class MediatorCombinePipeline
 
     // Delegate test errors.
     if (this.filterErrors) {
-      let _testResults: IActorReply<A, H, T, H>[] = [];
+      const _testResults: IActorReply<A, H, T, H>[] = [];
       for (const result of testResults) {
         try {
           await result.reply;
           _testResults.push(result);
-        } catch {};
+          // eslint-disable-next-line no-empty
+        } catch {}
       }
       testResults = _testResults;
     }
 
-    await Promise.all(testResults.map(({ reply }) => reply))
+    await Promise.all(testResults.map(({ reply }) => reply));
 
     // Pass action to first actor,
     // and each actor output as input to the following actor.

--- a/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
+++ b/packages/mediator-combine-pipeline/lib/MediatorCombinePipeline.ts
@@ -9,7 +9,9 @@ import type { IActionContext } from '@comunica/types';
 export class MediatorCombinePipeline
 <A extends Actor<H, T, H>, H extends IAction | (IActorOutput & { context: IActionContext }), T extends IActorTest>
   extends Mediator<A, H, T, H> {
-  public constructor(args: IMediatorArgs<A, H, T, H>) {
+  public readonly filterErrors: boolean | undefined;
+
+  public constructor(args: IMediatorCombinePipelineArgs<A, H, T, H>) {
     super(args);
   }
 
@@ -22,8 +24,19 @@ export class MediatorCombinePipeline
       return action;
     }
 
+    if (this.filterErrors) {
+      let _testResults: IActorReply<A, H, T, H>[] = [];
+      for (const result of testResults) {
+        try {
+          await result.reply;
+          _testResults.push(result);
+        } catch (e) {};
+      }
+      testResults = _testResults;
+    }
+
     // Delegate test errors.
-    await Promise.all(testResults.map(({ reply }) => reply));
+    await Promise.all(testResults.map(({ reply }) => reply))
 
     // Pass action to first actor,
     // and each actor output as input to the following actor.
@@ -39,4 +52,12 @@ export class MediatorCombinePipeline
   protected mediateWith(): Promise<A> {
     throw new Error('Method not supported.');
   }
+}
+
+export interface IMediatorCombinePipelineArgs<A extends Actor<I, T, O>, I extends IAction, T extends IActorTest,
+  O extends IActorOutput> extends IMediatorArgs<A, I, T, O> {
+  /**
+   * If actors that throw test errors should be ignored
+   */
+  filterErrors?: boolean;
 }

--- a/packages/mediator-combine-pipeline/test/MediatorCombinePipeline-test.ts
+++ b/packages/mediator-combine-pipeline/test/MediatorCombinePipeline-test.ts
@@ -70,7 +70,7 @@ describe('MediatorCombinePipeline', () => {
 
     it('should throw an error when mediate is called', async() => {
       const context = new ActionContext();
-      await expect(() => mediator.mediate({ field: 1, context })).rejects.toThrowError('Dummy Error')
+      await expect(() => mediator.mediate({ field: 1, context })).rejects.toThrowError('Dummy Error');
     });
   });
 
@@ -145,14 +145,13 @@ class DummyThrowActor extends Actor<IDummyAction, IActorTest, IDummyOutput> {
   }
 
   public async test(action: IDummyAction): Promise<IActorTest> {
-    throw new Error('Dummy Error')
+    throw new Error('Dummy Error');
   }
 
   public async run(action: IDummyAction): Promise<IDummyOutput> {
     return { field: action.field * this.id + this.id, context: action.context };
   }
 }
-
 
 class DummyActorContextOutput extends DummyActor {
   public async run(action: IDummyAction): Promise<IDummyOutput> {

--- a/packages/mediator-combine-pipeline/test/MediatorCombinePipeline-test.ts
+++ b/packages/mediator-combine-pipeline/test/MediatorCombinePipeline-test.ts
@@ -53,6 +53,58 @@ describe('MediatorCombinePipeline', () => {
     });
   });
 
+  describe('An MediatorCombinePipeline instance with erroring actors and filtering disabled', () => {
+    let mediator: MediatorCombinePipeline<DummyActor, IDummyAction, IActorTest>;
+
+    beforeEach(() => {
+      mediator = new MediatorCombinePipeline({ name: 'mediator', bus });
+      new DummyActor(10, bus);
+      new DummyActor(100, bus);
+      new DummyActor(1, bus);
+      new DummyThrowActor(1_000, bus);
+    });
+
+    it('should throw an error when mediateWith is called', () => {
+      return expect(() => (<any> mediator).mediateWith({}, [])).toThrow();
+    });
+
+    it('should throw an error when mediate is called', async() => {
+      const context = new ActionContext();
+      await expect(() => mediator.mediate({ field: 1, context })).rejects.toThrowError('Dummy Error')
+    });
+  });
+
+  describe('An MediatorCombinePipeline instance with erroring actors', () => {
+    let mediator: MediatorCombinePipeline<DummyActor, IDummyAction, IActorTest>;
+
+    beforeEach(() => {
+      mediator = new MediatorCombinePipeline({ name: 'mediator', bus, filterErrors: true });
+      new DummyActor(10, bus);
+      new DummyActor(100, bus);
+      new DummyActor(1, bus);
+      new DummyThrowActor(1_000, bus);
+    });
+
+    it('should throw an error when mediateWith is called', () => {
+      return expect(() => (<any> mediator).mediateWith({}, [])).toThrow();
+    });
+
+    it('should mediate without changing the context', async() => {
+      const context = new ActionContext();
+      const result = await mediator.mediate({ field: 1, context });
+      expect(result).toEqual({ field: 2_101, context });
+    });
+
+    it('should mediate changing the context', async() => {
+      new DummyActorContextOutput(1_000, bus);
+      const context = new ActionContext({});
+      const result = await mediator.mediate({ field: 1, context });
+      expect(result).toHaveProperty('context');
+      expect(result.context).not.toEqual(context);
+      expect(result.context.toJS().id).toEqual(1_000);
+    });
+  });
+
   describe('An MediatorCombinePipeline instance without actors', () => {
     let mediator: MediatorCombinePipeline<DummyActor, IDummyAction, IActorTest>;
 
@@ -83,6 +135,24 @@ class DummyActor extends Actor<IDummyAction, IActorTest, IDummyOutput> {
     return { field: action.field * this.id + this.id, context: action.context };
   }
 }
+
+class DummyThrowActor extends Actor<IDummyAction, IActorTest, IDummyOutput> {
+  public readonly id: number;
+
+  public constructor(id: number, bus: Bus<DummyActor, IDummyAction, IActorTest, IDummyOutput>) {
+    super({ name: `dummyThrow${id}`, bus });
+    this.id = id;
+  }
+
+  public async test(action: IDummyAction): Promise<IActorTest> {
+    throw new Error('Dummy Error')
+  }
+
+  public async run(action: IDummyAction): Promise<IDummyOutput> {
+    return { field: action.field * this.id + this.id, context: action.context };
+  }
+}
+
 
 class DummyActorContextOutput extends DummyActor {
   public async run(action: IDummyAction): Promise<IDummyOutput> {


### PR DESCRIPTION
This PR adds an optional parameter to `MediatorCombinePipeline` which filters out actors with erroring tests.

This contains *no breaking changes*.

I'm not tied to this design - just proposing this now as it is useful to have something like this in the reasoning components I am working on