### PR TITLE
fix: polyfill Buffer in webpack

### DIFF
--- a/packages/actor-init-query/webpack.config.js
+++ b/packages/actor-init-query/webpack.config.js
@@ -20,6 +20,11 @@ module.exports = {
       },
     ]
   },
+  resolve: {
+    fallback: {
+      buffer: require.resolve("buffer/"),
+    }
+  },
   plugins: [
     new webpack.ProgressPlugin()
   ]


### PR DESCRIPTION
Resolves #1053 

My main question is - does the `ProvidePlugin` removed in https://github.com/comunica/comunica/pull/1023/files need to be introduced
