### PR TITLE
Properly sort named nodes, blank nodes and unbounded values

### DIFF
--- a/packages/actor-query-operation-extend/package.json
+++ b/packages/actor-query-operation-extend/package.json
@@ -35,7 +35,7 @@
     "@comunica/core": "^2.2.0",
     "@comunica/types": "^2.2.0",
     "sparqlalgebrajs": "^4.0.0",
-    "sparqlee": "^2.0.1"
+    "sparqlee": "^2.1.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-filter-sparqlee/package.json
+++ b/packages/actor-query-operation-filter-sparqlee/package.json
@@ -36,7 +36,7 @@
     "@comunica/core": "^2.2.0",
     "@comunica/types": "^2.2.0",
     "sparqlalgebrajs": "^4.0.0",
-    "sparqlee": "^2.0.1"
+    "sparqlee": "^2.1.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-group/package.json
+++ b/packages/actor-query-operation-group/package.json
@@ -40,7 +40,7 @@
     "asynciterator": "^3.4.0",
     "rdf-data-factory": "^1.1.0",
     "sparqlalgebrajs": "^4.0.0",
-    "sparqlee": "^2.0.1"
+    "sparqlee": "^2.1.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-leftjoin/package.json
+++ b/packages/actor-query-operation-leftjoin/package.json
@@ -36,7 +36,7 @@
     "@comunica/core": "^2.2.0",
     "@comunica/types": "^2.2.0",
     "sparqlalgebrajs": "^4.0.0",
-    "sparqlee": "^2.0.1"
+    "sparqlee": "^2.1.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-orderby-sparqlee/package.json
+++ b/packages/actor-query-operation-orderby-sparqlee/package.json
@@ -36,7 +36,7 @@
     "@comunica/types": "^2.2.0",
     "asynciterator": "^3.4.0",
     "sparqlalgebrajs": "^4.0.0",
-    "sparqlee": "^2.0.1"
+    "sparqlee": "^2.1.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10966,10 +10966,10 @@ sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.2:
     rdf-string "^1.6.0"
     sparqljs "^3.5.1"
 
-sparqlee@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-2.0.2.tgz#4f490678df3a377ad066ae60062f50d0dba988fe"
-  integrity sha512-Bd1gzDVJ3rJJZzG1U8CKCFSRhlryE4aBwxOvGyxpXo3S6pU3YqBRmPUY0wZhaNdw/DEqK5i33eA+xq8jF3Yzkg==
+sparqlee@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-2.1.0.tgz#4949c50d1c16ca0113e657ebb138cd85d630c9c0"
+  integrity sha512-4ElqFxcq1TKXGt4V37nSsQGoGBPqdZUftTd6w2s1iY9QtZosEAXcMelJ6i78vdwqWdSXTMSV7m4cQodp8219EQ==
   dependencies:
     "@comunica/bindings-factory" "^2.0.1"
     "@rdfjs/types" "^1.1.0"


### PR DESCRIPTION
The sorting order according to the SPARQL spec should be undefined < blank node < named node < literal

Closes #892