### PR TITLE
Fix Headers not being sent

### DIFF
--- a/packages/actor-http-fetch/lib/ActorHttpFetch.ts
+++ b/packages/actor-http-fetch/lib/ActorHttpFetch.ts
@@ -34,8 +34,8 @@ export class ActorHttpFetch extends ActorHttp {
 
   public async run(action: IActionHttp): Promise<IActorHttpOutput> {
     // Prepare headers
-    const initHeaders = action.init ? action.init.headers || {} : {};
-    action.init = action.init ? action.init : {};
+    const initHeaders = action.init?.headers ?? {};
+    action.init = action.init ?? {};
     action.init.headers = new Headers(initHeaders);
     if (!action.init.headers.has('user-agent')) {
       action.init.headers.append('user-agent', this.userAgent);

--- a/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
+++ b/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/filename-case */
+/* eslint-enable unicorn/filename-case */
 
 import { ActorHttp } from '@comunica/bus-http';
-import { KeysHttp } from '@comunica/context-entries';
 import type { IFetchInitPreprocessor } from './IFetchInitPreprocessor';
 
 /**

--- a/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
+++ b/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
@@ -1,5 +1,7 @@
 /* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
+
+import { ActorHttp } from '@comunica/bus-http';
+import { KeysHttp } from '@comunica/context-entries';
 import type { IFetchInitPreprocessor } from './IFetchInitPreprocessor';
 
 /**
@@ -14,6 +16,11 @@ export class FetchInitPreprocessor implements IFetchInitPreprocessor {
         headers.delete('user-agent');
       }
       init.headers = headers;
+    }
+
+    // TODO: remove this workaround once this has a fix: https://github.com/inrupt/solid-client-authn-js/issues/1708
+    if (init?.headers && 'append' in init.headers) {
+      init.headers = ActorHttp.headersToHash(init.headers);
     }
 
     // Browsers don't yet support passing ReadableStream as body to requests, see


### PR DESCRIPTION
Related issue: https://github.com/comunica/comunica-feature-solid/issues/30

I used https://github.com/remodietlicher/comunica-solid-react-test to test the fix. 
To replicate the fix clone the repo, and use `yarn link` in the `packages/actor-http-fetch` directory on this branch to test the fixed version

Also added a small refactor that i saw, the tests were unaffected by it so i assume its good but let me know if its not then ill remove it :v: