### PR TITLE
Replace setImmediate by setTimeout

### DIFF
--- a/packages/actor-http-native/lib/ActorHttpNative.ts
+++ b/packages/actor-http-native/lib/ActorHttpNative.ts
@@ -87,7 +87,7 @@ export class ActorHttpNative extends ActorHttp {
           httpResponse.destroy();
         }
         // Using setImmediate so error can be caught should it be thrown
-        setImmediate(() => {
+        setTimeout(() => {
           if (httpResponse) {
             // Expose fetch cancel promise
             httpResponse.cancel = () => {

--- a/packages/actor-http-native/lib/Requester.ts
+++ b/packages/actor-http-native/lib/Requester.ts
@@ -93,7 +93,7 @@ export default class Requester {
         return decoded;
       }
       // Error when no suitable decoder found
-      setImmediate(() => {
+      setTimeout(() => {
         response.emit('error', new Error(`Unsupported encoding: ${encoding}`));
       });
     }

--- a/packages/actor-query-result-serialize-json/lib/ActorQueryResultSerializeJson.ts
+++ b/packages/actor-query-result-serialize-json/lib/ActorQueryResultSerializeJson.ts
@@ -74,7 +74,7 @@ export class ActorQueryResultSerializeJson extends ActorQueryResultSerializeFixe
         data.push(`${JSON.stringify(await (<IQueryOperationResultBoolean> action).execute())}\n`);
         data.push(null);
       } catch (error: unknown) {
-        setImmediate(() => data.emit('error', error));
+        setTimeout(() => data.emit('error', error));
       }
     }
 

--- a/packages/actor-query-result-serialize-simple/lib/ActorQueryResultSerializeSimple.ts
+++ b/packages/actor-query-result-serialize-simple/lib/ActorQueryResultSerializeSimple.ts
@@ -57,7 +57,7 @@ export class ActorQueryResultSerializeSimple extends ActorQueryResultSerializeFi
         data.push(`${JSON.stringify(await (<IQueryOperationResultBoolean> action).execute())}\n`);
         data.push(null);
       } catch (error: unknown) {
-        setImmediate(() => data.emit('error', error));
+        setTimeout(() => data.emit('error', error));
       }
     } else {
       (<IQueryOperationResultVoid> action).execute()
@@ -65,7 +65,7 @@ export class ActorQueryResultSerializeSimple extends ActorQueryResultSerializeFi
           data.push('ok\n');
           data.push(null);
         })
-        .catch(error => setImmediate(() => data.emit('error', error)));
+        .catch(error => setTimeout(() => data.emit('error', error)));
     }
 
     return { data };

--- a/packages/actor-query-result-serialize-sparql-xml/lib/ActorQueryResultSerializeSparqlXml.ts
+++ b/packages/actor-query-result-serialize-sparql-xml/lib/ActorQueryResultSerializeSparqlXml.ts
@@ -97,16 +97,16 @@ export class ActorQueryResultSerializeSparqlXml extends ActorQueryResultSerializ
       resultStream.on('end', () => {
         serializer.close();
         serializer.close();
-        setImmediate(() => data.push(null));
+        setTimeout(() => data.push(null));
       });
     } else {
       try {
         const result = await (<IQueryOperationResultBoolean> action).execute();
         serializer.add({ name: 'boolean', children: result.toString() });
         serializer.close();
-        setImmediate(() => data.push(null));
+        setTimeout(() => data.push(null));
       } catch (error: unknown) {
-        setImmediate(() => data.emit('error', error));
+        setTimeout(() => data.emit('error', error));
       }
     }
 

--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/MediatedLinkedRdfSourcesAsyncRdfIterator.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/MediatedLinkedRdfSourcesAsyncRdfIterator.ts
@@ -119,7 +119,7 @@ export class MediatedLinkedRdfSourcesAsyncRdfIterator extends LinkedRdfSourcesAs
       // This for example allows SPARQL endpoints that error on service description fetching to still be source-forcible
       quads = new Readable();
       quads.read = () => {
-        setImmediate(() => quads.emit('error', error));
+        setTimeout(() => quads.emit('error', error));
         return null;
       };
       metadata = {};


### PR DESCRIPTION
setTimeout(X) runs the callback on the next event cycle
except if there is more than 5 nested setTimeout.
In this case it waits at least 4ms.
This should be fine because we are not overusing setTimeout in Comunica.