### PR TITLE
Draft: Allow sources to be a promise

### DIFF
--- a/.componentsjs-generator-config.json
+++ b/.componentsjs-generator-config.json
@@ -59,7 +59,9 @@
     "Factory",
 
     "UriTemplate",
-    "LRUCache"
+    "LRUCache",
+
+    "Promise"
   ],
   "modulePrefix": {
     "@comunica/actor-query-operation-service": "caqoser",

--- a/engines/config-query-sparql/config/rdf-resolve-quad-pattern/actors.json
+++ b/engines/config-query-sparql/config/rdf-resolve-quad-pattern/actors.json
@@ -5,6 +5,7 @@
   "import": [
     "ccqs:config/rdf-resolve-quad-pattern/actors/federated.json",
     "ccqs:config/rdf-resolve-quad-pattern/actors/hypermedia.json",
+    "ccqs:config/rdf-resolve-quad-pattern/actors/promise.json",
     "ccqs:config/rdf-resolve-quad-pattern/actors/rdfjs-source.json"
   ]
 }

--- a/engines/config-query-sparql/config/rdf-resolve-quad-pattern/actors/promise.json
+++ b/engines/config-query-sparql/config/rdf-resolve-quad-pattern/actors/promise.json
@@ -1,0 +1,16 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^2.0.0/components/context.jsonld",
+
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-quad-pattern-promise/^2.0.0/components/context.jsonld"
+  ],
+  "@id": "urn:comunica:default:Runner",
+  "@type": "Runner",
+  "actors": [
+    {
+      "@id": "urn:comunica:default:rdf-resolve-quad-pattern/actors#promise",
+      "@type": "ActorRdfResolveQuadPatternPromise",
+      "mediatorResolveQuadPattern": { "@id": "urn:comunica:default:rdf-resolve-quad-pattern/mediators#main" }
+    }
+  ]
+}

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -42,6 +42,13 @@ describe('System test: QuerySparql', () => {
         expect((await arrayifyStream(await result.execute())).length).toBeGreaterThan(100);
       });
 
+      it('with results on promisified source', async() => {
+        const result = <QueryBindings> await engine.query(`SELECT * WHERE {
+      ?s ?p ?o.
+    }`, { sources: [ Promise.resolve('https://www.rubensworks.net/') ]});
+        expect((await arrayifyStream(await result.execute())).length).toBeGreaterThan(100);
+      });
+
       it('without results', async() => {
         const result = <QueryBindings> await engine.query(`SELECT * WHERE {
       ?s <ex:dummy> ?o.

--- a/packages/actor-rdf-resolve-quad-pattern-promise/README.md
+++ b/packages/actor-rdf-resolve-quad-pattern-promise/README.md
@@ -1,0 +1,41 @@
+# Comunica Promise RDF Resolve Quad Pattern Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-rdf-resolve-quad-pattern-promise.svg)](https://www.npmjs.com/package/@comunica/actor-rdf-resolve-quad-pattern-promise)
+
+A comunica RDF Resolve Quat Pattern Actor for source wrapped in a promise
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica),
+and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
+
+[Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-rdf-resolve-quad-pattern-promise
+```
+
+## Configure
+
+After installing, this package can be added to your engine's configuration as follows:
+```text
+{
+  "@context": [
+    ...
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-resolve-quad-pattern-promise/^1.0.0/components/context.jsonld"  
+  ],
+  "actors": [
+    ...
+    {
+      "@id": "urn:comunica:default:rdf-resolve-quad-pattern/actors#promise",
+      "@type": "ActorRdfResolveQuadPatternPromise"
+    }
+  ]
+}
+```
+
+### Config Parameters
+
+TODO: fill in parameters (this section can be removed if there are none)
+
+* `mediatorRdfResolveQuadPattern`: Actors to use to resolve quad patterns once the source is resolved

--- a/packages/actor-rdf-resolve-quad-pattern-promise/lib/ActorRdfResolveQuadPatternPromise.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-promise/lib/ActorRdfResolveQuadPatternPromise.ts
@@ -1,0 +1,42 @@
+import type {
+  IActionRdfResolveQuadPattern,
+  IActorRdfResolveQuadPatternArgs,
+  IActorRdfResolveQuadPatternOutput,
+  MediatorRdfResolveQuadPattern,
+} from '@comunica/bus-rdf-resolve-quad-pattern';
+import {
+  ActorRdfResolveQuadPattern,
+  getContextSource,
+  hasContextSingleSourceOfType,
+} from '@comunica/bus-rdf-resolve-quad-pattern';
+import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
+import type { IActorTest } from '@comunica/core';
+
+/**
+ * A comunica RDF Resolve Quad Pattern Actor for source wrapped in a promise
+ */
+export class ActorRdfResolveQuadPatternPromise extends ActorRdfResolveQuadPattern {
+  private readonly mediatorResolveQuadPattern: MediatorRdfResolveQuadPattern;
+
+  public constructor(args: IActorRdfResolveQuadPatternPromiseArgs) {
+    super(args);
+  }
+
+  public async test(action: IActionRdfResolveQuadPattern): Promise<IActorTest> {
+    if (!hasContextSingleSourceOfType('promise', action.context)) {
+      throw new Error(`${this.name} requires a single source as a promise to be present in the context.`);
+    }
+    return true;
+  }
+
+  public async run(action: IActionRdfResolveQuadPattern): Promise<IActorRdfResolveQuadPatternOutput> {
+    return this.mediatorResolveQuadPattern.mediate({
+      ...action,
+      context: action.context.set(KeysRdfResolveQuadPattern.source, await getContextSource(action.context)),
+    });
+  }
+}
+
+export interface IActorRdfResolveQuadPatternPromiseArgs extends IActorRdfResolveQuadPatternArgs {
+  mediatorResolveQuadPattern: MediatorRdfResolveQuadPattern;
+}

--- a/packages/actor-rdf-resolve-quad-pattern-promise/lib/index.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-promise/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './ActorRdfResolveQuadPatternPromise';

--- a/packages/actor-rdf-resolve-quad-pattern-promise/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-promise/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@comunica/actor-rdf-resolve-quad-pattern-promise",
+  "version": "2.0.0",
+  "description": "A promise rdf-resolve-quad-pattern actor",
+  "lsd:module": true,
+  "main": "lib/index.js",
+  "typings": "lib/index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/comunica/comunica.git",
+    "directory": "packages/actor-rdf-resolve-quad-pattern-promise"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "keywords": [
+    "comunica",
+    "actor",
+    "rdf-resolve-quad-pattern",
+    "promise"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://comunica.dev/",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js"
+  ],
+  "dependencies": {
+    "@comunica/bus-rdf-resolve-quad-pattern": "^2.2.0",
+    "@comunica/context-entries": "^2.2.0",
+    "@comunica/core": "^2.2.0"
+  },
+  "scripts": {
+    "build": "npm run build:ts && npm run build:components",
+    "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
+    "build:components": "componentsjs-generator"
+  }
+}

--- a/packages/actor-rdf-resolve-quad-pattern-promise/test/ActorRdfResolveQuadPatternPromise-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-promise/test/ActorRdfResolveQuadPatternPromise-test.ts
@@ -1,0 +1,73 @@
+import type { IActorRdfResolveQuadPatternOutput } from '@comunica/bus-rdf-resolve-quad-pattern';
+import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
+import { Bus, ActionContext } from '@comunica/core';
+import { fromArray } from 'asynciterator';
+import { DataFactory } from 'n3';
+import { Factory } from 'sparqlalgebrajs';
+import { ActorRdfResolveQuadPatternPromise } from '../lib/ActorRdfResolveQuadPatternPromise';
+const { namedNode, quad } = DataFactory;
+
+const factory = new Factory();
+
+describe('ActorRdfResolveQuadPatternPromise', () => {
+  let bus: any;
+  let mediatorResolveQuadPattern: any;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+  });
+
+  describe('An ActorRdfResolveQuadPatternPromise instance', () => {
+    let actor: ActorRdfResolveQuadPatternPromise;
+
+    beforeEach(() => {
+      mediatorResolveQuadPattern = {
+        async mediate(): Promise<IActorRdfResolveQuadPatternOutput> {
+          return {
+            // @ts-expect-error
+            data: fromArray([
+              quad(namedNode('a'), namedNode('a'), namedNode('a'), namedNode('a')),
+            ]),
+          };
+        },
+      };
+      actor = new ActorRdfResolveQuadPatternPromise({
+        name: 'actor',
+        bus,
+        mediatorResolveQuadPattern,
+      });
+    });
+
+    it('should test', async() => {
+      await expect(actor.test({ context: new ActionContext({
+        [KeysRdfResolveQuadPattern.source.name]: Promise.resolve('http://example.org/'),
+      }),
+      pattern: factory.createPattern(
+        namedNode('http://example.org/s'),
+        namedNode('http://example.org/s'),
+        namedNode('http://example.org/s'),
+      ) })).resolves.toBe(true);
+
+      await expect(actor.test({ context: new ActionContext({
+        [KeysRdfResolveQuadPattern.source.name]: 'http://example.org/',
+      }),
+      pattern: factory.createPattern(
+        namedNode('http://example.org/s'),
+        namedNode('http://example.org/s'),
+        namedNode('http://example.org/s'),
+      ) })).rejects.toThrowError();
+    });
+
+    it('should run', async() => {
+      const { data } = await actor.run({ context: new ActionContext({
+        [KeysRdfResolveQuadPattern.source.name]: Promise.resolve('http://example.org/'),
+      }),
+      pattern: factory.createPattern(
+        namedNode('http://example.org/s'),
+        namedNode('http://example.org/s'),
+        namedNode('http://example.org/s'),
+      ) });
+      expect(await data.toArray()).toEqual([ quad(namedNode('a'), namedNode('a'), namedNode('a'), namedNode('a')) ]);
+    });
+  });
+});

--- a/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/ActorRdfResolveQuadPatternRdfJsSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/ActorRdfResolveQuadPatternRdfJsSource.ts
@@ -20,7 +20,12 @@ export class ActorRdfResolveQuadPatternRdfJsSource extends ActorRdfResolveQuadPa
       throw new Error(`${this.name} requires a single source with an rdfjsSource to be present in the context.`);
     }
     const source = getContextSource(action.context);
-    if (!source || typeof source === 'string' || (!('match' in source) && !source.value.match)) {
+    if (
+      !source ||
+      typeof source === 'string' ||
+      source instanceof Promise ||
+      (!('match' in source) && !source.value.match)
+    ) {
       throw new Error(`${this.name} received an invalid rdfjsSource.`);
     }
     return true;

--- a/packages/types/lib/IDataSource.ts
+++ b/packages/types/lib/IDataSource.ts
@@ -1,7 +1,9 @@
 import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 
-export type IDataSource = string | RDF.Source | {
+export type IDataSource = IResolvedDataSource | Promise<IResolvedDataSource>;
+
+export type IResolvedDataSource = string | RDF.Source | {
   type?: string;
   value: string | RDF.Source;
   context?: IActionContext;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,7 +2152,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@>=1.1.0", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@>=1.1.0", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==


### PR DESCRIPTION
This adds an actor that handles sources wrapped in a promise.

The use case for this functionality is to wrap a source that is having reasoning applied to it wrapped in a Promise until reasoning is completed - this allows for query results to be returned from the raw sources _while_ reasoning is taking place, rather than the current behavior of blocking results until reasoning is completed.