### PR TITLE
chore: add solid integration tests

### DIFF
--- a/engines/config-query-sparql/config/http/actors-wayback.json
+++ b/engines/config-query-sparql/config/http/actors-wayback.json
@@ -1,0 +1,19 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^2.0.0/components/context.jsonld",
+
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-wayback/^2.0.0/components/context.jsonld",
+
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^2.0.0/components/context.jsonld"
+  ],
+  "@id": "urn:comunica:default:Runner",
+  "@type": "Runner",
+  "actors": [
+    {
+      "@id": "urn:comunica:default:http/actors#main",
+      "@type": "ActorHttpWayback",
+      "bus": { "@id": "ActorHttp:_fallback_bus" },
+      "mediatorHttp": { "@id": "urn:comunica:default:http/mediators#no-fallback" }
+    }
+  ]
+}

--- a/engines/config-query-sparql/config/http/actors.json
+++ b/engines/config-query-sparql/config/http/actors.json
@@ -3,6 +3,7 @@
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^2.0.0/components/context.jsonld"
   ],
   "import": [
-    "ccqs:config/http/actors-fetch.json"
+    "ccqs:config/http/actors-fetch.json",
+    "ccqs:config/http/actors-wayback.json"
   ]
 }

--- a/engines/config-query-sparql/config/http/mediators.json
+++ b/engines/config-query-sparql/config/http/mediators.json
@@ -1,11 +1,23 @@
 {
   "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/core/^2.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/bus-http/^2.0.0/components/context.jsonld",
     "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/mediator-number/^2.0.0/components/context.jsonld"
   ],
   "@graph": [
     {
       "@id": "urn:comunica:default:http/mediators#main",
+      "@type": "MediatorNumber",
+      "type": "min",
+      "field": "time",
+      "ignoreErrors": true,
+      "bus": {
+        "@id": "ActorHttp:_fallback_bus",
+        "@type": "cc:components/Bus.jsonld#Bus"
+      }
+    },
+    {
+      "@id": "urn:comunica:default:http/mediators#no-fallback",
       "@type": "MediatorNumber",
       "type": "min",
       "field": "time",

--- a/engines/query-sparql-file/package.json
+++ b/engines/query-sparql-file/package.json
@@ -52,7 +52,7 @@
     "@comunica/actor-dereference-rdf-parse": "^2.4.2",
     "@comunica/actor-hash-bindings-sha1": "^2.4.0",
     "@comunica/actor-http-fetch": "^2.4.3",
-    "@comunica/actor-http-intercept-wayback": "^2.0.0",
+    "@comunica/actor-http-wayback": "^2.0.0",
     "@comunica/actor-http-proxy": "^2.4.0",
     "@comunica/actor-init-query": "^2.4.3",
     "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.4.0",

--- a/engines/query-sparql-file/package.json
+++ b/engines/query-sparql-file/package.json
@@ -52,6 +52,7 @@
     "@comunica/actor-dereference-rdf-parse": "^2.4.2",
     "@comunica/actor-hash-bindings-sha1": "^2.4.0",
     "@comunica/actor-http-fetch": "^2.4.3",
+    "@comunica/actor-http-intercept-wayback": "^2.0.0",
     "@comunica/actor-http-proxy": "^2.4.0",
     "@comunica/actor-init-query": "^2.4.3",
     "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.4.0",

--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -50,7 +50,7 @@
     "@comunica/actor-dereference-rdf-parse": "^2.4.2",
     "@comunica/actor-hash-bindings-sha1": "^2.4.0",
     "@comunica/actor-http-fetch": "^2.4.3",
-    "@comunica/actor-http-intercept-wayback": "^2.0.0",
+    "@comunica/actor-http-wayback": "^2.0.0",
     "@comunica/actor-http-proxy": "^2.4.0",
     "@comunica/actor-init-query": "^2.4.3",
     "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.4.0",

--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -50,6 +50,7 @@
     "@comunica/actor-dereference-rdf-parse": "^2.4.2",
     "@comunica/actor-hash-bindings-sha1": "^2.4.0",
     "@comunica/actor-http-fetch": "^2.4.3",
+    "@comunica/actor-http-intercept-wayback": "^2.0.0",
     "@comunica/actor-http-proxy": "^2.4.0",
     "@comunica/actor-init-query": "^2.4.3",
     "@comunica/actor-optimize-query-operation-bgp-to-join": "^2.4.0",

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -3,7 +3,7 @@
 // Needed to undo automock from actor-http-native, cleaner workarounds do not appear to be working.
 jest.unmock('follow-redirects');
 
-import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
+import { KeysHttpWayback, KeysRdfResolveQuadPattern } from '@comunica/context-entries';
 import { BlankNodeScoped } from '@comunica/data-factory';
 import type { QueryBindings, QueryStringContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
@@ -443,6 +443,27 @@ describe('System test: QuerySparql', () => {
     }`, { sources: [ 'https://fragments.dbpedia.org/2016-04/en' ]});
         expect((await arrayifyStream(await result.execute()))).toEqual([]);
       });
+    });
+  });
+
+  describe('foaf ontology broken link [using full key]', () => {
+    it('returns results with link recovery on [using full key]', async() => {
+      const result = <QueryBindings> await engine.query(`SELECT * WHERE {
+    <http://xmlns.com/foaf/0.1/> a <http://www.w3.org/2002/07/owl#Ontology>.
+  }`, {
+        sources: [ 'http://xmlns.com/foaf/spec/20140114.rdf' ],
+        [KeysHttpWayback.recoverBrokenLinks.name]: true,
+      });
+      expect((await arrayifyStream(await result.execute())).length).toEqual(1);
+    });
+  });
+
+  describe('foaf ontology broken link [using shortcut key]', () => {
+    it('returns results with link recovery on [using shortcut key]', async() => {
+      const result = <QueryBindings> await engine.query(`SELECT * WHERE {
+    <http://xmlns.com/foaf/0.1/> a <http://www.w3.org/2002/07/owl#Ontology>.
+  }`, { sources: [ 'http://xmlns.com/foaf/spec/20140114.rdf' ], recoverBrokenLinks: true });
+      expect((await arrayifyStream(await result.execute())).length).toEqual(1);
     });
   });
 

--- a/engines/query-sparql/test/Solid-test.ts
+++ b/engines/query-sparql/test/Solid-test.ts
@@ -1,0 +1,289 @@
+import * as path from 'path';
+import type { KeyPair } from '@inrupt/solid-client-authn-core';
+import {
+  createDpopHeader,
+  generateDpopKeyPair,
+  buildAuthenticatedFetch,
+} from '@inrupt/solid-client-authn-core';
+import type { App } from '@solid/community-server';
+import { AppRunner, resolveModulePath } from '@solid/community-server';
+import fetch from 'node-fetch';
+import { QueryEngine } from '../lib/QueryEngine';
+
+const config = [{
+  podName: 'example',
+  email: 'hello@example.com',
+  password: 'abc123',
+}];
+
+function createApp() {
+  return new AppRunner().create(
+    {
+      mainModulePath: resolveModulePath(''),
+      typeChecking: false,
+    },
+    resolveModulePath('config/default.json'),
+    {},
+    {
+      port: 3_001,
+      loggingLevel: 'off',
+      seededPodConfigJson: path.join(__dirname, 'configs', 'seed.json'),
+    },
+  );
+}
+
+interface ISecretData {
+  id: string;
+  secret: string;
+}
+
+// From https://communitysolidserver.github.io/CommunitySolidServer/5.x/usage/client-credentials/
+function getSecret(): Promise<ISecretData> {
+  return fetch('http://localhost:3001/idp/credentials/', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: config[0].email, password: config[0].password, name: config[0].podName }),
+  }).then(res => res.json());
+}
+
+interface ITokenData {
+  accessToken: string;
+  dpopKey: KeyPair;
+}
+
+// From https://communitysolidserver.github.io/CommunitySolidServer/5.x/usage/client-credentials/
+async function refreshToken({ id, secret }: ISecretData): Promise<ITokenData> {
+  const dpopKey = await generateDpopKeyPair();
+  const authString = `${encodeURIComponent(id)}:${encodeURIComponent(secret)}`;
+  const tokenUrl = 'http://localhost:3001/.oidc/token';
+  const accessToken = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: {
+      // The header needs to be in base64 encoding.
+      authorization: `Basic ${Buffer.from(authString).toString('base64')}`,
+      'content-type': 'application/x-www-form-urlencoded',
+      dpop: await createDpopHeader(tokenUrl, 'POST', dpopKey),
+    },
+    body: 'grant_type=client_credentials&scope=webid',
+  })
+    .then(res => res.json())
+    .then(res => res.access_token);
+
+  return { accessToken, dpopKey };
+}
+
+describe('System test: QuerySparql over Solid Pods', () => {
+  let app: App;
+  let engine: QueryEngine;
+  let secret: ISecretData;
+  let token: ITokenData;
+  let authFetch: typeof fetch;
+
+  beforeEach(() => {
+    engine = new QueryEngine();
+  });
+
+  beforeAll(async() => {
+    // Start up the server
+    app = await createApp();
+    await app.start();
+
+    // Generate secret
+    secret = await getSecret();
+
+    // Get token
+    token = await refreshToken(secret);
+
+    // Build authenticated fetch
+    authFetch = <any> await buildAuthenticatedFetch(<any>fetch, token.accessToken, { dpopKey: token.dpopKey });
+
+    // TODO: Mock this better
+    // Override global fetch with auth fetch
+    // @ts-expect-error
+    // eslint-disable-next-line no-undef
+    globalThis.fetch = authFetch;
+  });
+
+  afterAll(async() => {
+    await app.stop();
+  });
+
+  describe('Querying data from a Pod', () => {
+    let resource: string;
+    let i = 0;
+
+    describe('A single resource containing <ex:s> <ex:p> <ex:o1> . <ex:s> <ex:p> <ex:o1.1>', () => {
+      // Create a new file in the Pod
+      beforeEach(async() => {
+        resource = `http://localhost:3001/${config[0].podName}/myContainer/myFile-${i++}.ttl`;
+        // Create test.ttl (did not exist before)
+        await engine.queryVoid(`INSERT DATA { <ex:s> <ex:p> <ex:o1> . <ex:s> <ex:p> <ex:o1.1> }`, {
+          sources: [ resource ],
+          destination: resource,
+        });
+      });
+
+      it('Should return 2 quads from resource', async() => {
+        // Get data in resource file
+        const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }`, {
+          sources: [ resource ],
+        }).then(res => res.toArray());
+
+        expect(quads).toHaveLength(2);
+      });
+
+      it('Should return 1 quads from when doing more restricted query', async() => {
+        // Get data in resource file
+        const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p 1 } WHERE { ?s ?p <ex:o1.1> }`, {
+          sources: [ resource ],
+        }).then(res => res.toArray());
+
+        expect(quads).toHaveLength(1);
+      });
+
+      it('Should return 2 quads from resource [Link Recovery Enabled]', async() => {
+        // Get data in resource file
+        const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }`, {
+          sources: [ resource ],
+          recoverBrokenLinks: true,
+        }).then(res => res.toArray());
+
+        expect(quads).toHaveLength(2);
+      });
+
+      it('Should return 1 quads from when doing more restricted query [Link Recovery Enabled]', async() => {
+        // Get data in resource file
+        const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p 1 } WHERE { ?s ?p <ex:o1.1> }`, {
+          sources: [ resource ],
+          recoverBrokenLinks: true,
+        }).then(res => res.toArray());
+
+        expect(quads).toHaveLength(1);
+      });
+    });
+
+    describe('A single resource containing <ex:s> <ex:p> <ex:o1> . <ex:s> <ex:p> <ex:o1.1> [linkRecovery: true]',
+      () => {
+      // Create a new file in the Pod
+        beforeEach(async() => {
+          resource = `http://localhost:3001/${config[0].podName}/myContainer/myFile-${i++}.ttl`;
+          // Create test.ttl (did not exist before)
+          await engine.queryVoid(`INSERT DATA { <ex:s> <ex:p> <ex:o1> . <ex:s> <ex:p> <ex:o1.1> }`, {
+            sources: [ resource ],
+            destination: resource,
+            recoverBrokenLinks: true,
+          });
+        });
+
+        it('Should return 2 quads from resource', async() => {
+        // Get data in resource file
+          const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }`, {
+            sources: [ resource ],
+          }).then(res => res.toArray());
+
+          expect(quads).toHaveLength(2);
+        });
+
+        it('Should return 1 quads from when doing more restricted query', async() => {
+        // Get data in resource file
+          const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p 1 } WHERE { ?s ?p <ex:o1.1> }`, {
+            sources: [ resource ],
+          }).then(res => res.toArray());
+
+          expect(quads).toHaveLength(1);
+        });
+
+        it('Should return 2 quads from resource [Link Recovery Enabled]', async() => {
+        // Get data in resource file
+          const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }`, {
+            sources: [ resource ],
+            recoverBrokenLinks: true,
+          }).then(res => res.toArray());
+
+          expect(quads).toHaveLength(2);
+        });
+
+        it('Should return 1 quads from when doing more restricted query [Link Recovery Enabled]', async() => {
+        // Get data in resource file
+          const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p 1 } WHERE { ?s ?p <ex:o1.1> }`, {
+            sources: [ resource ],
+            recoverBrokenLinks: true,
+          }).then(res => res.toArray());
+
+          expect(quads).toHaveLength(1);
+        });
+      });
+
+    // TODO: Enable this once https://github.com/comunica/comunica-feature-solid/issues/43 is solved
+    // describe('A single resource containing <ex:s> <ex:p> <ex:o1> after deletion', () => {
+    //   // Create a new file in the Pod
+    //   beforeEach(async () => {
+    //     resource = `http://localhost:3001/${config[0].podName}/myContainer/myFile-${i++}.ttl`;
+    //     // Create test.ttl (did not exist before)
+    //     await engine.queryVoid(`INSERT DATA { <ex:s> <ex:p> <ex:o1> . <ex:s> <ex:p> <ex:o1.1> }`, {
+    //       sources: [resource],
+    //       destination: resource
+    //     });
+
+    //     await engine.queryVoid(`DELETE DATA { <ex:s> <ex:p> <ex:o1.1> }`, {
+    //       sources: [resource],
+    //       destination: resource
+    //     });
+    //   });
+
+    //   it('Should return 1 quads from resource', async () => {
+    //     // Get data in resource file
+    //     const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }`, {
+    //       sources: [resource]
+    //     }).then(res => res.toArray());
+
+    //     expect(quads).toHaveLength(1);
+    //   });
+
+    //   it('Should return 0 quads from when doing more restricted query', async () => {
+    //     // Get data in resource file
+    //     const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p 1 } WHERE { ?s ?p <ex:o1.1> }`, {
+    //       sources: [resource]
+    //     }).then(res => res.toArray());
+
+    //     expect(quads).toHaveLength(0);
+    //   });
+    // });
+
+    describe('A single resource containing <ex:s> <ex:p> <ex:o1> . <ex:s> <ex:p> <ex:o1.1> inserted separately', () => {
+      // Create a new file in the Pod
+      beforeEach(async() => {
+        resource = `http://localhost:3001/${config[0].podName}/myContainer/myFile-${i++}.ttl`;
+        // Create test.ttl (did not exist before)
+        await engine.queryVoid(`INSERT DATA { <ex:s> <ex:p> <ex:o1> }`, {
+          sources: [ resource ],
+          destination: resource,
+        });
+
+        await engine.queryVoid(`INSERT DATA { <ex:s> <ex:p> <ex:o1.1> }`, {
+          sources: [ resource ],
+          destination: resource,
+        });
+      });
+
+      // TODO: Enable this when https://github.com/comunica/comunica-feature-solid/issues/43 is closed
+      // it('Should return 2 quads from resource', async () => {
+      //   // Get data in resource file
+      //   const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }`, {
+      //     sources: [resource]
+      //   }).then(res => res.toArray());
+
+      //   expect(quads).toHaveLength(2);
+      // });
+
+      it('Should return 1 quads from when doing more restricted query', async() => {
+        // Get data in resource file
+        const quads = await engine.queryQuads(`CONSTRUCT { ?s ?p 1 } WHERE { ?s ?p <ex:o1.1> }`, {
+          sources: [ resource ],
+        }).then(res => res.toArray());
+
+        expect(quads).toHaveLength(1);
+      });
+    });
+  });
+});

--- a/engines/query-sparql/test/assets/http/System-test-QuerySparql_3917140063/foaf-ontology-broken-link-using-full-key_1078950405/returns-results-with-link-recovery-on-using-full-key_2180544308/recording.har
+++ b/engines/query-sparql/test/assets/http/System-test-QuerySparql_3917140063/foaf-ontology-broken-link-using-full-key_1078950405/returns-results-with-link-recovery-on-using-full-key_2180544308/recording.har
@@ -1,0 +1,393 @@
+{
+  "log": {
+    "_recordingName": "System test: QuerySparql/foaf ontology broken link [using full key]/returns results with link recovery on [using full key]",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "6.0.5"
+    },
+    "entries": [
+      {
+        "_id": "6b273d1822ba3c3454b05d5bda0c2d35",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "application/n-quads,application/trig;q=0.95,application/ld+json;q=0.9,application/n-triples;q=0.8,text/turtle;q=0.6,application/rdf+xml;q=0.5,application/json;q=0.45,text/n3;q=0.35,application/xml;q=0.3,image/svg+xml;q=0.3,text/xml;q=0.3,text/html;q=0.2,application/xhtml+xml;q=0.18"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "xmlns.com"
+            }
+          ],
+          "headersSize": 460,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://xmlns.com/foaf/spec/20140114.rdf"
+        },
+        "response": {
+          "bodySize": 271,
+          "content": {
+            "mimeType": "text/html; charset=iso-8859-1",
+            "size": 271,
+            "text": "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p>The requested URL was not found on this server.</p>\n<hr>\n<address>Apache/2.4.54 (Debian) Server at xmlns.com Port 80</address>\n</body></html>\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Wed, 28 Sep 2022 02:06:50 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache/2.4.54 (Debian)"
+            },
+            {
+              "name": "content-length",
+              "value": "271"
+            },
+            {
+              "name": "keep-alive",
+              "value": "timeout=5, max=100"
+            },
+            {
+              "name": "connection",
+              "value": "Keep-Alive"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=iso-8859-1"
+            }
+          ],
+          "headersSize": 193,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2022-09-28T02:06:48.224Z",
+        "time": 2599,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2599
+        }
+      },
+      {
+        "_id": "ff4ba59936732a9776ed0f7e25f2de1b",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "wayback.archive-it.org"
+            }
+          ],
+          "headersSize": 224,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf"
+        },
+        "response": {
+          "bodySize": 299,
+          "content": {
+            "mimeType": "text/html; charset=utf-8",
+            "size": 299,
+            "text": "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">\n<title>Redirecting...</title>\n<h1>Redirecting...</h1>\n<p>You should be redirected automatically to target URL: <a href=\"/all/2/http://xmlns.com/foaf/spec/20140114.rdf\">/all/2/http://xmlns.com/foaf/spec/20140114.rdf</a>.  If not click the link."
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "server",
+              "value": "gunicorn/19.10.0"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 28 Sep 2022 02:06:52 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "299"
+            },
+            {
+              "name": "location",
+              "value": "http://wayback.archive-it.org/all/2/http://xmlns.com/foaf/spec/20140114.rdf"
+            }
+          ],
+          "headersSize": 213,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "http://wayback.archive-it.org/all/2/http://xmlns.com/foaf/spec/20140114.rdf",
+          "status": 303,
+          "statusText": "See Other"
+        },
+        "startedDateTime": "2022-09-28T02:06:50.826Z",
+        "time": 2058,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2058
+        }
+      },
+      {
+        "_id": "160176254a9e3a6f5f63fd1a09760ba8",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "wayback.archive-it.org"
+            }
+          ],
+          "headersSize": 230,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://wayback.archive-it.org/all/2/http://xmlns.com/foaf/spec/20140114.rdf"
+        },
+        "response": {
+          "bodySize": 0,
+          "content": {
+            "mimeType": "text/plain; charset=utf-8",
+            "size": 0
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "server",
+              "value": "gunicorn/19.10.0"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 28 Sep 2022 02:06:53 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain; charset=utf-8"
+            },
+            {
+              "name": "content-length",
+              "value": "0"
+            },
+            {
+              "name": "x-archive-redirect-reason",
+              "value": "found capture at 20211020094933"
+            },
+            {
+              "name": "location",
+              "value": "http://wayback.archive-it.org/all/20211020094933/http://xmlns.com/foaf/spec/20140114.rdf"
+            },
+            {
+              "name": "server-timing",
+              "value": "captures_list;dur=196.283898, RulesEngine.query;dur=137.349886"
+            }
+          ],
+          "headersSize": 364,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "http://wayback.archive-it.org/all/20211020094933/http://xmlns.com/foaf/spec/20140114.rdf",
+          "status": 302,
+          "statusText": "Found"
+        },
+        "startedDateTime": "2022-09-28T02:06:52.886Z",
+        "time": 495,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 495
+        }
+      },
+      {
+        "_id": "4a906974735452a92170cb9944827827",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "name": "host",
+              "value": "wayback.archive-it.org"
+            }
+          ],
+          "headersSize": 243,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "http://wayback.archive-it.org/all/20211020094933/http://xmlns.com/foaf/spec/20140114.rdf"
+        },
+        "response": {
+          "bodySize": 44209,
+          "content": {
+            "mimeType": "application/rdf+xml",
+            "size": 44209,
+            "text": "<!-- This is the FOAF formal vocabulary description, expressed using W3C RDFS and OWL markup. foaf/spec version -->\n<!-- For more information about FOAF:                                            -->\n<!--   see the FOAF project homepage, http://www.foaf-project.org/               -->\n<!--   FOAF specification, http://xmlns.com/foaf/spec/                             -->\n<!--                                                                             -->\n<!-- first we introduce a number of RDF namespaces we will be using... -->\n<rdf:RDF \n\txmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\" \n\txmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\" \n\txmlns:owl=\"http://www.w3.org/2002/07/owl#\" \n\txmlns:vs=\"http://www.w3.org/2003/06/sw-vocab-status/ns#\" \n\txmlns:foaf=\"http://xmlns.com/foaf/0.1/\" \n\txmlns:wot=\"http://xmlns.com/wot/0.1/\" \n\txmlns:dc=\"http://purl.org/dc/elements/1.1/\">\n<!-- Here we describe general characteristics of the FOAF vocabulary ('ontology'). -->\n  <owl:Ontology rdf:about=\"http://xmlns.com/foaf/0.1/\" dc:title=\"Friend of a Friend (FOAF) vocabulary\" dc:description=\"The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language.\" >\n  </owl:Ontology>\n\n\n  <!-- OWL/RDF interop section - geeks only -->\n  <!--  most folk can ignore this lot. the game here is to make FOAF\n  \twork with vanilla RDF/RDFS tools, and with the stricter OWL DL \n\tprofile of OWL. At the moment we're in the OWL Full flavour of OWL. \n\tThe following are tricks to try have the spec live in both worlds\n\tat once. See\n\t\thttp://phoebus.cs.man.ac.uk:9999/OWL/Validator\n\t\thttp://www.mindswap.org/2003/pellet/demo.shtml\n\t...for some tools that help. \t\t\t\t\t-->\n  <owl:AnnotationProperty rdf:about=\"http://xmlns.com/wot/0.1/assurance\"/>\n  <owl:AnnotationProperty rdf:about=\"http://xmlns.com/wot/0.1/src_assurance\"/>\n  <owl:AnnotationProperty rdf:about=\"http://www.w3.org/2003/06/sw-vocab-status/ns#term_status\"/>\n  <!--  DC terms are NOT annotation properties in general, so we consider the following \n\tclaims scoped to this document. They may be removed in future revisions if\n\tOWL tools become more flexible. -->\n  <owl:AnnotationProperty rdf:about=\"http://purl.org/dc/elements/1.1/description\"/>\n  <owl:AnnotationProperty rdf:about=\"http://purl.org/dc/elements/1.1/title\"/>\n  <owl:AnnotationProperty rdf:about=\"http://purl.org/dc/elements/1.1/date\"/>\n  <owl:Class rdf:about=\"http://www.w3.org/2000/01/rdf-schema#Class\"/>\n\n<!--  <owl:Class rdf:about=\"http://www.w3.org/2000/01/rdf-schema#Resource\"/>\n  <owl:Class rdf:about=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/> -->\n  <!-- end of OWL/RDF interop voodoo. mostly. -->\n\n  <!-- utility class, a candidate for replacing the pattern of subproperty-ing rdfs:label -->\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/LabelProperty\" vs:term_status=\"unstable\">\n    <rdfs:label>Label Property</rdfs:label>\n    <rdfs:comment>A foaf:LabelProperty is any RDF property with texual values that serve as labels.</rdfs:comment>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdfs:Class>\n\n<!-- FOAF classes (types) are listed first. -->\n\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/Person\" rdfs:label=\"Person\" rdfs:comment=\"A person.\" vs:term_status=\"stable\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\" />\n    <owl:equivalentClass rdf:resource=\"http://schema.org/Person\" />\n    <owl:equivalentClass rdf:resource=\"http://www.w3.org/2000/10/swap/pim/contact#Person\" />\n<!--    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/wordnet/1.6/Person\"/></rdfs:subClassOf> -->\n    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/foaf/0.1/Agent\"/></rdfs:subClassOf>\n<!--    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/wordnet/1.6/Agent\"/></rdfs:subClassOf> -->\n    <rdfs:subClassOf><owl:Class rdf:about=\"http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing\" rdfs:label=\"Spatial Thing\"/></rdfs:subClassOf>\n    <!-- aside: \n\tare spatial things always spatially located? \n\tPerson includes imaginary people... discuss... -->\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n\n<!--    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/> this was a mistake; tattoo'd people, for example. -->\n\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Organization\"/>\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Project\"/>\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/Document\" rdfs:label=\"Document\" rdfs:comment=\"A document.\" vs:term_status=\"stable\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <owl:equivalentClass rdf:resource=\"http://schema.org/CreativeWork\" />\n<!--    <rdfs:subClassOf rdf:resource=\"http://xmlns.com/wordnet/1.6/Document\"/> -->\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Organization\"/>\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Project\"/>\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/Organization\" rdfs:label=\"Organization\" rdfs:comment=\"An organization.\" vs:term_status=\"stable\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n<!--    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/wordnet/1.6/Organization\"/></rdfs:subClassOf> -->\n    <rdfs:subClassOf rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/Group\" vs:term_status=\"stable\" rdfs:label=\"Group\" rdfs:comment=\"A class of Agents.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <rdfs:subClassOf rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/Agent\" vs:term_status=\"stable\" rdfs:label=\"Agent\" rdfs:comment=\"An agent (eg. person, group, software or physical artifact).\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <owl:equivalentClass rdf:resource=\"http://purl.org/dc/terms/Agent\"/>\n<!--    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/wordnet/1.6/Agent-3\"/></rdfs:subClassOf> -->\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/Project\" vs:term_status=\"testing\" rdfs:label=\"Project\" rdfs:comment=\"A project (a collective endeavour of some kind).\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n<!--    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/wordnet/1.6/Project\"/></rdfs:subClassOf> -->\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <owl:disjointWith rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n<!-- arguably a subclass of Agent; to be discussed -->\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/Image\" vs:term_status=\"stable\" rdfs:label=\"Image\" rdfs:comment=\"An image.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <owl:equivalentClass rdf:resource=\"http://schema.org/ImageObject\" />\n<!--    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/wordnet/1.6/Document\"/></rdfs:subClassOf> -->\n    <rdfs:subClassOf><owl:Class rdf:about=\"http://xmlns.com/foaf/0.1/Document\"/></rdfs:subClassOf>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdfs:Class>\n\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/PersonalProfileDocument\" rdfs:label=\"PersonalProfileDocument\" rdfs:comment=\"A personal profile RDF document.\" vs:term_status=\"testing\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <rdfs:subClassOf rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n  </rdfs:Class>\n\t\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/OnlineAccount\" vs:term_status=\"testing\" rdfs:label=\"Online Account\" rdfs:comment=\"An online account.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:subClassOf rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\" rdfs:label=\"Thing\"/>\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/OnlineGamingAccount\" vs:term_status=\"unstable\" rdfs:label=\"Online Gaming Account\" rdfs:comment=\"An online gaming account.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <rdfs:subClassOf rdf:resource=\"http://xmlns.com/foaf/0.1/OnlineAccount\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/OnlineEcommerceAccount\" vs:term_status=\"unstable\" rdfs:label=\"Online E-commerce Account\" rdfs:comment=\"An online e-commerce account.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <rdfs:subClassOf rdf:resource=\"http://xmlns.com/foaf/0.1/OnlineAccount\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdfs:Class>\n  <rdfs:Class rdf:about=\"http://xmlns.com/foaf/0.1/OnlineChatAccount\" vs:term_status=\"unstable\" rdfs:label=\"Online Chat Account\" rdfs:comment=\"An online chat account.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/>\n    <rdfs:subClassOf rdf:resource=\"http://xmlns.com/foaf/0.1/OnlineAccount\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdfs:Class>\n<!-- FOAF properties (ie. relationships). -->\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/mbox\" vs:term_status=\"stable\" rdfs:label=\"personal mailbox\" rdfs:comment=\"A \npersonal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that  there is (across time and change) at most one individual that ever has any particular value for foaf:mbox.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/mbox_sha1sum\" vs:term_status=\"testing\" rdfs:label=\"sha1sum of a personal mailbox URI name\" rdfs:comment=\"The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the  first owner of the mailbox.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n\n<!--\nput it back in again 2006-01-29 - see \nhttp://chatlogs.planetrdf.com/swig/2006-01-29.html#T21-12-35\nI have mailed rdfweb-dev@vapours.rdfweb.org for discussion.\nLibby\n\nCommenting out as a kindness to OWL DL users. The semantics didn't quite cover\nour usage anyway, since (a) we want static-across-time, which is so beyond OWL as \nto be from another planet (b) we want identity reasoning invariant across xml:lang \ntagging. FOAF code will know what to do. OWL folks note, this assertion might return. \n\ndanbri\n-->\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/gender\" vs:term_status=\"testing\" \nrdfs:label=\"gender\" \nrdfs:comment=\"The gender of this Agent (typically but not necessarily 'male' or 'female').\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#FunctionalProperty\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <!-- whatever one's gender is, and we are liberal in leaving room for more options \n    than 'male' and 'female', we model this so that an agent has only one gender. -->\n  </rdf:Property>\n\n\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/geekcode\" vs:term_status=\"archaic\" rdfs:label=\"geekcode\" rdfs:comment=\"A textual geekcode for this person, see http://www.geekcode.com/geek.html\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/dnaChecksum\" vs:term_status=\"archaic\" rdfs:label=\"DNA checksum\" rdfs:comment=\"A checksum for the DNA of some thing. Joke.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/sha1\" vs:term_status=\"unstable\" rdfs:label=\"sha1sum (hex)\" rdfs:comment=\"A sha1sum hash, in hex.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n<!-- rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\" -->\n<!-- IFP under discussion -->\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/based_near\" vs:term_status=\"testing\" rdfs:label=\"based near\" rdfs:comment=\"A location that something is based near, for some broadly human notion of near.\">\n<!-- see http://esw.w3.org/topic/GeoOnion for extension  ideas -->\n<!-- this was ranged as Agent... hmm -->\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n<!-- FOAF naming properties -->\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/title\" vs:term_status=\"testing\" rdfs:label=\"title\" rdfs:comment=\"Title (Mr, Mrs, Ms, Dr. etc)\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/nick\" vs:term_status=\"testing\" rdfs:label=\"nickname\" rdfs:comment=\"A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames).\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n<!-- ......................... chat IDs ........................... -->\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/jabberID\" vs:term_status=\"testing\" rdfs:label=\"jabber ID\" rdfs:comment=\"A jabber ID for something.\">\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n<!--\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/nick\"/>\n...different to the other IM IDs, as Jabber has wider usage, so \nwe don't want the implied rdfs:domain here.\n\n-->\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <!-- there is a case for using resources/URIs here, ... -->\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/aimChatID\" vs:term_status=\"testing\" rdfs:label=\"AIM chat ID\" rdfs:comment=\"An AIM chat ID\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/nick\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/skypeID\" vs:term_status=\"testing\" rdfs:label=\"Skype ID\" rdfs:comment=\"A Skype ID\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/nick\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <!-- todo: OWL2 easy key definition -->\n  </rdf:Property>\n\n<!-- http://www.stud.uni-karlsruhe.de/~uck4/ICQ/Packet-112.html -->\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/icqChatID\" vs:term_status=\"testing\" rdfs:label=\"ICQ chat ID\" rdfs:comment=\"An ICQ chat ID\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/nick\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/yahooChatID\" vs:term_status=\"testing\" rdfs:label=\"Yahoo chat ID\" rdfs:comment=\"A Yahoo chat ID\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/nick\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/msnChatID\" vs:term_status=\"testing\" rdfs:label=\"MSN chat ID\" rdfs:comment=\"An MSN chat ID\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/nick\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n  </rdf:Property>\n<!-- ....................................................... -->\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/name\" vs:term_status=\"testing\" rdfs:label=\"name\" rdfs:comment=\"A name for some thing.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#label\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/firstName\" vs:term_status=\"testing\" rdfs:label=\"firstName\" rdfs:comment=\"The first name of a person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/lastName\" vs:term_status=\"testing\" rdfs:label=\"lastName\" rdfs:comment=\"The last name of a person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/givenName\" vs:term_status=\"testing\" rdfs:label=\"Given name\" rdfs:comment=\"The given name of some person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/givenname\" vs:term_status=\"archaic\" rdfs:label=\"Given name\" rdfs:comment=\"The given name of some person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/surname\" vs:term_status=\"archaic\" rdfs:label=\"Surname\" rdfs:comment=\"The surname of some person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/family_name\" vs:term_status=\"archaic\" rdfs:label=\"family_name\" rdfs:comment=\"The family name of some person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/familyName\" vs:term_status=\"testing\" rdfs:label=\"familyName\" rdfs:comment=\"The family name of some person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n<!-- end of naming properties. See http://rdfweb.org/issues/show_bug.cgi?id=7\n\t   for open issue / re-design discussions.\n\t-->\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/phone\" vs:term_status=\"testing\" rdfs:label=\"phone\" rdfs:comment=\"A phone,  specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel).\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/homepage\" vs:term_status=\"stable\" rdfs:label=\"homepage\" rdfs:comment=\"A homepage for some thing.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/page\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/isPrimaryTopicOf\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n    <!--  previously: rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\" -->\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/weblog\" vs:term_status=\"stable\" rdfs:label=\"weblog\" rdfs:comment=\"A weblog of some thing (whether person, group, company etc.).\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/page\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/openid\" vs:term_status=\"testing\" rdfs:label=\"openid\" rdfs:comment=\"An OpenID for an Agent.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/isPrimaryTopicOf\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/tipjar\" vs:term_status=\"testing\" rdfs:label=\"tipjar\" rdfs:comment=\"A tipjar document for this agent, describing means for payment and reward.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/page\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/plan\" vs:term_status=\"testing\" rdfs:label=\"plan\" rdfs:comment=\"A .plan comment, in the tradition of finger and '.plan' files.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/made\" vs:term_status=\"stable\" rdfs:label=\"made\" rdfs:comment=\"Something that was made by this agent.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/maker\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/maker\"  vs:term_status=\"stable\" rdfs:label=\"maker\" rdfs:comment=\"An agent that \nmade this thing.\">\n    <owl:equivalentProperty rdf:resource=\"http://purl.org/dc/terms/creator\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/made\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/img\" vs:term_status=\"testing\" rdfs:label=\"image\" rdfs:comment=\"An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage).\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Image\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/depiction\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/depiction\" vs:term_status=\"testing\" rdfs:label=\"depiction\" rdfs:comment=\"A depiction of some thing.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Image\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/depicts\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/depicts\" vs:term_status=\"testing\" rdfs:label=\"depicts\" rdfs:comment=\"A thing depicted in this representation.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Image\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/depiction\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/thumbnail\" vs:term_status=\"testing\" rdfs:label=\"thumbnail\" rdfs:comment=\"A derived thumbnail image.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Image\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Image\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/myersBriggs\" vs:term_status=\"testing\" rdfs:label=\"myersBriggs\" rdfs:comment=\"A Myers Briggs (MBTI) personality classification.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/workplaceHomepage\" vs:term_status=\"testing\" rdfs:label=\"workplace homepage\" rdfs:comment=\"A workplace homepage of some person; the homepage of an organization they work for.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/workInfoHomepage\" vs:term_status=\"testing\" rdfs:label=\"work info homepage\" rdfs:comment=\"A work info homepage of some person; a page about their work for some organization.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/schoolHomepage\" vs:term_status=\"testing\" rdfs:label=\"schoolHomepage\" rdfs:comment=\"A homepage of a school attended by the person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/knows\" vs:term_status=\"stable\" rdfs:label=\"knows\" rdfs:comment=\"A person known by this person (indicating some level of reciprocated interaction between the parties).\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/interest\" vs:term_status=\"testing\" rdfs:label=\"interest\" rdfs:comment=\"A page about a topic of interest to this person.\">\n<!-- we should distinguish the page from the topic more carefully. danbri 2002-07-08 -->\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/topic_interest\" vs:term_status=\"testing\" rdfs:label=\"topic_interest\" rdfs:comment=\"A thing of interest to this person.\">\n<!-- we should distinguish the page from the topic more carefully. danbri 2002-07-08 -->\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/publications\" vs:term_status=\"testing\" rdfs:label=\"publications\" rdfs:comment=\"A link to the publications of this person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n<!-- by libby for ILRT mappings 2001-10-31 -->\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/currentProject\" vs:term_status=\"testing\" rdfs:label=\"current project\" rdfs:comment=\"A current project this person works on.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/pastProject\" vs:term_status=\"testing\" rdfs:label=\"past project\" rdfs:comment=\"A project this person has previously worked on.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Person\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/fundedBy\" vs:term_status=\"archaic\" rdfs:label=\"funded by\" rdfs:comment=\"An organization funding a project or person.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/logo\" vs:term_status=\"testing\" rdfs:label=\"logo\" rdfs:comment=\"A logo representing some thing.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/topic\" vs:term_status=\"testing\" rdfs:label=\"topic\" rdfs:comment=\"A topic of some page or document.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/page\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/primaryTopic\"\n vs:term_status=\"stable\" rdfs:label=\"primary topic\" rdfs:comment=\"The primary topic of some page or document.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#FunctionalProperty\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/isPrimaryTopicOf\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/focus\"  vs:term_status=\"testing\" rdfs:label=\"focus\" rdfs:comment=\"The underlying or 'focal' entity associated with some SKOS-described concept.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2004/02/skos/core#Concept\" rdfs:label=\"Concept\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/isPrimaryTopicOf\"\n vs:term_status=\"stable\" rdfs:label=\"is primary topic of\" rdfs:comment=\"A document that this thing is the primary topic of.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#InverseFunctionalProperty\"/>\n    <rdfs:subPropertyOf rdf:resource=\"http://xmlns.com/foaf/0.1/page\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/primaryTopic\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/page\" vs:term_status=\"stable\" rdfs:label=\"page\" rdfs:comment=\"A page or document about this thing.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n    <owl:inverseOf rdf:resource=\"http://xmlns.com/foaf/0.1/topic\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/theme\" vs:term_status=\"archaic\" rdfs:label=\"theme\" rdfs:comment=\"A theme.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Thing\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/account\" vs:term_status=\"testing\" rdfs:label=\"account\" rdfs:comment=\"Indicates an account held by this agent.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/OnlineAccount\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/holdsAccount\" vs:term_status=\"archaic\" rdfs:label=\"account\" rdfs:comment=\"Indicates an account held by this agent.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/OnlineAccount\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/accountServiceHomepage\" vs:term_status=\"testing\" rdfs:label=\"account service homepage\" rdfs:comment=\"Indicates a homepage of the service provide for this online account.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/OnlineAccount\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Document\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/accountName\" vs:term_status=\"testing\" rdfs:label=\"account name\" rdfs:comment=\"Indicates the name (identifier) associated with this online account.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/OnlineAccount\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/member\" vs:term_status=\"stable\" rdfs:label=\"member\" rdfs:comment=\"Indicates a member of a Group\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#ObjectProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Group\"/>\n    <rdfs:range rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/membershipClass\" vs:term_status=\"unstable\" rdfs:label=\"membershipClass\" rdfs:comment=\"Indicates the class of individuals that are a member of a Group\">\n    <!-- maybe we should just use SPARQL or Rules, instead of trying to use OWL here -->\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#AnnotationProperty\"/>\n    <!-- Added to keep OWL DL from bluescreening. DON'T CROSS THE STREAMERS, etc. -->\n    <!-- This may get dropped if it means non-DL tools don't expose it as a real property.\n\t Should be fine though; I think only OWL stuff cares about AnnotationProperty.\n\t Dan\t\t\t\t\t\t\t\t\t -->\n\n<!--    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Group\"/> prose only for now...-->\n<!--    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Class\"/> -->\n<!--    <rdfs:range rdf:resource=\"http://www.w3.org/2002/07/owl#Class\"/> -->\n\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n\n  <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/birthday\" vs:term_status=\"unstable\" rdfs:label=\"birthday\" rdfs:comment=\"The birthday of this Agent, represented in mm-dd string form, eg. '12-31'.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#FunctionalProperty\"/>\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n    <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n    <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n    <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n  </rdf:Property>\n\n   <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/age\" vs:term_status=\"unstable\" rdfs:label=\"age\" rdfs:comment=\"The age in years of some agent.\">\n    <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#FunctionalProperty\"/>\n     <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n     <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n     <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n     <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n   </rdf:Property>\n\n   <rdf:Property rdf:about=\"http://xmlns.com/foaf/0.1/status\" vs:term_status=\"unstable\" rdfs:label=\"status\" rdfs:comment=\"A string expressing what the user is happy for the general public (normally) to know about their current activity.\">\n     <rdf:type rdf:resource=\"http://www.w3.org/2002/07/owl#DatatypeProperty\"/>\n     <rdfs:domain rdf:resource=\"http://xmlns.com/foaf/0.1/Agent\"/>\n     <rdfs:range rdf:resource=\"http://www.w3.org/2000/01/rdf-schema#Literal\"/>\n     <rdfs:isDefinedBy rdf:resource=\"http://xmlns.com/foaf/0.1/\"/>\n   </rdf:Property>\n\n</rdf:RDF>\n\n"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "server",
+              "value": "gunicorn/19.10.0"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 28 Sep 2022 02:06:53 GMT"
+            },
+            {
+              "name": "x-archive-orig-date",
+              "value": "Wed, 20 Oct 2021 09:49:19 GMT"
+            },
+            {
+              "name": "x-archive-orig-server",
+              "value": "Apache/2.4.7 (Ubuntu)"
+            },
+            {
+              "name": "x-archive-orig-last-modified",
+              "value": "Tue, 14 Jan 2014 19:16:42 GMT"
+            },
+            {
+              "name": "x-archive-orig-etag",
+              "value": "\"acb1-4eff3085673ff\""
+            },
+            {
+              "name": "x-archive-orig-accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "x-archive-orig-content-length",
+              "value": "44209"
+            },
+            {
+              "name": "x-archive-orig-connection",
+              "value": "close"
+            },
+            {
+              "name": "content-type",
+              "value": "application/rdf+xml"
+            },
+            {
+              "name": "cache-control",
+              "value": "max-age=1800"
+            },
+            {
+              "name": "x-archive-guessed-content-type",
+              "value": "application/rdf+xml"
+            },
+            {
+              "name": "x-archive-guessed-encoding",
+              "value": "utf-8"
+            },
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "content-length",
+              "value": "44209"
+            },
+            {
+              "name": "memento-datetime",
+              "value": "Wed, 20 Oct 2021 09:49:33 GMT"
+            },
+            {
+              "name": "link",
+              "value": "<http://xmlns.com/foaf/spec/20140114.rdf>; rel=\"original\", <http://wayback.archive-it.org/all/timemap/link/http://xmlns.com/foaf/spec/20140114.rdf>; rel=\"timemap\"; type=\"application/link-format\", <http://wayback.archive-it.org/all/http://xmlns.com/foaf/spec/20140114.rdf>; rel=\"timegate\", <http://wayback.archive-it.org/all/20211020094933/http://xmlns.com/foaf/spec/20140114.rdf>; rel=\"first memento\"; datetime=\"Wed, 20 Oct 2021 09:49:33 GMT\", <http://wayback.archive-it.org/all/20211020094933/http://xmlns.com/foaf/spec/20140114.rdf>; rel=\"memento\"; datetime=\"Wed, 20 Oct 2021 09:49:33 GMT\", <http://wayback.archive-it.org/all/20211020094933/http://xmlns.com/foaf/spec/20140114.rdf>; rel=\"last memento\"; datetime=\"Wed, 20 Oct 2021 09:49:33 GMT\""
+            },
+            {
+              "name": "content-security-policy-report-only",
+              "value": "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: blob: archive-it.org wayback.archive-it.org partner.archive-it.org bmiller-dev.us.archive.org ; report-uri https://partner.archive-it.org/csp-report"
+            },
+            {
+              "name": "x-archive-src",
+              "value": "ARCHIVEIT-5486-ANNUAL-JOB1497309-SEED866434-20211020085239817-00031-h3.warc.gz"
+            },
+            {
+              "name": "server-timing",
+              "value": "captures_list;dur=250.129099, RulesEngine.query;dur=207.575646, load_resource;dur=176.736296, PetaboxLoader3.resolve;dur=47.492671, PetaboxLoader3.datanode;dur=34.476937"
+            }
+          ],
+          "headersSize": 1898,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2022-09-28T02:06:53.383Z",
+        "time": 1329,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 1329
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/engines/query-sparql/test/configs/seed.json
+++ b/engines/query-sparql/test/configs/seed.json
@@ -1,0 +1,7 @@
+[
+  {
+    "podName": "example",
+    "email": "hello@example.com",
+    "password": "abc123"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.4",
+    "@inrupt/solid-client-authn-core": "^1.12.2",
+    "@inrupt/solid-client-authn-node": "^1.12.2",
     "@pollyjs/adapter-node-http": "^6.0.4",
     "@pollyjs/core": "^6.0.0",
     "@pollyjs/persister-fs": "^6.0.0",
+    "@solid/community-server": "^5.0.0",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.4.2",
     "@types/jest": "^27.0.0",
     "@types/node": "^14.0.0",

--- a/packages/actor-http-wayback/README.md
+++ b/packages/actor-http-wayback/README.md
@@ -1,0 +1,40 @@
+# Comunica Wayback Http Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-http-wayback.svg)](https://www.npmjs.com/package/@comunica/actor-http-wayback)
+
+A Comunica actor to intercept HTTP requests to recover broken links using the WayBack Machine
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica),
+and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
+
+[Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-http-wayback
+```
+
+## Configure
+
+After installing, this package can be added to your engine's configuration as follows:
+```text
+{
+  "@context": [
+    ...
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-wayback/^1.0.0/components/context.jsonld"  
+  ],
+  "actors": [
+    ...
+    {
+      "@id": "urn:comunica:default:http/actors#wayback",
+      "@type": "ActorHttpWayback",
+      "mediatorHttp": { "@id": "urn:comunica:default:http/mediators#no-fallback" }
+    }
+  ]
+}
+```
+
+### Config Parameters
+
+* `mediatorHttp`: A mediator over the [HTTP bus](https://github.com/comunica/comunica/tree/master/packages/bus-http).

--- a/packages/actor-http-wayback/lib/ActorHttpWayback.ts
+++ b/packages/actor-http-wayback/lib/ActorHttpWayback.ts
@@ -1,0 +1,73 @@
+import type { IActionHttp, IActorHttpArgs, IActorHttpOutput, MediatorHttp } from '@comunica/bus-http';
+import { ActorHttp } from '@comunica/bus-http';
+import { KeysHttpWayback, KeysHttpProxy } from '@comunica/context-entries';
+import type { IActorTest } from '@comunica/core';
+import type { IActionContext, IProxyHandler, IRequest } from '@comunica/types';
+import { Request } from 'cross-fetch';
+import * as stringifyStream from 'stream-to-string';
+
+const WAYBACK_URL = 'http://wayback.archive-it.org/';
+
+function addWayback(action: IRequest): IRequest {
+  const request = new Request(action.input, action.init);
+  return {
+    input: new Request(new URL(`/${request.url}`, WAYBACK_URL), request),
+  };
+}
+
+function getProxyHandler(context: IActionContext): (action: IRequest) => Promise<IRequest> {
+  const handler = context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler);
+  if (handler) {
+    return (action: IRequest) => handler.getProxy(addWayback(action));
+  }
+  return (action: IRequest) => Promise.resolve(addWayback(action));
+}
+
+/**
+ * A Comunica actor to intercept HTTP requests to recover broken links using the WayBack Machine
+ */
+export class ActorHttpWayback extends ActorHttp {
+  public readonly mediatorHttp: MediatorHttp;
+
+  public constructor(args: IActorHttpWaybackArgs) {
+    super(args);
+  }
+
+  public async test(action: IActionHttp): Promise<IActorTest> {
+    return true;
+  }
+
+  public async run(action: IActionHttp): Promise<IActorHttpOutput> {
+    let result = await this.mediatorHttp.mediate(action);
+
+    if (result.status === 404 && action.context.get(KeysHttpWayback.recoverBrokenLinks)) {
+      let fallbackResult = await this.mediatorHttp.mediate({
+        ...action,
+        context: action.context
+          .set(KeysHttpWayback.recoverBrokenLinks, false)
+          .set<IProxyHandler>(KeysHttpProxy.httpProxyHandler, { getProxy: getProxyHandler(action.context) }),
+      });
+
+      // If the wayback machine returns a 200 status then use that result
+      if (fallbackResult.status === 200) {
+        [ result, fallbackResult ] = [ fallbackResult, result ];
+      }
+
+      // Consume stream to avoid process
+      const { body } = fallbackResult;
+      if (body) {
+        if ('destroy' in body && typeof (<any>body).destroy === 'function') {
+          (<any>body).destroy();
+        } else {
+          await stringifyStream(ActorHttp.toNodeReadable(fallbackResult.body));
+        }
+      }
+    }
+
+    return result;
+  }
+}
+
+export interface IActorHttpWaybackArgs extends IActorHttpArgs {
+  mediatorHttp: MediatorHttp;
+}

--- a/packages/actor-http-wayback/lib/index.ts
+++ b/packages/actor-http-wayback/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './ActorHttpWayback';

--- a/packages/actor-http-wayback/package.json
+++ b/packages/actor-http-wayback/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@comunica/actor-http-wayback",
+  "version": "2.0.0",
+  "description": "A wayback http actor",
+  "lsd:module": true,
+  "main": "lib/index.js",
+  "typings": "lib/index",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/comunica/comunica.git",
+    "directory": "packages/actor-http-wayback"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "keywords": [
+    "comunica",
+    "actor",
+    "http",
+    "wayback"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "homepage": "https://comunica.dev/",
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js"
+  ],
+  "dependencies": {
+    "@comunica/bus-http": "^2.4.0",
+    "@comunica/context-entries": "^2.4.0",
+    "@comunica/core": "^2.4.0",
+    "cross-fetch": "^3.1.5",
+    "stream-to-string": "^1.2.0"
+  },
+  "scripts": {
+    "build": "npm run build:ts && npm run build:components",
+    "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
+    "build:components": "componentsjs-generator"
+  }
+}

--- a/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
+++ b/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream';
 import type { MediatorHttp, IActionHttp, IActorHttpOutput } from '@comunica/bus-http';
 import { KeysHttpWayback, KeysHttpProxy } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
@@ -356,6 +357,124 @@ describe('ActorHttpInterceptWayback', () => {
           context: context.set(KeysHttpWayback.recoverBrokenLinks, false),
           input: 'http://xmlns.com/foaf/spec/20140114.rdf',
         })).resolves.toEqual(true);
+      });
+
+      it('should return foaf url when wayback gives a 404', async() => {
+        const result = await actor.run({
+          context: context.set(KeysHttpProxy.httpProxyHandler, { async getProxy(url: IRequest) { return url; } }),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(404);
+        expect(result.url).toEqual('http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+    });
+
+    describe('404 foaf, 404 wayback with body to consume', () => {
+      beforeEach(() => {
+        // @ts-expect-error
+        mediatorHttp = {
+          async mediate(action: IActionHttp): Promise<IActorHttpOutput> {
+            const { input, init } =
+              await action.context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler)?.getProxy(action) ??
+              action;
+
+            const request = new Request(input, init);
+
+            const body: any = new Readable();
+            body._read = () => { /* Noop */ };
+
+            if (request.url === 'http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+                body,
+              };
+            }
+
+            if (request.url === 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+                body,
+              };
+            }
+
+            throw new Error('Unexpected URL');
+          },
+        };
+        actor = new ActorHttpWayback({ name: 'actor', bus, mediatorHttp });
+        context = new ActionContext({
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
+        });
+      });
+
+      it('should return foaf url when wayback gives a 404', async() => {
+        const result = await actor.run({
+          context: context.set(KeysHttpProxy.httpProxyHandler, { async getProxy(url: IRequest) { return url; } }),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(404);
+        expect(result.url).toEqual('http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+    });
+
+    describe('404 foaf, 404 wayback with body to consume but no destroy function', () => {
+      beforeEach(() => {
+        // @ts-expect-error
+        mediatorHttp = {
+          async mediate(action: IActionHttp): Promise<IActorHttpOutput> {
+            const { input, init } =
+              await action.context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler)?.getProxy(action) ??
+              action;
+
+            const request = new Request(input, init);
+
+            const _body: any = new Readable();
+            _body._read = () => { /* Noop */ };
+
+            const body: any = {
+              read(...args: any[]) {
+                return _body.read(...args);
+              },
+
+              on(...args: any[]) {
+                return _body.on(...args);
+              },
+
+              getReader(...args: any[]) {
+                return {
+                  async read() {
+                    return { done: true };
+                  },
+                };
+              },
+            };
+
+            if (request.url === 'http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+                body,
+              };
+            }
+
+            if (request.url === 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+                body,
+              };
+            }
+
+            throw new Error('Unexpected URL');
+          },
+        };
+        actor = new ActorHttpWayback({ name: 'actor', bus, mediatorHttp });
+        context = new ActionContext({
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
+        });
       });
 
       it('should return foaf url when wayback gives a 404', async() => {

--- a/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
+++ b/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
@@ -1,0 +1,372 @@
+import type { MediatorHttp, IActionHttp, IActorHttpOutput } from '@comunica/bus-http';
+import { KeysHttpWayback, KeysHttpProxy } from '@comunica/context-entries';
+import { ActionContext, Bus } from '@comunica/core';
+import type { IActionContext, IProxyHandler, IRequest } from '@comunica/types';
+import { Request } from 'cross-fetch';
+import { ActorHttpWayback } from '../lib';
+const stringToStream = require('streamify-string');
+
+describe('ActorHttpInterceptWayback', () => {
+  let bus: any;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+  });
+
+  describe('An ActorHttpInterceptWayback instance', () => {
+    let actor: ActorHttpWayback;
+    let context: IActionContext;
+    let mediatorHttp: MediatorHttp;
+
+    describe('404 foaf, 200 wayback', () => {
+      beforeEach(() => {
+        // @ts-expect-error
+        mediatorHttp = {
+          async mediate(action: IActionHttp): Promise<IActorHttpOutput> {
+            const { input, init } =
+              await action.context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler)?.getProxy(action) ??
+              action;
+
+            const request = new Request(input, init);
+
+            if (request.url === 'http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+              };
+            }
+
+            if (request.url === 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 200,
+                url: request.url,
+              };
+            }
+
+            throw new Error('Unexpected URL');
+          },
+        };
+        actor = new ActorHttpWayback({ name: 'actor', bus, mediatorHttp });
+        context = new ActionContext({
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
+        });
+      });
+
+      it('should always test true', async() => {
+        await expect(actor.test({
+          context,
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.delete(KeysHttpWayback.recoverBrokenLinks),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.set(KeysHttpWayback.recoverBrokenLinks, false),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+      });
+
+      it('should return 200 on foaf when wayback machine is already the url', async() => {
+        const result = await actor.run({
+          context,
+          input: 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+
+      it('should return 200 on foaf', async() => {
+        const result = await actor.run({
+          context,
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+
+      it('should return 200 on foaf with existing proxy', async() => {
+        const result = await actor.run({
+          context: context.set(KeysHttpProxy.httpProxyHandler, { async getProxy(url: IRequest) { return url; } }),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+    });
+
+    describe('404 foaf with body, 200 wayback', () => {
+      beforeEach(() => {
+        // @ts-expect-error
+        mediatorHttp = {
+          async mediate(action: IActionHttp): Promise<IActorHttpOutput> {
+            const { input, init } =
+              await action.context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler)?.getProxy(action) ??
+              action;
+
+            const request = new Request(input, init);
+
+            if (request.url === 'http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> <unknown> {
+                status: 404,
+                body: stringToStream('page not found'),
+                url: request.url,
+              };
+            }
+
+            if (request.url === 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 200,
+                url: request.url,
+              };
+            }
+
+            throw new Error('Unexpected URL');
+          },
+        };
+        actor = new ActorHttpWayback({ name: 'actor', bus, mediatorHttp });
+        context = new ActionContext({
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
+        });
+      });
+
+      it('should always test true', async() => {
+        await expect(actor.test({
+          context,
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.delete(KeysHttpWayback.recoverBrokenLinks),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.set(KeysHttpWayback.recoverBrokenLinks, false),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+      });
+
+      it('should return 200 on foaf when wayback machine is already the url', async() => {
+        const result = await actor.run({
+          context,
+          input: 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+
+      it('should return 200 on foaf', async() => {
+        const result = await actor.run({
+          context,
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+
+      it('should return 200 on foaf with existing proxy', async() => {
+        const result = await actor.run({
+          context: context.set(KeysHttpProxy.httpProxyHandler, { async getProxy(url: IRequest) { return url; } }),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+    });
+
+    describe('200 foaf, 200 wayback', () => {
+      beforeEach(() => {
+        // @ts-expect-error
+        mediatorHttp = {
+          async mediate(action: IActionHttp): Promise<IActorHttpOutput> {
+            const { input, init } =
+              await action.context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler)?.getProxy(action) ??
+              action;
+
+            const request = new Request(input, init);
+
+            if (request.url === 'http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 200,
+                url: request.url,
+              };
+            }
+
+            if (request.url === 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 200,
+                url: request.url,
+              };
+            }
+
+            throw new Error('Unexpected URL');
+          },
+        };
+        actor = new ActorHttpWayback({ name: 'actor', bus, mediatorHttp });
+        context = new ActionContext({
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
+        });
+      });
+
+      it('should always test true', async() => {
+        await expect(actor.test({
+          context,
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.delete(KeysHttpWayback.recoverBrokenLinks),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.set(KeysHttpWayback.recoverBrokenLinks, false),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+      });
+
+      it('should return foaf url when foaf is 200', async() => {
+        const result = await actor.run({
+          context: context.set(KeysHttpProxy.httpProxyHandler, { async getProxy(url: IRequest) { return url; } }),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+    });
+
+    describe('200 foaf, 404 wayback', () => {
+      beforeEach(() => {
+        // @ts-expect-error
+        mediatorHttp = {
+          async mediate(action: IActionHttp): Promise<IActorHttpOutput> {
+            const { input, init } =
+              await action.context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler)?.getProxy(action) ??
+              action;
+
+            const request = new Request(input, init);
+
+            if (request.url === 'http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 200,
+                url: request.url,
+              };
+            }
+
+            if (request.url === 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+              };
+            }
+
+            throw new Error('Unexpected URL');
+          },
+        };
+        actor = new ActorHttpWayback({ name: 'actor', bus, mediatorHttp });
+        context = new ActionContext({
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
+        });
+      });
+
+      it('should always test true', async() => {
+        await expect(actor.test({
+          context,
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.delete(KeysHttpWayback.recoverBrokenLinks),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.set(KeysHttpWayback.recoverBrokenLinks, false),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+      });
+
+      it('should return foaf url when foaf is 200', async() => {
+        const result = await actor.run({
+          context: context.set(KeysHttpProxy.httpProxyHandler, { async getProxy(url: IRequest) { return url; } }),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(200);
+        expect(result.url).toEqual('http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+    });
+
+    describe('404 foaf, 404 wayback', () => {
+      beforeEach(() => {
+        // @ts-expect-error
+        mediatorHttp = {
+          async mediate(action: IActionHttp): Promise<IActorHttpOutput> {
+            const { input, init } =
+              await action.context.get<IProxyHandler>(KeysHttpProxy.httpProxyHandler)?.getProxy(action) ??
+              action;
+
+            const request = new Request(input, init);
+
+            if (request.url === 'http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+              };
+            }
+
+            if (request.url === 'http://wayback.archive-it.org/http://xmlns.com/foaf/spec/20140114.rdf') {
+              return <Response> {
+                status: 404,
+                url: request.url,
+              };
+            }
+
+            throw new Error('Unexpected URL');
+          },
+        };
+        actor = new ActorHttpWayback({ name: 'actor', bus, mediatorHttp });
+        context = new ActionContext({
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
+        });
+      });
+
+      it('should always test true', async() => {
+        await expect(actor.test({
+          context,
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.delete(KeysHttpWayback.recoverBrokenLinks),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+
+        await expect(actor.test({
+          context: context.set(KeysHttpWayback.recoverBrokenLinks, false),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        })).resolves.toEqual(true);
+      });
+
+      it('should return foaf url when wayback gives a 404', async() => {
+        const result = await actor.run({
+          context: context.set(KeysHttpProxy.httpProxyHandler, { async getProxy(url: IRequest) { return url; } }),
+          input: 'http://xmlns.com/foaf/spec/20140114.rdf',
+        });
+
+        expect(result.status).toEqual(404);
+        expect(result.url).toEqual('http://xmlns.com/foaf/spec/20140114.rdf');
+      });
+    });
+  });
+});

--- a/packages/actor-init-query/lib/ActorInitQueryBase.ts
+++ b/packages/actor-init-query/lib/ActorInitQueryBase.ts
@@ -114,6 +114,7 @@ export interface IActorInitQueryBaseArgs extends IActorInitArgs {
    *   "httpTimeout": "@comunica/bus-http:http-timeout",
    *   "httpBodyTimeout": "@comunica/bus-http:http-body-timeout",
    *   "fetch": "@comunica/bus-http:fetch",
+   *   "recoverBrokenLinks": "@comunica/bus-http-wayback:recover-broken-links",
    *   "readOnly": "@comunica/bus-query-operation:readOnly",
    *   "extensionFunctions": "@comunica/actor-init-query:extensionFunctions",
    *   "extensionFunctionCreator": "@comunica/actor-init-query:extensionFunctionCreator",

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -1,5 +1,11 @@
 import { ProxyHandlerStatic } from '@comunica/actor-http-proxy';
-import { KeysHttpMemento, KeysHttpProxy, KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
+import {
+  KeysHttpMemento,
+  KeysHttpProxy,
+  KeysHttpWayback,
+  KeysInitQuery,
+  KeysQueryOperation,
+} from '@comunica/context-entries';
 import type { ICliArgsHandler } from '@comunica/types';
 import type { Argv } from 'yargs';
 
@@ -84,6 +90,12 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
           type: 'boolean',
           describe: 'If blank nodes should be localized per bindings entry',
         },
+        recoverBrokenLinks: {
+          alias: 'r',
+          type: 'boolean',
+          describe: 'Use the WayBack machine to recover broken links',
+          default: false,
+        },
       })
       .check(args => {
         if (args.version || args.listformats) {
@@ -120,6 +132,11 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
     // Set the blank node localization
     if (args.localizeBlankNodes) {
       context[KeysQueryOperation.localizeBlankNodes.name] = args.localizeBlankNodes;
+    }
+
+    // Set recover broken links flag
+    if (args.recoverBrokenLinks) {
+      context[KeysHttpWayback.recoverBrokenLinks.name] = args.recoverBrokenLinks;
     }
   }
 }

--- a/packages/actor-init-query/test/ActorInitQuery-test.ts
+++ b/packages/actor-init-query/test/ActorInitQuery-test.ts
@@ -3,6 +3,7 @@ import {
   KeysCore,
   KeysHttp,
   KeysHttpMemento, KeysHttpProxy,
+  KeysHttpWayback,
   KeysInitQuery, KeysQueryOperation,
   KeysRdfResolveQuadPattern, KeysRdfUpdateQuads,
 } from '@comunica/context-entries';
@@ -556,6 +557,22 @@ LIMIT 100
           [KeysRdfResolveQuadPattern.sources.name]: [{ value: sourceHypermedia }],
           [KeysCore.log.name]: expect.any(LoggerPretty),
           [KeysHttpMemento.datetime.name]: dt,
+        });
+      });
+
+      it('handles the recoverBrokenLinks -r option', async() => {
+        const stdout = await stringifyStream(<any> (await actor.run({
+          argv: [ sourceHypermedia, '-q', queryString, '-r' ],
+          env: {},
+          stdin: <Readable><any> new PassThrough(),
+          context,
+        })).stdout);
+        expect(stdout).toContain(`{"a":"triple"}`);
+        expect(spyQueryOrExplain).toHaveBeenCalledWith(queryString, {
+          [KeysInitQuery.queryFormat.name]: { language: 'sparql', version: '1.1' },
+          [KeysRdfResolveQuadPattern.sources.name]: [{ value: sourceHypermedia }],
+          [KeysCore.log.name]: new LoggerPretty({ level: 'warn' }),
+          [KeysHttpWayback.recoverBrokenLinks.name]: true,
         });
       });
 

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -50,6 +50,14 @@ export const KeysHttp = {
   httpBodyTimeout: new ActionContextKey<boolean>('@comunica/bus-http:http-body-timeout'),
 };
 
+export const KeysHttpWayback = {
+  /**
+   * Use the WayBack machine to get the most recent representation of a file if a link is broken.
+   * @default false
+   */
+  recoverBrokenLinks: new ActionContextKey<boolean>('@comunica/bus-http:recover-broken-links'),
+};
+
 export const KeysHttpMemento = {
   /**
    * The desired datetime for Memento datetime-negotiation.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,7 +2454,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
@@ -4802,7 +4802,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.0.5, cross-fetch@^3.0.6:
+cross-fetch@^3.0.5, cross-fetch@^3.0.6, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,6 +994,43 @@
   resolved "https://registry.yarnpkg.com/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
+"@inrupt/solid-client-authn-core@^1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.12.2.tgz#80852ba7692dd3faecb933091f2773eb2561fb4f"
+  integrity sha512-UitzMHfUKVHy5ogYgdRLo82CUkHrFLJfnYH8jxpELEK+EzOg3zDT0vmNyNjpZ9vL9th9BOzy8RBuwWusZuo/wg==
+  dependencies:
+    "@inrupt/solid-common-vocab" "^1.0.0"
+    "@types/lodash.clonedeep" "^4.5.6"
+    "@types/uuid" "^8.3.0"
+    cross-fetch "^3.1.5"
+    events "^3.3.0"
+    jose "^4.3.7"
+    lodash.clonedeep "^4.5.0"
+    uuid "^8.3.1"
+
+"@inrupt/solid-client-authn-node@^1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.12.2.tgz#58a42c7d755c09426ba31a6219aa35f24d7af802"
+  integrity sha512-w7RLSMz87gJ+5xUFoH/XfKTC05kipJr5kjfJdezKrGr1RhrbLu1byPWn5iW+tfANuWtvlsXIHhEJxG7YW1Q2bQ==
+  dependencies:
+    "@inrupt/solid-client-authn-core" "^1.12.2"
+    cross-fetch "^3.1.5"
+    jose "^4.3.7"
+    openid-client "^5.1.0"
+    uuid "^8.3.2"
+
+"@inrupt/solid-common-vocab@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@inrupt/solid-common-vocab/-/solid-common-vocab-1.0.1.tgz#ac50bf3cf35aff453376541f980752ab1a550b41"
+  integrity sha512-daCb8amQHzfB9N5bop3enur6l6UHjt9/fxvC8Or9wdzybAGMSF7UcrW3Pr/MM5H0GOKrVBczlxR4t6sMWgul1g==
+  dependencies:
+    "@rdfjs/types" "^1.1.0"
+
+"@ioredis/commands@^1.1.1":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ioredis/commands/-/commands-1.2.0.tgz#6d61b3097470af1fdbbe622795b8921d42018e11"
+  integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
+
 "@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz#291c227e93fd407a96ecd59879a35809120e432b"
@@ -1231,6 +1268,13 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@koa/cors@^3.1.0":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@koa/cors/-/cors-3.4.1.tgz#ddd5c6ff07a1e60831e1281411a3b9fdb95a5b26"
+  integrity sha512-/sG9NlpGZ/aBpnRamIlGs+wX+C/IJ5DodNK7iPQIVCG4eUQdGeshGhWQ6JCi7tpnD9sCtFXcS04iTimuaJfh4Q==
+  dependencies:
+    vary "^1.1.2"
 
 "@lerna/add@5.1.6":
   version "5.1.6"
@@ -2471,6 +2515,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@sindresorhus/is@^4.0.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.6.0.tgz#3c7c9c46e678feefe7a2e5bb609d3dbd665ffb3f"
+  integrity sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==
+
 "@sindresorhus/is@^5.2.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.3.0.tgz#0ec9264cf54a527671d990eb874e030b55b70dcc"
@@ -2490,6 +2539,83 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@solid/access-token-verifier@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@solid/access-token-verifier/-/access-token-verifier-2.0.3.tgz#a624edb6937d3d9fc4192e3b3c08c487441ba3c4"
+  integrity sha512-4mOE7av85m7Wl8cR0N2ocG+Jrx8dQSSTUk2Qt/75KDsCrBHRiG8nUyOQmkZsWPB+deqn5SAnl9Qjg0dMLfKkyA==
+  dependencies:
+    jose "^4.8.1"
+    lru-cache "^6.0.0"
+    n3 "^1.16.2"
+    node-fetch "^2.6.7"
+    ts-guards "^0.5.1"
+
+"@solid/community-server@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@solid/community-server/-/community-server-5.0.0.tgz#19165d9248723b667040e62d7179346a55d54e16"
+  integrity sha512-nIQK2QZ/L8JLUxEwQuU2r6iZsTmVBiZ9BWxnWDJnKDHgTNK8AnW98heG3DZQSpXC0y0LlPhjMyj4ZMMlpOoO1Q==
+  dependencies:
+    "@comunica/query-sparql" "^2.2.1"
+    "@rdfjs/types" "^1.1.0"
+    "@solid/access-token-verifier" "^2.0.3"
+    "@types/async-lock" "^1.1.5"
+    "@types/bcryptjs" "^2.4.2"
+    "@types/cors" "^2.8.12"
+    "@types/ejs" "^3.1.1"
+    "@types/end-of-stream" "^1.4.1"
+    "@types/fs-extra" "^9.0.13"
+    "@types/lodash.orderby" "^4.6.7"
+    "@types/marked" "^4.0.3"
+    "@types/mime-types" "^2.1.1"
+    "@types/n3" "^1.10.4"
+    "@types/node" "^14.18.23"
+    "@types/nodemailer" "^6.4.4"
+    "@types/oidc-provider" "^7.11.1"
+    "@types/proper-lockfile" "^4.1.2"
+    "@types/pump" "^1.1.1"
+    "@types/punycode" "^2.1.0"
+    "@types/sparqljs" "^3.1.3"
+    "@types/url-join" "^4.0.1"
+    "@types/uuid" "^8.3.4"
+    "@types/ws" "^8.5.3"
+    "@types/yargs" "^17.0.10"
+    arrayify-stream "^2.0.0"
+    async-lock "^1.3.2"
+    bcryptjs "^2.4.3"
+    componentsjs "^5.3.0"
+    cors "^2.8.5"
+    cross-fetch "^3.1.5"
+    ejs "^3.1.8"
+    end-of-stream "^1.4.4"
+    escape-string-regexp "^4.0.0"
+    fetch-sparql-endpoint "^3.0.1"
+    fs-extra "^10.1.0"
+    handlebars "^4.7.7"
+    ioredis "^5.2.2"
+    jose "^4.8.3"
+    jsonld-context-parser "^2.1.5"
+    lodash.orderby "^4.6.0"
+    marked "^4.0.18"
+    mime-types "^2.1.35"
+    n3 "^1.16.2"
+    nodemailer "^6.7.7"
+    oidc-provider "7.10.6"
+    proper-lockfile "^4.1.2"
+    pump "^3.0.0"
+    punycode "^2.1.1"
+    rdf-dereference "^2.0.0"
+    rdf-parse "^2.1.0"
+    rdf-serialize "^2.0.0"
+    rdf-terms "^1.9.0"
+    sparqlalgebrajs "^4.0.3"
+    sparqljs "^3.5.2"
+    url-join "^4.0.1"
+    uuid "^8.3.2"
+    winston "^3.8.1"
+    winston-transport "^4.5.0"
+    ws "^8.8.1"
+    yargs "^17.5.1"
+
 "@strictsoftware/typedoc-plugin-monorepo@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@strictsoftware/typedoc-plugin-monorepo/-/typedoc-plugin-monorepo-0.4.2.tgz#7fbd039b0e2f56f736cc90da207efa7e5eb660f5"
@@ -2503,6 +2629,13 @@
   integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
   dependencies:
     defer-to-connect "^1.0.1"
+
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
+  integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
+  dependencies:
+    defer-to-connect "^2.0.0"
 
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
@@ -2520,6 +2653,18 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@types/accepts@*":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
+  integrity sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/async-lock@^1.1.5":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/async-lock/-/async-lock-1.3.0.tgz#12d165b890935afbc553eb9db467c0b540658b8e"
+  integrity sha512-Z93wDSYW9aMgPR5t+7ouwTvy91Vp3M0Snh4Pd3tf+caSAq5bXZaGnnH9CDbjrwgmfDkRIX0Dx8GvSDgwuoaxoA==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -2554,10 +2699,72 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bcryptjs@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/bcryptjs/-/bcryptjs-2.4.2.tgz#e3530eac9dd136bfdfb0e43df2c4c5ce1f77dfae"
+  integrity sha512-LiMQ6EOPob/4yUL66SZzu6Yh77cbzJFYll+ZfaPiPPFswtIlA/Fs1MzdKYA7JApHU49zQTbJGX3PDmCpIdDBRQ==
+
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
 "@types/bunyan@^1.8.4":
   version "1.8.8"
   resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.8.tgz#8d6d33f090f37c07e2a80af30ae728450a101008"
   integrity sha512-Cblq+Yydg3u+sGiz2mjHjC5MPmdjY+No4qvHrF+BUhblsmSfMvsHLbOG62tPbonsqBj6sbWv1LHcsoe5Jw+/Ow==
+  dependencies:
+    "@types/node" "*"
+
+"@types/cacheable-request@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.2.tgz#c324da0197de0a98a2312156536ae262429ff6b9"
+  integrity sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/content-disposition@*":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.5.tgz#650820e95de346e1f84e30667d168c8fd25aa6e3"
+  integrity sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==
+
+"@types/cookies@*":
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.7.tgz#7a92453d1d16389c05a5301eef566f34946cfd81"
+  integrity sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==
+  dependencies:
+    "@types/connect" "*"
+    "@types/express" "*"
+    "@types/keygrip" "*"
+    "@types/node" "*"
+
+"@types/cors@^2.8.12":
+  version "2.8.12"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
+  integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
+
+"@types/ejs@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.1.1.tgz#29c539826376a65e7f7d672d51301f37ed718f6d"
+  integrity sha512-RQul5wEfY7BjWm0sYY86cmUN/pcXWGyVxWX93DFFJvcrxax5zKlieLwA3T77xJGwNcZW0YW6CYG70p1m8xPFmA==
+
+"@types/end-of-stream@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@types/end-of-stream/-/end-of-stream-1.4.1.tgz#9a401b642bcb0e4a8f0b70326725fbbb0216eb10"
+  integrity sha512-dYCSlUtCGXuP2axeKD5l1vj/04iNXW8TLXryDa0uA8u8EsNE68jn27ZLg7jAPV+qJAlk1wC4WtRdIoZXvuUl0A==
   dependencies:
     "@types/node" "*"
 
@@ -2587,10 +2794,36 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
+"@types/express-serve-static-core@^4.17.18":
+  version "4.17.31"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
+  integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*":
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
+  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
 "@types/fs-extra@^8.0.0":
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.2.tgz#7125cc2e4bdd9bd2fc83005ffdb1d0ba00cca61f"
   integrity sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
   dependencies:
     "@types/node" "*"
 
@@ -2608,6 +2841,21 @@
   integrity sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==
   dependencies:
     "@types/node" "*"
+
+"@types/http-assert@*":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.3.tgz#ef8e3d1a8d46c387f04ab0f2e8ab8cb0c5078661"
+  integrity sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==
+
+"@types/http-cache-semantics@*":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
+  integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
+
+"@types/http-errors@*":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-1.8.2.tgz#7315b4c4c54f82d13fa61c228ec5c2ea5cc9e0e1"
+  integrity sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==
 
 "@types/http-link-header@^1.0.1":
   version "1.0.3"
@@ -2658,6 +2906,58 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/keygrip@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/keygrip/-/keygrip-1.0.2.tgz#513abfd256d7ad0bf1ee1873606317b33b1b2a72"
+  integrity sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw==
+
+"@types/keyv@*":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
+  integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/koa-compose@*":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@types/koa-compose/-/koa-compose-3.2.5.tgz#85eb2e80ac50be95f37ccf8c407c09bbe3468e9d"
+  integrity sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==
+  dependencies:
+    "@types/koa" "*"
+
+"@types/koa@*":
+  version "2.13.5"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.13.5.tgz#64b3ca4d54e08c0062e89ec666c9f45443b21a61"
+  integrity sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==
+  dependencies:
+    "@types/accepts" "*"
+    "@types/content-disposition" "*"
+    "@types/cookies" "*"
+    "@types/http-assert" "*"
+    "@types/http-errors" "*"
+    "@types/keygrip" "*"
+    "@types/koa-compose" "*"
+    "@types/node" "*"
+
+"@types/lodash.clonedeep@^4.5.6":
+  version "4.5.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz#0e119f582ed6f9e6b373c04a644651763214f197"
+  integrity sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.orderby@^4.6.7":
+  version "4.6.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.orderby/-/lodash.orderby-4.6.7.tgz#3484098c0633f45aa0d3a57c5a8fc8a031cebb43"
+  integrity sha512-GaaUBTS4RTjL8gz1ZXkwAB/defpGMOWwCG9C4HL9g81i4wghIoVVESQCUa1xRsyUBqAb5JwLbSwvL0q36rK0sA==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.186"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.186.tgz#862e5514dd7bd66ada6c70ee5fce844b06c8ee97"
+  integrity sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==
+
 "@types/log-symbols@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/log-symbols/-/log-symbols-3.0.0.tgz#bcd48948cb85de11e64c6654cc18a67e256b3a1a"
@@ -2670,6 +2970,21 @@
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
   integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
 
+"@types/marked@^4.0.3":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-4.0.7.tgz#400a76809fd08c2bbd9e25f3be06ea38c8e0a1d3"
+  integrity sha512-eEAhnz21CwvKVW+YvRvcTuFKNU9CV1qH+opcgVK3pIMI6YZzDm6gc8o2vHjldFk6MGKt5pueSB7IOpvpx5Qekw==
+
+"@types/mime-types@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.1.tgz#d9ba43490fa3a3df958759adf69396c3532cf2c1"
+  integrity sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==
+
+"@types/mime@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -2680,7 +2995,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/n3@^1.10.3":
+"@types/n3@^1.10.3", "@types/n3@^1.10.4":
   version "1.10.4"
   resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.10.4.tgz#fd23d15fd7e47cf6d199d1f44ac5d6930cc50905"
   integrity sha512-FfRTwcbXcScVHuAjIASveRWL6Fi6fPALl1Ge8tMESYLqU7R42LJvtdBpUi+f9YK0oQPqIN+zFFgMDFJfLMx0bg==
@@ -2711,6 +3026,18 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.21.tgz#0155ee46f6be28b2ff0342ca1a9b9fd4468bef41"
   integrity sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==
 
+"@types/node@^14.18.23":
+  version "14.18.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.31.tgz#4b873dea3122e71af4f77e65ec5841397ff254d3"
+  integrity sha512-vQAnaReSQkEDa8uwAyQby8bYGKu84R/deEc6mg5T8fX6gzCn8QW6rziSgsti1fNvsrswKUKPnVTi7uoB+u62Mw==
+
+"@types/nodemailer@^6.4.4":
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.6.tgz#ce21b4b474a08f672f182e15982b7945dde1f288"
+  integrity sha512-pD6fL5GQtUKvD2WnPmg5bC2e8kWCAPDwMPmHe/ohQbW+Dy0EcHgZ2oCSuPlWNqk74LS5BVMig1SymQbFMPPK3w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -2720,6 +3047,13 @@
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@types/object-inspect/-/object-inspect-1.8.1.tgz#7c08197ad05cc0e513f529b1f3919cc99f720e1f"
   integrity sha512-0JTdf3CGV0oWzE6Wa40Ayv2e2GhpP3pEJMcrlM74vBSJPuuNkVwfDnl0SZxyFCXETcB4oKA/MpTVfuYSMOelBg==
+
+"@types/oidc-provider@^7.11.1":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@types/oidc-provider/-/oidc-provider-7.12.0.tgz#6cb835b768c7a3042443c799f9b2b2cac035f98a"
+  integrity sha512-PQtsWdbjzq/AARiNu2WjPnnbiCF78BCYgDOdKW0VYsjrbDa9HN8dALt7bSIJ0O67ti1l0pYDk8UCpmUu8rPAUQ==
+  dependencies:
+    "@types/koa" "*"
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2770,6 +3104,35 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"
   integrity sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==
 
+"@types/proper-lockfile@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@types/proper-lockfile/-/proper-lockfile-4.1.2.tgz#49537cee7134055ee13a1833b76a1c298f39bb26"
+  integrity sha512-kd4LMvcnpYkspDcp7rmXKedn8iJSCoa331zRRamUp5oanKt/CefbEGPQP7G89enz7sKD4bvsr8mHSsC8j5WOvA==
+  dependencies:
+    "@types/retry" "*"
+
+"@types/pump@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/pump/-/pump-1.1.1.tgz#edb3475e2bad0f4552bdaa91c6c43b82e08ff15e"
+  integrity sha512-wpRerjHDxFBQ4r8XNv3xHJZeuqrBBoeQ/fhgkooV2F7KsPIYRROb/+f9ODgZfOEyO5/w2ej4YQdpPPXipT8DAA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/punycode@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/punycode/-/punycode-2.1.0.tgz#89e4f3d09b3f92e87a80505af19be7e0c31d4e83"
+  integrity sha512-PG5aLpW6PJOeV2fHRslP4IOMWn+G+Uq8CfnyJ+PDS8ndCbU+soO+fB3NKCKo0p/Jh2Y4aPaiQZsrOXFdzpcA6g==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
 "@types/readable-stream@^2.3.11":
   version "2.3.13"
   resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-2.3.13.tgz#46451c1b87cb61010e420ac02a76cfc1b2c2089a"
@@ -2786,6 +3149,18 @@
     "@types/node" "*"
     safe-buffer "*"
 
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
+
+"@types/retry@*":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
+  integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
+
 "@types/sax@^1.0.1":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/sax/-/sax-1.2.4.tgz#8221affa7f4f3cb21abd22f244cfabfa63e6a69e"
@@ -2797,6 +3172,14 @@
   version "7.3.10"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.10.tgz#5f19ee40cbeff87d916eedc8c2bfe2305d957f73"
   integrity sha512-zsv3fsC7S84NN6nPK06u79oWgrPVd0NvOyqgghV1haPaFcVxIrP4DLomRwGAXk0ui4HZA7mOcSFL98sMVW9viw==
+
+"@types/serve-static@*":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
+  integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
+  dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
 
 "@types/set-cookie-parser@^2.4.1":
   version "2.4.2"
@@ -2834,10 +3217,22 @@
   resolved "https://registry.yarnpkg.com/@types/uritemplate/-/uritemplate-0.3.4.tgz#c7a7f2b7e16b212baa69623183cde641659a4b97"
   integrity sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA==
 
-"@types/uuid@^8.0.0":
+"@types/url-join@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/url-join/-/url-join-4.0.1.tgz#4989c97f969464647a8586c7252d97b449cdc045"
+  integrity sha512-wDXw9LEEUHyV+7UWy7U315nrJGJ7p1BzaCxDpEoLr789Dk1WDVMMlf3iBfbG2F8NdWnYyFbtTxUn2ZNbm1Q4LQ==
+
+"@types/uuid@^8.0.0", "@types/uuid@^8.3.0", "@types/uuid@^8.3.4":
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
+"@types/ws@^8.5.3":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -2848,6 +3243,13 @@
   version "16.0.4"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.10":
+  version "17.0.13"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.13.tgz#34cced675ca1b1d51fcf4d34c3c6f0fa142a5c76"
+  integrity sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3169,7 +3571,7 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-accepts@~1.3.8:
+accepts@^1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -3508,6 +3910,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==
 
+async-lock@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.3.2.tgz#56668613f91c1c55432b4db73e65c9ced664e789"
+  integrity sha512-phnXdS3RP7PPcmP6NWWzWMU0sLTeyvtZCxBPpZdkYE3seGLKSQZs9FrmVO/qwypq98FUtWWUEYxziLkdGk5nnA==
+
 async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
@@ -3693,6 +4100,11 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
   dependencies:
     tweetnacl "^0.14.3"
+
+bcryptjs@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  integrity sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==
 
 before-after-hook@^2.2.0:
   version "2.2.2"
@@ -4053,7 +4465,20 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-cacheable-lookup@^6.0.4:
+cache-content-type@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-content-type/-/cache-content-type-1.0.1.tgz#035cde2b08ee2129f4a8315ea8f00a00dba1453c"
+  integrity sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==
+  dependencies:
+    mime-types "^2.1.18"
+    ylru "^1.2.0"
+
+cacheable-lookup@^5.0.3:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
+  integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
+
+cacheable-lookup@^6.0.1, cacheable-lookup@^6.0.4:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-6.1.0.tgz#0330a543471c61faa4e9035db583aad753b36385"
   integrity sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==
@@ -4082,6 +4507,19 @@ cacheable-request@^6.0.0:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^1.0.2"
+
+cacheable-request@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
+  integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^6.0.1"
+    responselike "^2.0.0"
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -4182,7 +4620,7 @@ chalk@^2.0.0, chalk@^2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -4342,6 +4780,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
+cluster-key-slot@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz#10ccb9ded0729464b6d2e7d714b100a2d1259d43"
+  integrity sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==
 
 cmd-shim@^4.1.0:
   version "4.1.0"
@@ -4537,6 +4980,26 @@ componentsjs@^5.0.1, componentsjs@^5.2.0:
     semver "^7.3.2"
     winston "^3.3.3"
 
+componentsjs@^5.3.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/componentsjs/-/componentsjs-5.3.1.tgz#5c87be7d57acb66e7a3d6ccca06979f5815bc5cc"
+  integrity sha512-v0PRq/egMpGR3KWuR8mQEbtTZvOK2PFOBNULshR+VdyHiR4kyAq7Kh1qpjUIGoGY7FEshLD1eBlJYOIXnteJ7w==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/minimist" "^1.2.0"
+    "@types/node" "^14.14.7"
+    "@types/semver" "^7.3.4"
+    jsonld-context-parser "^2.1.1"
+    minimist "^1.2.0"
+    rdf-data-factory "^1.1.0"
+    rdf-object "^1.13.1"
+    rdf-parse "^2.0.0"
+    rdf-quad "^1.5.0"
+    rdf-string "^1.6.0"
+    rdf-terms "^1.7.0"
+    semver "^7.3.2"
+    winston "^3.3.3"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4608,14 +5071,14 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==
 
-content-disposition@0.5.4:
+content-disposition@0.5.4, content-disposition@~0.5.2:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@~1.0.4:
+content-type@^1.0.4, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
@@ -4718,6 +5181,14 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookies@~0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.8.0.tgz#1293ce4b391740a8406e3c9870e828c4b54f3f90"
+  integrity sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==
+  dependencies:
+    depd "~2.0.0"
+    keygrip "~1.1.0"
 
 copy-descriptor@^0.1.0:
   version "0.1.1"
@@ -4992,6 +5463,11 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==
 
+deep-equal@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+  integrity sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==
+
 deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
@@ -5019,7 +5495,7 @@ defer-to-connect@^1.0.1:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
-defer-to-connect@^2.0.1:
+defer-to-connect@^2.0.0, defer-to-connect@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
@@ -5064,6 +5540,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
 
+denque@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-2.1.0.tgz#e93e1a6569fb5e66f16a3c2a2964617d349d6ab1"
+  integrity sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==
+
 depcheck@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/depcheck/-/depcheck-1.4.3.tgz#faa4c143921f3fe25d5a7a633f9864327c250843"
@@ -5093,12 +5574,12 @@ depcheck@^1.4.3:
     semver "^7.3.2"
     yargs "^16.1.0"
 
-depd@2.0.0, depd@~2.0.0:
+depd@2.0.0, depd@^2.0.0, depd@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
-depd@^1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
@@ -5121,7 +5602,7 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
-destroy@1.2.0:
+destroy@1.2.0, destroy@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
@@ -5294,6 +5775,13 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+ejs@^3.1.6, ejs@^3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
+  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
+
 electron-to-chromium@^1.4.164:
   version "1.4.170"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.170.tgz#0415fc489402e09bfbe1f0c99bbf4d73f31d48d4"
@@ -5337,7 +5825,7 @@ enabled@2.0.x:
   resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
   integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
-encodeurl@~1.0.2:
+encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
@@ -5349,7 +5837,7 @@ encoding@^0.1.12, encoding@^0.1.13:
   dependencies:
     iconv-lite "^0.6.2"
 
-end-of-stream@^1.1.0:
+end-of-stream@^1.1.0, end-of-stream@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -5490,7 +5978,7 @@ escape-goat@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-4.0.0.tgz#9424820331b510b0666b98f7873fe11ac4aa8081"
   integrity sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
@@ -6045,7 +6533,7 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
-fetch-sparql-endpoint@^3.0.0:
+fetch-sparql-endpoint@^3.0.0, fetch-sparql-endpoint@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.1.0.tgz#531c60fa1ce14960cdfe53cf8d3f4f5f5c971827"
   integrity sha512-NS0+84W4nMK6/2VxJC5jQhPKPfUI31zXswgJ9TpHzp4BzQLPeu2ksgvZ4NffhyQ86JrDx2bfq4xAS3yxhmwyHQ==
@@ -6078,6 +6566,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+filelist@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
+  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
+  dependencies:
+    minimatch "^5.0.1"
 
 fill-range@^4.0.0:
   version "4.0.0"
@@ -6231,7 +6726,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fresh@0.5.2:
+fresh@0.5.2, fresh@~0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
@@ -6245,7 +6740,7 @@ fs-extra@8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^10.0.0:
+fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -6593,6 +7088,23 @@ globby@^9.2.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
+got@^11.8.2:
+  version "11.8.5"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.5.tgz#ce77d045136de56e8f024bebb82ea349bc730046"
+  integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
 got@^12.1.0:
   version "12.5.0"
   resolved "https://registry.yarnpkg.com/got/-/got-12.5.0.tgz#b31c556aa25a14ea06f173da888860984f323d3b"
@@ -6840,6 +7352,14 @@ htmlparser2@^8.0.0:
     domutils "^3.0.1"
     entities "^4.3.0"
 
+http-assert@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/http-assert/-/http-assert-1.5.0.tgz#c389ccd87ac16ed2dfa6246fd73b926aa00e6b8f"
+  integrity sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==
+  dependencies:
+    deep-equal "~1.0.1"
+    http-errors "~1.8.0"
+
 http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
@@ -6854,6 +7374,17 @@ http-errors@2.0.0:
     inherits "2.0.4"
     setprototypeof "1.2.0"
     statuses "2.0.1"
+    toidentifier "1.0.1"
+
+http-errors@^1.6.3, http-errors@~1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.1.tgz#7c3f28577cbc8a207388455dbd62295ed07bd68c"
+  integrity sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
+    statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
 http-graceful-shutdown@^3.1.5:
@@ -6894,6 +7425,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+http2-wrapper@^1.0.0-beta.5.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.3.tgz#b8f55e0c1f25d4ebd08b3b0c2c079f9590800b3d"
+  integrity sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 http2-wrapper@^2.1.10:
   version "2.1.11"
@@ -7120,6 +7659,21 @@ invariant@2.2.4:
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
   dependencies:
     loose-envify "^1.0.0"
+
+ioredis@^5.2.2:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-5.2.3.tgz#d5b37eb13e643241660d6cee4eeb41a026cda8c0"
+  integrity sha512-gQNcMF23/NpvjCaa1b5YycUyQJ9rBNH2xP94LWinNpodMWVUPP5Ai/xXANn/SM7gfIvI62B5CCvZxhg5pOgyMw==
+  dependencies:
+    "@ioredis/commands" "^1.1.1"
+    cluster-key-slot "^1.1.0"
+    debug "^4.3.4"
+    denque "^2.0.1"
+    lodash.defaults "^4.2.0"
+    lodash.isarguments "^3.1.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
+    standard-as-callback "^2.1.0"
 
 ip-regex@^4.1.0:
   version "4.3.0"
@@ -7618,6 +8172,16 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+jake@^10.8.5:
+  version "10.8.5"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.5.tgz#f2183d2c59382cb274226034543b9c03b8164c46"
+  integrity sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==
+  dependencies:
+    async "^3.2.3"
+    chalk "^4.0.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
+
 jest-changed-files@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.5.1.tgz#a348aed00ec9bf671cc58a66fcbe7c3dfd6a68f5"
@@ -8037,6 +8601,11 @@ jju@^1.1.0, jju@~1.4.0:
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
   integrity sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==
 
+jose@^4.1.4, jose@^4.3.7, jose@^4.8.1, jose@^4.8.3:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.10.0.tgz#2e0b7bcc80dd0775f8a4588e55beb9460c37d60a"
+  integrity sha512-KEhB/eLGLomWGPTb+/RNbYsTjIyx03JmbqAyIyiXBuNSa7CmNrJd5ysFhblayzs/e/vbOPMUaLnjHUMhGp4yLw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -8099,6 +8668,11 @@ jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+jsesc@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -8292,6 +8866,13 @@ just-diff@^5.0.1:
   resolved "https://registry.yarnpkg.com/just-diff/-/just-diff-5.0.3.tgz#4c9c514dec5526b25ab977590e3c39a0cf271554"
   integrity sha512-a8p80xcpJ6sdurk5PxDKb4mav9MeKjA3zFKZpCWBIfvg8mznfnmb13MKZvlrwJ+Lhis0wM3uGAzE0ArhFHvIcg==
 
+keygrip@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.1.0.tgz#871b1681d5e159c62a445b0c74b615e0917e7226"
+  integrity sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==
+  dependencies:
+    tsscmp "1.0.6"
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -8299,7 +8880,7 @@ keyv@^3.0.0:
   dependencies:
     json-buffer "3.0.0"
 
-keyv@^4.5.0:
+keyv@^4.0.0, keyv@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.0.tgz#dbce9ade79610b6e641a9a65f2f6499ba06b9bc6"
   integrity sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==
@@ -8339,6 +8920,48 @@ kleur@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
+
+koa-compose@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
+  integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
+
+koa-convert@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/koa-convert/-/koa-convert-2.0.0.tgz#86a0c44d81d40551bae22fee6709904573eea4f5"
+  integrity sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==
+  dependencies:
+    co "^4.6.0"
+    koa-compose "^4.1.0"
+
+koa@^2.13.3:
+  version "2.13.4"
+  resolved "https://registry.yarnpkg.com/koa/-/koa-2.13.4.tgz#ee5b0cb39e0b8069c38d115139c774833d32462e"
+  integrity sha512-43zkIKubNbnrULWlHdN5h1g3SEKXOEzoAlRsHOTFpnlDu8JlAOZSMJBLULusuXRequboiwJcj5vtYXKB3k7+2g==
+  dependencies:
+    accepts "^1.3.5"
+    cache-content-type "^1.0.0"
+    content-disposition "~0.5.2"
+    content-type "^1.0.4"
+    cookies "~0.8.0"
+    debug "^4.3.2"
+    delegates "^1.0.0"
+    depd "^2.0.0"
+    destroy "^1.0.4"
+    encodeurl "^1.0.2"
+    escape-html "^1.0.3"
+    fresh "~0.5.2"
+    http-assert "^1.3.0"
+    http-errors "^1.6.3"
+    is-generator-function "^1.0.7"
+    koa-compose "^4.1.0"
+    koa-convert "^2.0.0"
+    on-finished "^2.3.0"
+    only "~0.0.2"
+    parseurl "^1.3.2"
+    statuses "^1.5.0"
+    type-is "^1.6.16"
+    vary "^1.1.2"
 
 kuler@^2.0.0:
   version "2.0.0"
@@ -8525,10 +9148,25 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+  integrity sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==
+
+lodash.isarguments@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
+  integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
 lodash.ismatch@^4.4.0:
   version "4.4.0"
@@ -8544,6 +9182,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.orderby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.orderby/-/lodash.orderby-4.6.0.tgz#e697f04ce5d78522f54d9338b32b81a3393e4eb3"
+  integrity sha512-T0rZxKmghOOf5YPnn8EY5iLYeWCpZq8G41FfqoVHH5QDTAFaghJRmAdLiadEDq+ztgM2q5PjA+Z1fOwGrLgmtg==
 
 lodash@4.17.15:
   version "4.17.15"
@@ -8791,6 +9434,11 @@ marked@^4.0.10:
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.17.tgz#1186193d85bb7882159cdcfc57d1dfccaffb3fe9"
   integrity sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==
 
+marked@^4.0.18:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.1.0.tgz#3fc6e7485f21c1ca5d6ec4a39de820e146954796"
+  integrity sha512-+Z6KDjSPa6/723PQYyc1axYZpYYpDnECDaU6hkaf5gqBieBkMKYReL5hteF2QizhlMbgbo8umXl/clZ67+GlsA==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -8915,7 +9563,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -9183,7 +9831,7 @@ mv@~2:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-n3@^1.11.1, n3@^1.6.3:
+n3@^1.11.1, n3@^1.16.2, n3@^1.6.3:
   version "1.16.2"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.16.2.tgz#ef86b4bf48b556505da1cc3062a3c2ef35f02976"
   integrity sha512-5vYa2HuNEJ+a26FEs4FGgfFLgaPOODaZpJlc7FS0eUjDumc4uK0cvx216PjKXBkLzmAsSqGgQPwqztcLLvwDsw==
@@ -9196,7 +9844,7 @@ nan@^2.14.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
   integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
 
-nanoid@^3.3.4:
+nanoid@^3.1.28, nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
@@ -9343,6 +9991,11 @@ node-releases@^2.0.5:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.5.tgz#280ed5bc3eba0d96ce44897d8aee478bfb3d9666"
   integrity sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==
 
+nodemailer@^6.7.7:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.8.0.tgz#804bcc5256ee5523bc914506ee59f8de8f0b1cd5"
+  integrity sha512-EjYvSmHzekz6VNkNd12aUqAco+bOkRe3Of5jVhltqKhEsjw/y0PYPJfp83+s9Wzh1dspYAkUW/YNQ350NATbSQ==
+
 nodemon@^2.0.15:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.18.tgz#0f5a3aa7b4587f2626e6f01369deba89cb0462a2"
@@ -9413,7 +10066,7 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
   integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
 
-normalize-url@^6.1.0:
+normalize-url@^6.0.1, normalize-url@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
@@ -9637,6 +10290,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^2.0.1, object-hash@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
+
 object-inspect@^1.12.0, object-inspect@^1.12.2, object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
@@ -9724,7 +10382,35 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-on-finished@2.4.1:
+oidc-provider@7.10.6:
+  version "7.10.6"
+  resolved "https://registry.yarnpkg.com/oidc-provider/-/oidc-provider-7.10.6.tgz#85cc16974fb114fa38289aa14451a6b5c1a790dd"
+  integrity sha512-7fbnormUyTLP34dmR5WXoJtTWtfj6MsFNzIMKVRKv21e18NIXggn14EBUFC5rrMMtmeExb03+lJI/v+opD+0oQ==
+  dependencies:
+    "@koa/cors" "^3.1.0"
+    cacheable-lookup "^6.0.1"
+    debug "^4.3.2"
+    ejs "^3.1.6"
+    got "^11.8.2"
+    jose "^4.1.4"
+    jsesc "^3.0.2"
+    koa "^2.13.3"
+    koa-compose "^4.1.0"
+    nanoid "^3.1.28"
+    object-hash "^2.2.0"
+    oidc-token-hash "^5.0.1"
+    paseto2 "npm:paseto@^2.1.3"
+    quick-lru "^5.1.1"
+    raw-body "^2.4.1"
+  optionalDependencies:
+    paseto3 "npm:paseto@^3.0.0"
+
+oidc-token-hash@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/oidc-token-hash/-/oidc-token-hash-5.0.1.tgz#ae6beec3ec20f0fd885e5400d175191d6e2f10c6"
+  integrity sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==
+
+on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -9763,6 +10449,21 @@ onetime@^5.1.0, onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+only@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/only/-/only-0.0.2.tgz#2afde84d03e50b9a8edc444e30610a70295edfb4"
+  integrity sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==
+
+openid-client@^5.1.0:
+  version "5.1.10"
+  resolved "https://registry.yarnpkg.com/openid-client/-/openid-client-5.1.10.tgz#add6044878b9be75ffdd09abfcaae6feff376b1f"
+  integrity sha512-KYAtkxTuUwTvjAmH0QMFFP3i9l0+XhP2/blct6Q9kn+DUJ/lu8/g/bI8ghSgxz9dJLm/9cpB/1uLVGTcGGY0hw==
+  dependencies:
+    jose "^4.1.4"
+    lru-cache "^6.0.0"
+    object-hash "^2.0.1"
+    oidc-token-hash "^5.0.1"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -9820,6 +10521,11 @@ p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
+p-cancelable@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
+  integrity sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==
 
 p-cancelable@^3.0.0:
   version "3.0.0"
@@ -10105,7 +10811,7 @@ parse5@6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parseurl@~1.3.3:
+parseurl@^1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -10114,6 +10820,16 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==
+
+"paseto2@npm:paseto@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/paseto/-/paseto-2.1.3.tgz#9913f9f46172ce88c397a0f035fdfedd34d827ef"
+  integrity sha512-BNkbvr0ZFDbh3oV13QzT5jXIu8xpFc9r0o5mvWBhDU1GBkVt1IzHK1N6dcYmN7XImrUmPQ0HCUXmoe2WPo8xsg==
+
+"paseto3@npm:paseto@^3.0.0":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/paseto/-/paseto-3.1.1.tgz#970ed7b2b5e2815aa0a2619219c00cec5bd02848"
+  integrity sha512-pZmPoGPsR9dBdaKhyKeRLNdvdDbpFA/1Ku/3LuQaY/ssPE4fzSRuNz2+qoSRaIB/mDcbWyzZKjV8ook6AzlsSg==
 
 path-browserify@^1.0.1:
   version "1.0.1"
@@ -10374,6 +11090,15 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -10557,7 +11282,7 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raw-body@2.5.1:
+raw-body@2.5.1, raw-body@^2.4.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
   integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
@@ -10593,6 +11318,41 @@ rdf-data-factory@^1.0.1, rdf-data-factory@^1.0.3, rdf-data-factory@^1.0.4, rdf-d
   integrity sha512-g8feOVZ/KL1OK2Pco/jDBDFh4m29QDsOOD+rWloG9qFvIzRFchGy2CviLUX491E0ByewXxMpaq/A3zsWHQA16A==
   dependencies:
     "@rdfjs/types" "*"
+
+rdf-dereference@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-dereference/-/rdf-dereference-2.0.0.tgz#eae55c9e30d0a462c8845d7906ce3b9f1b07a662"
+  integrity sha512-ddHsc7lgqWhAhmW+QmunWRlWQ13O/V6voZS17Sp+T72Kfi2kD3ShVqwEmQMQiouNI/efLrTaiJim04rgsk5g7g==
+  dependencies:
+    "@comunica/actor-dereference-fallback" "^2.0.2"
+    "@comunica/actor-dereference-file" "^2.0.2"
+    "@comunica/actor-dereference-http" "^2.0.2"
+    "@comunica/actor-dereference-rdf-parse" "^2.0.2"
+    "@comunica/actor-http-fetch" "^2.0.1"
+    "@comunica/actor-http-proxy" "^2.0.1"
+    "@comunica/actor-rdf-parse-html" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-microdata" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-rdfa" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-script" "^2.0.1"
+    "@comunica/actor-rdf-parse-jsonld" "^2.0.1"
+    "@comunica/actor-rdf-parse-n3" "^2.0.1"
+    "@comunica/actor-rdf-parse-rdfxml" "^2.0.1"
+    "@comunica/actor-rdf-parse-xml-rdfa" "^2.0.1"
+    "@comunica/bus-dereference" "^2.0.2"
+    "@comunica/bus-dereference-rdf" "^2.0.2"
+    "@comunica/bus-http" "^2.0.1"
+    "@comunica/bus-init" "^2.0.1"
+    "@comunica/bus-rdf-parse" "^2.0.1"
+    "@comunica/bus-rdf-parse-html" "^2.0.1"
+    "@comunica/config-query-sparql" "^2.0.1"
+    "@comunica/core" "^2.0.1"
+    "@comunica/mediator-combine-pipeline" "^2.0.1"
+    "@comunica/mediator-combine-union" "^2.0.1"
+    "@comunica/mediator-number" "^2.0.1"
+    "@comunica/mediator-race" "^2.0.1"
+    "@rdfjs/types" "*"
+    rdf-string "^1.6.0"
+    stream-to-string "^1.2.0"
 
 rdf-isomorphic@^1.3.0:
   version "1.3.0"
@@ -10658,6 +11418,34 @@ rdf-parse@^2.0.0:
     "@rdfjs/types" "*"
     stream-to-string "^1.2.0"
 
+rdf-parse@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rdf-parse/-/rdf-parse-2.1.0.tgz#7c4a92f1e3a8bab0643fc335365d2b6fba67c445"
+  integrity sha512-Ew0M3uokgtDr3YAJ77/Wcwxu1pRarFeR7dNAPFncpLfpmOhfh0UzYAhw1JRMyqNb4t0pIvB3qWHf5yDxy8upgQ==
+  dependencies:
+    "@comunica/actor-http-fetch" "^2.0.1"
+    "@comunica/actor-http-proxy" "^2.0.1"
+    "@comunica/actor-rdf-parse-html" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-microdata" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-rdfa" "^2.0.1"
+    "@comunica/actor-rdf-parse-html-script" "^2.0.1"
+    "@comunica/actor-rdf-parse-jsonld" "^2.0.1"
+    "@comunica/actor-rdf-parse-n3" "^2.0.1"
+    "@comunica/actor-rdf-parse-rdfxml" "^2.0.1"
+    "@comunica/actor-rdf-parse-xml-rdfa" "^2.0.1"
+    "@comunica/bus-http" "^2.0.1"
+    "@comunica/bus-init" "^2.0.1"
+    "@comunica/bus-rdf-parse" "^2.0.1"
+    "@comunica/bus-rdf-parse-html" "^2.0.1"
+    "@comunica/config-query-sparql" "^2.0.1"
+    "@comunica/core" "^2.0.1"
+    "@comunica/mediator-combine-pipeline" "^2.0.1"
+    "@comunica/mediator-combine-union" "^2.0.1"
+    "@comunica/mediator-number" "^2.0.1"
+    "@comunica/mediator-race" "^2.0.1"
+    "@rdfjs/types" "*"
+    stream-to-string "^1.2.0"
+
 rdf-quad@^1.4.0, rdf-quad@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/rdf-quad/-/rdf-quad-1.5.0.tgz#531c4c132cdcbc0ca3295a3df9060cd3b0ce896f"
@@ -10666,6 +11454,23 @@ rdf-quad@^1.4.0, rdf-quad@^1.5.0:
     rdf-data-factory "^1.0.1"
     rdf-literal "^1.2.0"
     rdf-string "^1.5.0"
+
+rdf-serialize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-serialize/-/rdf-serialize-2.0.0.tgz#8f21f971ea2e09e6eeea4d2e5dfaf44ed27aae97"
+  integrity sha512-Ty++WuivkrnDF6dtWcOTziQoQl+ztz8p19x3FRREQo6nHGQPupv2f9xLZ38u/NGuvgo98+mb/QHRrbnqA7PE9A==
+  dependencies:
+    "@comunica/actor-rdf-serialize-jsonld" "^2.0.1"
+    "@comunica/actor-rdf-serialize-n3" "^2.0.1"
+    "@comunica/bus-init" "^2.0.1"
+    "@comunica/bus-rdf-serialize" "^2.0.1"
+    "@comunica/config-query-sparql" "^2.0.1"
+    "@comunica/core" "^2.0.1"
+    "@comunica/mediator-combine-pipeline" "^2.0.1"
+    "@comunica/mediator-combine-union" "^2.0.1"
+    "@comunica/mediator-race" "^2.0.1"
+    "@rdfjs/types" "*"
+    stream-to-string "^1.2.0"
 
 rdf-store-stream@^1.1.0, rdf-store-stream@^1.3.0:
   version "1.3.0"
@@ -10695,6 +11500,15 @@ rdf-terms@^1.6.2, rdf-terms@^1.7.0, rdf-terms@^1.7.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.8.2.tgz#5a744227819549f8603c487a89c44c751c1cc7b2"
   integrity sha512-py0v2HSd+8ioTKmt7j4hripQSXezrG99B5/WtilbZ9JZHwqvYl+eu1UQHts1T0TaY8lYR7MLAolVfW5lrkxw4g==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    rdf-string "^1.6.0"
+
+rdf-terms@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.9.0.tgz#09da2e4f051a77836f3e63f0a49ca11fff254caa"
+  integrity sha512-FGMPOIpr6vEN8gWd/dVuPpcE/7k+u4Ufqi8FvM5lczjhduT1MN9Shmrw50fWCpHFVE4n0T3lV0qti1PCaHxAfg==
   dependencies:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
@@ -11017,6 +11831,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==
+  dependencies:
+    redis-errors "^1.0.0"
+
 regenerate-unicode-properties@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz#7f442732aa7934a3740c779bb9b3340dccc1fb56"
@@ -11191,7 +12017,7 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-resolve-alpn@^1.2.0:
+resolve-alpn@^1.0.0, resolve-alpn@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
   integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
@@ -11260,6 +12086,13 @@ responselike@^1.0.2:
   integrity sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==
   dependencies:
     lowercase-keys "^1.0.0"
+
+responselike@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.1.tgz#9a0bc8fdc252f3fb1cca68b016591059ba1422bc"
+  integrity sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 responselike@^3.0.0:
   version "3.0.0"
@@ -11797,7 +12630,7 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.2:
+sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.2, sparqlalgebrajs@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.0.3.tgz#8c4d3e24b1705226d66e6e9047330eeba5821719"
   integrity sha512-iObqFlq/QjhJoVNzObPSq+7zdm+VTgUQI0UIG2TI1eAs+mi029Toivip5PWw5J25QE0o9x/rFQzCEQ9v6Ddfdg==
@@ -12001,6 +12834,11 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+standard-as-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/standard-as-callback/-/standard-as-callback-2.1.0.tgz#8953fc05359868a77b5b9739a665c5977bb7df45"
+  integrity sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -12013,6 +12851,11 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
+"statuses@>= 1.5.0 < 2", statuses@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
 
 stream-browserify@^3.0.0:
   version "3.0.0"
@@ -12488,6 +13331,11 @@ truncate-utf8-bytes@^1.0.0:
   dependencies:
     utf8-byte-length "^1.0.1"
 
+ts-guards@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/ts-guards/-/ts-guards-0.5.1.tgz#10241ce5203cfeeba4709f48dca5ea6907b17e55"
+  integrity sha512-Y6P/VJnwARiPMfxO7rvaYaz5tGQ5TQ0Wnb2cWIxMpFOioYkhsT8XaCrJX6wYPNFACa4UOrN5SPqhwpM8NolAhQ==
+
 ts-jest@^27.0.1:
   version "27.1.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.5.tgz#0ddf1b163fbaae3d5b7504a1e65c914a95cff297"
@@ -12516,6 +13364,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tsscmp@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -12605,7 +13458,7 @@ type-fest@^2.13.0, type-fest@^2.14.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
   integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
-type-is@~1.6.18:
+type-is@^1.6.16, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
@@ -12840,6 +13693,11 @@ url-exists@^1.0.3:
   dependencies:
     request "^2.69.0"
 
+url-join@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
+  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+
 url-parse-lax@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
@@ -12900,7 +13758,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.0.0, uuid@^8.3.2:
+uuid@^8.0.0, uuid@^8.3.1, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
@@ -12946,7 +13804,7 @@ varname@2.0.2:
   resolved "https://registry.yarnpkg.com/varname/-/varname-2.0.2.tgz#df7969952b882f6d011f85029e13b2c83e721158"
   integrity sha512-+04KQt82uYOoagL2mutu7XYWILEQ8qhE+3zXyJN0Zz+MiuMYv8IvzVJeC4cD1RBfvVvuPPH2KH80MTFcU+cYRw==
 
-vary@^1, vary@~1.1.2:
+vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -13226,6 +14084,23 @@ winston@^3.2.1, winston@^3.3.3:
     triple-beam "^1.3.0"
     winston-transport "^4.5.0"
 
+winston@^3.8.1:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.8.2.tgz#56e16b34022eb4cff2638196d9646d7430fdad50"
+  integrity sha512-MsE1gRx1m5jdTTO9Ld/vND4krP2To+lgDoMEHGGa4HIlAUyXJtfc7CxQcGXVyz2IBpw5hbFkj2b/AtUdQwyRew==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
+
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -13353,6 +14228,11 @@ ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.8.tgz#ac2729881ab9e7cbaf8787fe3469a48c5c7f636a"
   integrity sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==
 
+ws@^8.8.1:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.9.0.tgz#2a994bb67144be1b53fe2d23c53c028adeb7f45e"
+  integrity sha512-Ja7nszREasGaYUYCI2k4lCKIRTt+y7XuqVoHR44YpI49TtryyqbqvDMn5eqfW7e6HzTukDRIsXqzVHScqRcafg==
+
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
@@ -13461,7 +14341,7 @@ yargs@^16.1.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.1.1:
+yargs@^17.1.1, yargs@^17.5.1:
   version "17.5.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.5.1.tgz#e109900cab6fcb7fd44b1d8249166feb0b36e58e"
   integrity sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==
@@ -13473,6 +14353,11 @@ yargs@^17.1.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
+
+ylru@^1.2.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.3.2.tgz#0de48017473275a4cbdfc83a1eaf67c01af8a785"
+  integrity sha512-RXRJzMiK6U2ye0BlGGZnmpwJDPgakn6aNQ0A7gHRbD4I0uvK4TW6UqkK1V0pp9jskjJBAXd3dRrbzWkqJ+6cxA==
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,7 +2454,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==


### PR DESCRIPTION
This PR adds some integration tests against a Solid Pod.

There are two TODOs
 - Fix failing tests by resolving https://github.com/comunica/comunica-feature-solid/issues/43
 - Improve test coverage with more complex operations
 - Use jest mock functionality properly rather than overriding global fetch
 - Test against different CSS versions / configs?

Currently CI/CD is failing because CSS does not work on Node 18. I'm not sure if there is an easy way to disable these tests specifically on that version of node for now @rubensworks ?

