### PR TITLE
Removes dependency on 'web-streams-node'

### DIFF
--- a/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
+++ b/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
@@ -10,6 +10,9 @@ import { ActorDereferenceHttp } from '../lib/ActorDereferenceHttp';
 
 const streamifyString = require('streamify-string');
 
+// TODO: Remove when targeting NodeJS 18+
+global.ReadableStream = global.ReadableStream || require('web-streams-ponyfill').ReadableStream;
+
 describe('ActorDereferenceHttp', () => {
   let bus: any;
   let mediatorHttp: any;
@@ -97,7 +100,7 @@ describe('ActorDereferenceHttp', () => {
         }
         const dummyBodyStream = streamifyString('DUMMY BODY');
         let body = action.input === 'https://www.google.com/noweb' ?
-          require('web-streams-node').toWebReadableStream(dummyBodyStream) :
+          require('readable-stream-node-to-web')(dummyBodyStream) :
           dummyBodyStream;
         body.cancel = jest.fn();
         if (action.input.includes('nobody')) {

--- a/packages/actor-rdf-resolve-hypermedia-sparql/test/RdfSourceSparql-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/test/RdfSourceSparql-test.ts
@@ -10,6 +10,9 @@ const quad = require('rdf-quad');
 const streamifyString = require('streamify-string');
 const DF = new DataFactory();
 
+// TODO: Remove when targeting NodeJS 18+
+global.ReadableStream = global.ReadableStream || require('web-streams-ponyfill').ReadableStream;
+
 describe('RdfSourceSparql', () => {
   const context = new ActionContext({});
   const mediatorHttp: any = {
@@ -136,7 +139,7 @@ describe('RdfSourceSparql', () => {
           const query = action.init.body.toString();
           return {
             headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
-            body: require('web-streams-node').toWebReadableStream(query.indexOf('COUNT') > 0 ?
+            body: require('readable-stream-node-to-web')(query.indexOf('COUNT') > 0 ?
               streamifyString(`{
   "head": { "vars": [ "count" ]
   } ,

--- a/packages/bus-http/lib/ActorHttp.ts
+++ b/packages/bus-http/lib/ActorHttp.ts
@@ -2,8 +2,11 @@ import type { IAction, IActorArgs, IActorOutput, IActorTest, Mediate } from '@co
 import { Actor } from '@comunica/core';
 import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
 
+// TODO: Remove when targeting NodeJS 18+
+global.ReadableStream = global.ReadableStream || require('web-streams-ponyfill').ReadableStream;
+
 const isStream = require('is-stream');
-const toWebReadableStream = require('web-streams-node').toWebReadableStream;
+const toWebReadableStream = require('readable-stream-node-to-web');
 
 /**
  * A base actor for listening to HTTP events.

--- a/packages/bus-http/package.json
+++ b/packages/bus-http/package.json
@@ -33,7 +33,8 @@
     "@comunica/core": "^2.3.0",
     "is-stream": "^2.0.0",
     "readable-web-to-node-stream": "^3.0.2",
-    "web-streams-node": "^0.4.0"
+    "readable-stream-node-to-web": "^1.0.1",
+    "web-streams-ponyfill": "^1.4.2"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11951,16 +11951,7 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-web-streams-node@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/web-streams-node/-/web-streams-node-0.4.0.tgz#641e42d7a7c4df95785a774e2484ba93d36fd672"
-  integrity sha512-u+PBQs8DFaBrN/bxCLFn21tO/ZP7EM3qA4FGzppoUCcZ5CaMbKOsN8uOp27ylVEsfrxcR2tsF6gWHI5M8bN73w==
-  dependencies:
-    is-stream "^1.1.0"
-    readable-stream-node-to-web "^1.0.1"
-    web-streams-ponyfill "^1.4.1"
-
-web-streams-ponyfill@^1.4.1:
+web-streams-ponyfill@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/web-streams-ponyfill/-/web-streams-ponyfill-1.4.2.tgz#0ae863cc5f7493903679f16b08cbf14d432b62f4"
   integrity sha512-LCHW+fE2UBJ2vjhqJujqmoxh1ytEDEr0dPO3CabMdMDJPKmsaxzS90V1Ar6LtNE5VHLqxR4YMEj1i4lzMAccIA==


### PR DESCRIPTION
The only useful line in this module was exporting globally the ReadableStream polyfill provided by 'web-streams-ponyfill'