### PR TITLE
fix: require @rdfjs/types version

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,7 +31,7 @@
     "bin/**/*.js"
   ],
   "dependencies": {
-    "@rdfjs/types": "*",
+    "@rdfjs/types": "^1.1.0",
     "@types/yargs": "^17.0.2",
     "asynciterator": "^3.3.0",
     "sparqlalgebrajs": "^4.0.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,7 +31,7 @@
     "bin/**/*.js"
   ],
   "dependencies": {
-    "@rdfjs/types": "^1.1.0",
+    "@rdfjs/types": ">=1.1.0",
     "@types/yargs": "^17.0.2",
     "asynciterator": "^3.3.0",
     "sparqlalgebrajs": "^4.0.0"


### PR DESCRIPTION
@rubensworks, as you suggested, this should fix `Namespace '"[...]/node_modules/@rdfjs/types/index"' has no exported member [...]` errors when running `tsc` on a package depending on `@comunica/types@^2.0.1`.