### PR TITLE
ignore also .vscode file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .rdf-test-suite-cache
 .rdf-test-suite-ldf-cache
 .idea
+.vscode
 lerna-debug.log
 yarn-error.log
 .eslintcache


### PR DESCRIPTION
For the convenience of vs code users, since web storm config file are already ignored.