### PR TITLE
feature/localizeBlankNodes expose to the cli interface.

### DIFF
--- a/packages/actor-init-query/lib/ActorInitQueryBase.ts
+++ b/packages/actor-init-query/lib/ActorInitQueryBase.ts
@@ -118,7 +118,8 @@ export interface IActorInitQueryBaseArgs extends IActorInitArgs {
    *   "extensionFunctions": "@comunica/actor-init-query:extensionFunctions",
    *   "extensionFunctionCreator": "@comunica/actor-init-query:extensionFunctionCreator",
    *   "explain": "@comunica/actor-init-query:explain",
-   *   "unionDefaultGraph": "@comunica/bus-query-operation:unionDefaultGraph"
+   *   "unionDefaultGraph": "@comunica/bus-query-operation:unionDefaultGraph",
+   *   "localizeBlankNodes": "@comunica/actor-query-operation:localizeBlankNodes"
    * }}
    */
   contextKeyShortcuts: Record<string, string>;

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -1,5 +1,5 @@
 import { ProxyHandlerStatic } from '@comunica/actor-http-proxy';
-import { KeysHttpMemento, KeysHttpProxy, KeysInitQuery } from '@comunica/context-entries';
+import { KeysHttpMemento, KeysHttpProxy, KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import type { ICliArgsHandler } from '@comunica/types';
 import type { Argv } from 'yargs';
 
@@ -80,6 +80,11 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
             'physical',
           ],
         },
+        localizeBlankNodes: {
+          type: 'boolean',
+          describe: `Set the blank node localization.
+          If it is activated than each blank node occurence in the output will be threated as a new one.`,
+        },
       })
       .check(args => {
         if (args.version || args.listformats) {
@@ -111,6 +116,11 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
     // Mark explain output
     if (args.explain) {
       context[KeysInitQuery.explain.name] = args.explain;
+    }
+
+    // Set the blank node localization
+    if (args.localizeBlankNodes) {
+      context[KeysQueryOperation.localizeBlankNodes.name] = args.localizeBlankNodes;
     }
   }
 }

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -82,8 +82,7 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
         },
         localizeBlankNodes: {
           type: 'boolean',
-          describe: `Set the blank node localization.
-          If it is activated then each blank node occurence in the output will be threated as a new one.`,
+          describe: "If blank nodes should be localized per bindings entry",
         },
       })
       .check(args => {

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -82,7 +82,7 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
         },
         localizeBlankNodes: {
           type: 'boolean',
-          describe: "If blank nodes should be localized per bindings entry",
+          describe: 'If blank nodes should be localized per bindings entry',
         },
       })
       .check(args => {

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -83,7 +83,7 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
         localizeBlankNodes: {
           type: 'boolean',
           describe: `Set the blank node localization.
-          If it is activated than each blank node occurence in the output will be threated as a new one.`,
+          If it is activated then each blank node occurence in the output will be threated as a new one.`,
         },
       })
       .check(args => {

--- a/packages/actor-init-query/test/ActorInitQuery-test.ts
+++ b/packages/actor-init-query/test/ActorInitQuery-test.ts
@@ -291,6 +291,23 @@ describe('ActorInitQuery', () => {
           .toHaveBeenCalledWith(expect.anything(), 'testtype', expect.anything());
       });
 
+      it('handle the --localizeBlankNodes option', async() => {
+        const stdout = await stringifyStream(<any> (await actor.run({
+          argv: [ sourceHypermedia, queryString, '--localizeBlankNodes', 'true' ],
+          env: {},
+          stdin: <Readable><any> new PassThrough(),
+          context,
+        })).stdout);
+
+        expect(stdout).toContain(`{"a":"triple"}`);
+        expect(spyQueryOrExplain).toHaveBeenCalledWith(queryString, {
+          [KeysInitQuery.queryFormat.name]: { language: 'sparql', version: '1.1' },
+          [KeysQueryOperation.localizeBlankNodes.name]: true,
+          [KeysRdfResolveQuadPattern.sources.name]: [{ value: sourceHypermedia }],
+          [KeysCore.log.name]: expect.any(LoggerPretty),
+        });
+      });
+
       it('handles the old inline context form', async() => {
         const stdout = await stringifyStream(<any> (await actor.run({
           argv: [ `{ "bla": true }`, 'Q' ],

--- a/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
+++ b/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
@@ -46,9 +46,9 @@ export class ActorQueryOperationConstruct extends ActorQueryOperationTypedMediat
       await this.mediatorQueryOperation.mediate({ operation, context }),
     );
 
-    // Check if the we apply blank node localization
-    // Using the context, if this parameter is not provided
-    // the blank node localization will be apply
+    // Check if we apply blank node localization.
+    // The context dictate it's application.
+    // If it is not provided will apply the localization by default.
     const localizeBlankNodesFromContext = context.get(KeysQueryOperation.localizeBlankNodes);
     const localizeBlankNodes = localizeBlankNodesFromContext !== undefined ?
     <boolean> localizeBlankNodesFromContext :

--- a/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
+++ b/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
@@ -47,11 +47,10 @@ export class ActorQueryOperationConstruct extends ActorQueryOperationTypedMediat
     );
 
     // Check if the query if it's a DESCRIBE query
-    let localizeBlankNodes = true;
     const localizeBlankNodesFromContext = context.get(KeysQueryOperation.localizeBlankNodes);
-    if (localizeBlankNodesFromContext !== null) {
-      localizeBlankNodes = <boolean> localizeBlankNodesFromContext;
-    }
+    const localizeBlankNodes = localizeBlankNodesFromContext !== undefined ?
+    <boolean> localizeBlankNodesFromContext :
+      true;
 
     // Construct triples using the result based on the pattern.
     // If it's a DESCRIBE query don't apply the blank node localisation.

--- a/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
+++ b/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
@@ -46,7 +46,9 @@ export class ActorQueryOperationConstruct extends ActorQueryOperationTypedMediat
       await this.mediatorQueryOperation.mediate({ operation, context }),
     );
 
-    // Check if the query if it's a DESCRIBE query
+    // Check if the we apply blank node localization
+    // Using the context, if this parameter is not provided
+    // the blank node localization will be apply
     const localizeBlankNodesFromContext = context.get(KeysQueryOperation.localizeBlankNodes);
     const localizeBlankNodes = localizeBlankNodesFromContext !== undefined ?
     <boolean> localizeBlankNodesFromContext :

--- a/packages/actor-query-operation-describe-subject/lib/ActorQueryOperationDescribeSubject.ts
+++ b/packages/actor-query-operation-describe-subject/lib/ActorQueryOperationDescribeSubject.ts
@@ -80,8 +80,12 @@ export class ActorQueryOperationDescribeSubject extends ActorQueryOperationTyped
       });
     }
 
-    context = context.set(KeysQueryOperation.localizeBlankNodes, false);
-
+    // Set the blank node localization
+    // If it was not provided by the context it will set to false and added into the context
+    const localizeBlankNode = context.get(KeysQueryOperation.localizeBlankNodes);
+    context = context.set(KeysQueryOperation.localizeBlankNodes, localizeBlankNode !== undefined ?
+      <boolean> localizeBlankNode :
+      false);
     // Evaluate the construct queries
     const outputs: IQueryOperationResultQuads[] = (await Promise.all(operations.map(
       operation => this.mediatorQueryOperation.mediate({ operation, context }),

--- a/packages/actor-query-operation-describe-subject/test/ActorQueryOperationDescribeSubject-test.ts
+++ b/packages/actor-query-operation-describe-subject/test/ActorQueryOperationDescribeSubject-test.ts
@@ -1,4 +1,6 @@
 import { ActorQueryOperation } from '@comunica/bus-query-operation';
+import type { IActionQueryOperation } from '@comunica/bus-query-operation';
+import { KeysQueryOperation } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IQueryOperationResultQuads } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
@@ -143,6 +145,34 @@ describe('ActorQueryOperationDescribeSubject', () => {
           DF.quad(DF.namedNode('b'), DF.namedNode('__predicate1'), DF.namedNode('__object1')),
         ]);
       });
+    });
+
+    it('should handle localizeBlankNodes provided by the context', () => {
+      const context = new ActionContext({ name: 'context', [KeysQueryOperation.localizeBlankNodes.name]: true });
+      const op: any = {
+        context,
+        operation: {
+          input: { type: 'bgp', patterns: [ DF.quad(DF.variable('a'), DF.variable('b'), DF.namedNode('dummy')) ]},
+          terms: [ DF.variable('a'), DF.variable('b'), DF.namedNode('c') ],
+          type: 'describe',
+        },
+      };
+      const spyMediator = jest.spyOn(mediatorQueryOperation, 'mediate');
+
+      const result = actor.run(op).then(async(output: IQueryOperationResultQuads) => {
+        expect(await output.metadata())
+          .toEqual({ cardinality: { type: 'estimate', value: 4 }, canContainUndefs: false });
+        expect(output.type).toEqual('quads');
+        expect(await arrayifyStream(output.quadStream)).toEqual([
+          DF.quad(DF.namedNode('c'), DF.namedNode('__predicate'), DF.namedNode('__object')),
+          DF.quad(DF.namedNode('a'), DF.namedNode('b'), DF.namedNode('dummy')),
+          DF.quad(DF.namedNode('a'), DF.namedNode('__predicate0'), DF.namedNode('__object0')),
+          DF.quad(DF.namedNode('b'), DF.namedNode('__predicate1'), DF.namedNode('__object1')),
+        ]);
+      });
+      expect((<IActionQueryOperation>spyMediator.mock.calls[0][0])
+        .context.get(KeysQueryOperation.localizeBlankNodes)).toBe(true);
+      return result;
     });
   });
 });


### PR DESCRIPTION
using the CLI interface the user can use the flag `--localizeBlankNodes` to force the application to use or not the blank node localization for the construct and describe query.

followup to #1063