### PR TITLE
fix: add format parameter in n3 parser

### DIFF
--- a/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
+++ b/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
@@ -34,7 +34,7 @@ export class ActorRdfParseN3 extends ActorRdfParseFixedMediaTypes {
   public async runHandle(action: IActionRdfParse, mediaType: string, context: IActionContext):
   Promise<IActorRdfParseOutput> {
     action.data.on('error', error => data.emit('error', error));
-    const data = action.data.pipe(new StreamParser({ baseIRI: action.metadata?.baseIRI }));
+    const data = action.data.pipe(new StreamParser({ baseIRI: action.metadata?.baseIRI, format: mediaType }));
     return {
       data,
       metadata: {

--- a/packages/actor-rdf-parse-n3/test/ActorRdfParseN3-test.ts
+++ b/packages/actor-rdf-parse-n3/test/ActorRdfParseN3-test.ts
@@ -100,11 +100,40 @@ describe('ActorRdfParseN3', () => {
       });
     });
 
+    describe('for parsing n3', () => {
+      beforeEach(() => {
+        input = stringToStream(`
+        { ?uuu ?aaa ?yyy } => { ?aaa a <http://www.w3.org/1999/02/22-rdf-syntax-ns#Property> } .
+      `);
+        inputError = new Readable();
+        inputError._read = () => inputError.emit('error', new Error('ParseN3'));
+      });
+
+      it('should test on N3', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'text/n3', context }))
+          .resolves.toBeTruthy();
+        await expect(actor
+          .test({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'text/n3',
+            context,
+          }))
+          .resolves.toBeTruthy();
+      });
+
+      it('should parse N3', async() => {
+        const output: any = await actor.run({ handle: { data: input, context }, handleMediaType: 'text/n3', context });
+        const arr = await arrayifyStream(output.handle.data);
+        return expect(arr).toHaveLength(3);
+      });
+    });
+
     describe('for parsing', () => {
       beforeEach(() => {
         input = stringToStream(`
           <a> <b> <c>.
-          <d> <e> <f> <g>.
+          <d> <e> <f>.
       `);
         inputError = new Readable();
         inputError._read = () => inputError.emit('error', new Error('ParseN3'));
@@ -195,6 +224,89 @@ describe('ActorRdfParseN3', () => {
           context,
         })
           .then(async(output: any) => expect(await arrayifyStream(output.handle.data)).toHaveLength(2));
+      });
+
+      it('should forward stream errors', async() => {
+        await expect(arrayifyStream((<any>(await actor.run(
+          { handle: { data: inputError, context }, handleMediaType: 'application/trig', context },
+        )))
+          .handle.data)).rejects.toBeTruthy();
+      });
+
+      it('should forward stream errors (with no metadata in input handle)', async() => {
+        await expect(arrayifyStream((<any>(await actor.run({
+          handle: { data: inputError, metadata: { baseIRI: '' }, context },
+          handleMediaType: 'application/trig',
+          context,
+        })))
+          .handle.data)).rejects.toBeTruthy();
+      });
+    });
+
+    describe('for parsing with quads', () => {
+      beforeEach(() => {
+        input = stringToStream(`
+          <a> <b> <c>.
+          <d> <e> <f> <g>.
+      `);
+        inputError = new Readable();
+        inputError._read = () => inputError.emit('error', new Error('ParseN3'));
+      });
+
+      it('should test on N-Quads', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'application/n-quads', context }))
+          .resolves.toBeTruthy();
+        await expect(actor
+          .test({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'application/n-quads',
+            context,
+          }))
+          .resolves.toBeTruthy();
+      });
+
+      it('should test on Turtle', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'text/turtle', context }))
+          .resolves.toBeTruthy();
+        await expect(actor
+          .test({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'text/turtle',
+            context,
+          }))
+          .resolves.toBeTruthy();
+      });
+
+      it('should test on N-Triples', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'application/n-triples', context }))
+          .resolves.toBeTruthy();
+        await expect(actor
+          .test({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'application/n-triples',
+            context,
+          }))
+          .resolves.toBeTruthy();
+      });
+
+      it('should not test on JSON-LD', async() => {
+        await expect(actor
+          .test({
+            handle: { data: input, context },
+            handleMediaType: 'application/ld+json',
+            context,
+          }))
+          .rejects.toBeTruthy();
+        await expect(actor
+          .test({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'application/ld+json',
+            context,
+          }))
+          .rejects.toBeTruthy();
       });
 
       it('should forward stream errors', async() => {


### PR DESCRIPTION
This adds a fix to a problem I just discovered where `.n3` files were not being parsed. This was found when @andreipopi discovered that N3 rules written in `.n3` files were not being read correctly in the reasoning components.

This is may cause a few breaks in downstream applications *if* they are using the wrong file formats (specifically if *quads* formatted in the form `<a> <b> <c> <d> .` have a `turtle` or `trig` file format - see the removed tests below).