### PR TITLE
Chore: improve context key injection

### DIFF
--- a/.componentsjs-generator-config.json
+++ b/.componentsjs-generator-config.json
@@ -56,6 +56,7 @@
 
     "RDF.Stream",
     "Omit",
+    "Partial",
     "MediateMediaTyped",
     "IActorDereferenceOutput",
     "Factory",

--- a/engines/query-sparql-file/lib/QueryEngine.ts
+++ b/engines/query-sparql-file/lib/QueryEngine.ts
@@ -1,12 +1,14 @@
 import { QueryEngineBase } from '@comunica/actor-init-query';
 import type { ActorInitQueryBase } from '@comunica/actor-init-query';
+import type { IQueryContextCommon } from '@comunica/types';
 const engineDefault = require('../engine-default.js');
 
 /**
  * A Comunica SPARQL query engine.
  */
-export class QueryEngine extends QueryEngineBase {
-  public constructor(engine: ActorInitQueryBase = engineDefault) {
+export class QueryEngine<QueryContext extends IQueryContextCommon = IQueryContextCommon>
+  extends QueryEngineBase<QueryContext> {
+  public constructor(engine: ActorInitQueryBase<QueryContext> = engineDefault) {
     super(engine);
   }
 }

--- a/engines/query-sparql-rdfjs/lib/QueryEngine.ts
+++ b/engines/query-sparql-rdfjs/lib/QueryEngine.ts
@@ -1,12 +1,14 @@
 import { QueryEngineBase } from '@comunica/actor-init-query';
 import type { ActorInitQueryBase } from '@comunica/actor-init-query';
+import type { IQueryContextCommon } from '@comunica/types';
 const engineDefault = require('../engine-default.js');
 
 /**
  * A Comunica SPARQL query engine.
  */
-export class QueryEngine extends QueryEngineBase {
-  public constructor(engine: ActorInitQueryBase = engineDefault) {
+export class QueryEngine<QueryContext extends IQueryContextCommon = IQueryContextCommon>
+  extends QueryEngineBase<QueryContext> {
+  public constructor(engine: ActorInitQueryBase<QueryContext> = engineDefault) {
     super(engine);
   }
 }

--- a/engines/query-sparql/lib/QueryEngine.ts
+++ b/engines/query-sparql/lib/QueryEngine.ts
@@ -1,12 +1,14 @@
 import { QueryEngineBase } from '@comunica/actor-init-query';
 import type { ActorInitQueryBase } from '@comunica/actor-init-query';
+import type { IQueryContextCommon } from '@comunica/types';
 const engineDefault = require('../engine-default.js');
 
 /**
  * A Comunica SPARQL query engine.
  */
-export class QueryEngine extends QueryEngineBase {
-  public constructor(engine: ActorInitQueryBase = engineDefault) {
+export class QueryEngine<QueryContext extends IQueryContextCommon = IQueryContextCommon>
+  extends QueryEngineBase<QueryContext> {
+  public constructor(engine: ActorInitQueryBase<QueryContext> = engineDefault) {
     super(engine);
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@pollyjs/adapter-node-http": "^6.0.4",
     "@pollyjs/core": "^6.0.0",
     "@pollyjs/persister-fs": "^6.0.0",
-    "@solid/community-server": "^5.0.0",
+    "@solid/community-server": "^5.1.0",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.4.2",
     "@types/jest": "^27.0.0",
     "@types/node": "^14.0.0",

--- a/packages/actor-init-query/lib/ActorInitQuery.ts
+++ b/packages/actor-init-query/lib/ActorInitQuery.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'fs';
 import type { IActionInit, IActorOutputInit } from '@comunica/bus-init';
 import { KeysInitQuery } from '@comunica/context-entries';
-import type { ICliArgsHandler } from '@comunica/types';
+import type { ICliArgsHandler, IQueryContextCommon } from '@comunica/types';
 import type { Readable } from 'readable-stream';
 import yargs from 'yargs';
 import type { IActorInitQueryBaseArgs } from './ActorInitQueryBase';
@@ -15,14 +15,15 @@ const streamifyString = require('streamify-string');
 /**
  * A comunica Query Init Actor.
  */
-export class ActorInitQuery extends ActorInitQueryBase {
-  public constructor(args: IActorInitQueryBaseArgs) {
+export class ActorInitQuery<QueryContext extends IQueryContextCommon = IQueryContextCommon>
+  extends ActorInitQueryBase<QueryContext> {
+  public constructor(args: IActorInitQueryBaseArgs<QueryContext>) {
     super(args);
   }
 
   public async run(action: IActionInit): Promise<IActorOutputInit> {
     // Wrap this actor in a query engine so we can conveniently execute queries
-    const queryEngine = new QueryEngineBase(this);
+    const queryEngine = new QueryEngineBase<QueryContext>(this);
 
     const cliArgsHandlers: ICliArgsHandler[] = [
       new CliArgsHandlerBase(action.context),

--- a/packages/actor-init-query/lib/ActorInitQueryBase.ts
+++ b/packages/actor-init-query/lib/ActorInitQueryBase.ts
@@ -9,12 +9,13 @@ import type { MediatorQueryResultSerializeHandle,
   MediatorQueryResultSerializeMediaTypes,
   MediatorQueryResultSerializeMediaTypeFormats } from '@comunica/bus-query-result-serialize';
 import type { IActorTest } from '@comunica/core';
-import type { Logger } from '@comunica/types';
+import type { IQueryContextCommon, Logger } from '@comunica/types';
 
 /**
  * A browser-safe comunica Query Init Actor.
  */
-export class ActorInitQueryBase extends ActorInit implements IActorInitQueryBaseArgs {
+export class ActorInitQueryBase<QueryContext extends IQueryContextCommon = IQueryContextCommon>
+  extends ActorInit implements IActorInitQueryBaseArgs<QueryContext> {
   public readonly mediatorOptimizeQueryOperation: MediatorOptimizeQueryOperation;
   public readonly mediatorQueryOperation: MediatorQueryOperation;
   public readonly mediatorQueryParse: MediatorQueryParse;
@@ -28,9 +29,10 @@ export class ActorInitQueryBase extends ActorInit implements IActorInitQueryBase
   public readonly queryString?: string;
   public readonly defaultQueryInputFormat?: string;
   public readonly context?: string;
-  public readonly contextKeyShortcuts: Record<string, string>;
+  public readonly contextKeyShortcuts: Record<string, string> & Partial<Record<keyof QueryContext, string>>;
   /** Array of `contextKeyShortcuts` appended to `contextKeyShortcuts` during construction. */
-  public readonly contextKeyShortcutsExtensions?: Record<string, string>[];
+  public readonly contextKeyShortcutsExtensions?: (Record<string, string>
+  | Partial<Record<keyof Omit<QueryContext, keyof IQueryContextCommon>, string>>)[];
 
   /**
    * Create new ActorInitQueryBase object.
@@ -60,7 +62,8 @@ export class ActorInitQueryBase extends ActorInit implements IActorInitQueryBase
   }
 }
 
-export interface IActorInitQueryBaseArgs extends IActorInitArgs {
+export interface IActorInitQueryBaseArgs<QueryContext extends IQueryContextCommon = IQueryContextCommon>
+  extends IActorInitArgs {
   /**
    * The query operation optimize mediator
    */
@@ -143,8 +146,7 @@ export interface IActorInitQueryBaseArgs extends IActorInitArgs {
    *   "localizeBlankNodes": "@comunica/actor-query-operation:localizeBlankNodes"
    * }}
    */
-  contextKeyShortcuts: Record<string, string>;
-
+  contextKeyShortcuts: Record<string, string> | Partial<Record<keyof QueryContext, string>>;
   /**
    * An array of `contextKeyShortcuts` that are to be appended to the (default) `contextKeyShortcuts`
    * (which are by default injected by component.js).
@@ -152,7 +154,7 @@ export interface IActorInitQueryBaseArgs extends IActorInitArgs {
    * The appending happens in the constructor call. Conflicting keys will cause an error.
    * If you extend `ActorInitQueryBase` and want to add custom shortcuts, do so as follows:
    * ```
-   * public constructor(args: IActorInitQueryBaseArgs) {
+   * public constructor(args: IActorInitQueryBaseArgs<QueryContext>) {
    *  if (!args.contextKeyShortcutsExtensions) {
    *    args.contextKeyShortcutsExtensions = [];
    *  }
@@ -162,5 +164,7 @@ export interface IActorInitQueryBaseArgs extends IActorInitArgs {
    * }
    * ```
    */
-  contextKeyShortcutsExtensions?: Record<string, string>[];
+  contextKeyShortcutsExtensions?: (Record<string, string>
+  | Partial<Record<keyof Omit<QueryContext, keyof IQueryContextCommon>, string>>)[];
+
 }

--- a/packages/actor-init-query/lib/ActorInitQueryBase.ts
+++ b/packages/actor-init-query/lib/ActorInitQueryBase.ts
@@ -44,7 +44,7 @@ export class ActorInitQueryBase<QueryContext extends IQueryContextCommon = IQuer
   public constructor(args: IActorInitQueryBaseArgs) {
     // Add additional contextKeyShortcuts.
     args.contextKeyShortcutsExtensions?.forEach(extensionShortcuts => {
-      // Throw, f there are duplicate keys that are to be added to `contextKeyShortcuts`.
+      // Throw, if there are duplicate keys that are to be added to `contextKeyShortcuts`.
       if (Object.keys(args.contextKeyShortcuts).some(key => Object.keys(extensionShortcuts).includes(key))) {
         throw new Error('Duplicate keys found while adding `contextKeyShortcutsExtensions`.');
       }
@@ -166,5 +166,4 @@ export interface IActorInitQueryBaseArgs<QueryContext extends IQueryContextCommo
    */
   contextKeyShortcutsExtensions?: (Record<string, string>
   | Partial<Record<keyof Omit<QueryContext, keyof IQueryContextCommon>, string>>)[];
-
 }

--- a/packages/actor-init-query/lib/ActorInitQueryBase.ts
+++ b/packages/actor-init-query/lib/ActorInitQueryBase.ts
@@ -29,8 +29,25 @@ export class ActorInitQueryBase extends ActorInit implements IActorInitQueryBase
   public readonly defaultQueryInputFormat?: string;
   public readonly context?: string;
   public readonly contextKeyShortcuts: Record<string, string>;
+  /** Array of `contextKeyShortcuts` appended to `contextKeyShortcuts` during construction. */
+  public readonly contextKeyShortcutsExtensions?: Record<string, string>[];
 
+  /**
+   * Create new ActorInitQueryBase object.
+   * @param args.contextKeyShortcutsExtensions Array of `contextKeyShortcuts` that are merged
+   *   with the `contextKeyShortcuts` field. This allows adding shortcuts to the defaults.
+   * @throws When duplicate keys are present in `args.contextKeyShortcuts`
+   *  and `args.contextKeyShortcutsExtensions`.
+   */
   public constructor(args: IActorInitQueryBaseArgs) {
+    // Add additional contextKeyShortcuts.
+    args.contextKeyShortcutsExtensions?.forEach(extensionShortcuts => {
+      // Throw, f there are duplicate keys that are to be added to `contextKeyShortcuts`.
+      if (Object.keys(args.contextKeyShortcuts).some(key => Object.keys(extensionShortcuts).includes(key))) {
+        throw new Error('Duplicate keys found while adding `contextKeyShortcutsExtensions`.');
+      }
+      args.contextKeyShortcuts = { ...args.contextKeyShortcuts, ...extensionShortcuts };
+    });
     super(args);
   }
 
@@ -127,4 +144,23 @@ export interface IActorInitQueryBaseArgs extends IActorInitArgs {
    * }}
    */
   contextKeyShortcuts: Record<string, string>;
+
+  /**
+   * An array of `contextKeyShortcuts` that are to be appended to the (default) `contextKeyShortcuts`
+   * (which are by default injected by component.js).
+   *
+   * The appending happens in the constructor call. Conflicting keys will cause an error.
+   * If you extend `ActorInitQueryBase` and want to add custom shortcuts, do so as follows:
+   * ```
+   * public constructor(args: IActorInitQueryBaseArgs) {
+   *  if (!args.contextKeyShortcutsExtensions) {
+   *    args.contextKeyShortcutsExtensions = [];
+   *  }
+   *  args.contextKeyShortcutsExtensions.push(addedShortcuts);
+   *
+   *  super(args);
+   * }
+   * ```
+   */
+  contextKeyShortcutsExtensions?: Record<string, string>[];
 }

--- a/packages/actor-init-query/test/ActorInitQueryBase-test.ts
+++ b/packages/actor-init-query/test/ActorInitQueryBase-test.ts
@@ -107,4 +107,52 @@ describe('ActorInitQueryBase', () => {
       });
     });
   });
+
+  describe('An ActorInitQueryBase instance with extended contextKeyShortcuts', () => {
+    it('should throw with duplicate shortcut extensions', async() => {
+      expect(() => new ActorInitQueryBase({
+        bus,
+        contextKeyShortcutsExtensions: [
+          { log: 'customKey' },
+        ],
+        contextKeyShortcuts,
+        defaultQueryInputFormat,
+        logger,
+        mediatorContextPreprocess,
+        mediatorHttpInvalidate,
+        mediatorOptimizeQueryOperation,
+        mediatorQueryOperation,
+        mediatorQueryParse: mediatorSparqlParse,
+        mediatorQueryResultSerialize: mediatorSparqlSerialize,
+        mediatorQueryResultSerializeMediaTypeCombiner: mediatorSparqlSerialize,
+        mediatorQueryResultSerializeMediaTypeFormatCombiner: mediatorSparqlSerialize,
+        name: 'actor',
+      })).toThrow('Duplicate keys found while adding `contextKeyShortcutsExtensions`.');
+    });
+
+    it('should create context shortcuts with two additional keys', async() => {
+      const actor = new ActorInitQueryBase({
+        bus,
+        contextKeyShortcutsExtensions: [
+          { customField1: 'exampleShortcut1' },
+          { customField2: 'exampleShortcut2' },
+        ],
+        contextKeyShortcuts,
+        defaultQueryInputFormat,
+        logger,
+        mediatorContextPreprocess,
+        mediatorHttpInvalidate,
+        mediatorOptimizeQueryOperation,
+        mediatorQueryOperation,
+        mediatorQueryParse: mediatorSparqlParse,
+        mediatorQueryResultSerialize: mediatorSparqlSerialize,
+        mediatorQueryResultSerializeMediaTypeCombiner: mediatorSparqlSerialize,
+        mediatorQueryResultSerializeMediaTypeFormatCombiner: mediatorSparqlSerialize,
+        name: 'actor',
+      });
+
+      expect(actor.contextKeyShortcuts.customField1).toBe('exampleShortcut1');
+      expect(actor.contextKeyShortcuts.customField2).toBe('exampleShortcut2');
+    });
+  });
 });

--- a/packages/types/lib/IQueryEngine.ts
+++ b/packages/types/lib/IQueryEngine.ts
@@ -4,7 +4,7 @@ import type { Algebra } from 'sparqlalgebrajs';
 import type { BindingsStream } from './Bindings';
 import type { IActionContext } from './IActionContext';
 import type { IDataSource } from './IDataSource';
-import type { QueryAlgebraContext, QueryStringContext } from './IQueryContext';
+import type { IQueryContextCommon, QueryAlgebraContext, QueryStringContext } from './IQueryContext';
 import type { IQueryExplained, QueryEnhanced, QueryExplainMode } from './IQueryOperationResult';
 
 export type QueryFormatType = string | Algebra.Operation;
@@ -14,7 +14,7 @@ export type QueryType = QueryEnhanced & { context?: IActionContext };
 /**
  * Base interface for a Comunica query engine.
  */
-export interface IQueryEngine extends
+export interface IQueryEngine<QueryContext extends IQueryContextCommon = IQueryContextCommon> extends
   RDF.StringQueryable<RDF.AllMetadataSupport, QueryStringContext>,
   RDF.AlgebraQueryable<Algebra.Operation, RDF.AllMetadataSupport, QueryAlgebraContext>,
   RDF.StringSparqlQueryable<RDF.SparqlResultSupport, QueryStringContext>,
@@ -27,7 +27,7 @@ export interface IQueryEngine extends
    */
   queryBindings: <QueryFormatTypeInner extends QueryFormatType>(
     query: QueryFormatTypeInner,
-    context?: QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
+    context?: QueryContext & QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
   ) => Promise<BindingsStream>;
 
   /**
@@ -37,7 +37,7 @@ export interface IQueryEngine extends
    */
   queryQuads: <QueryFormatTypeInner extends QueryFormatType>(
     query: QueryFormatTypeInner,
-    context?: QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
+    context?: QueryContext & QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
   ) => Promise<AsyncIterator<RDF.Quad> & RDF.ResultStream<RDF.Quad>>;
 
   /**
@@ -47,7 +47,7 @@ export interface IQueryEngine extends
    */
   queryBoolean: <QueryFormatTypeInner extends QueryFormatType>(
     query: QueryFormatTypeInner,
-    context?: QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
+    context?: QueryContext & QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
   ) => Promise<boolean>;
 
   /**
@@ -57,7 +57,7 @@ export interface IQueryEngine extends
    */
   queryVoid: <QueryFormatTypeInner extends QueryFormatType>(
     query: QueryFormatTypeInner,
-    context?: QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
+    context?: QueryContext & QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
   ) => Promise<void>;
 
   /**
@@ -73,7 +73,7 @@ export interface IQueryEngine extends
    */
   query: <QueryFormatTypeInner extends QueryFormatType>(
     query: QueryFormatTypeInner,
-    context?: QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
+    context?: QueryContext & QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
   ) => Promise<QueryType>;
 
   /**
@@ -86,7 +86,7 @@ export interface IQueryEngine extends
    */
   explain: <QueryFormatTypeInner extends QueryFormatType>(
     query: QueryFormatTypeInner,
-    context: QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
+    context: QueryContext & QueryFormatTypeInner extends string ? QueryStringContext : QueryAlgebraContext,
     explainMode: QueryExplainMode,
   ) => Promise<IQueryExplained>;
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,11 +2550,12 @@
     node-fetch "^2.6.7"
     ts-guards "^0.5.1"
 
-"@solid/community-server@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@solid/community-server/-/community-server-5.0.0.tgz#19165d9248723b667040e62d7179346a55d54e16"
-  integrity sha512-nIQK2QZ/L8JLUxEwQuU2r6iZsTmVBiZ9BWxnWDJnKDHgTNK8AnW98heG3DZQSpXC0y0LlPhjMyj4ZMMlpOoO1Q==
+"@solid/community-server@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@solid/community-server/-/community-server-5.1.0.tgz#164b70dca51c4ba744f6d24183ed95ceee498b5b"
+  integrity sha512-i0ANCJeumuM6hm6/iYV8viMA3z69CWVpy5U3k+Sr1QUWDqIBM/HSpOwlmn9HI917qJeTxkAgnCPGYVTXl3WS1Q==
   dependencies:
+    "@comunica/context-entries" "^2.2.0"
     "@comunica/query-sparql" "^2.2.1"
     "@rdfjs/types" "^1.1.0"
     "@solid/access-token-verifier" "^2.0.3"


### PR DESCRIPTION
Hey @Ruben
addressing issue https://github.com/comunica/comunica/issues/949, I created this PR.

I had to add an ignoreComponent record to `.componentsjs-generator-config.json`'s as it does not seem to support Partial correctly which is used here for context type support in the IDE.

I hope this has caught the right direction and happy for feedback :)