### PR TITLE
fix: failing node 14 tests

### DIFF
--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -40,6 +40,7 @@ jest.mock('http', () => {
 jest.mock('fs', () => {
   return fs;
 });
+
 jest.useFakeTimers('legacy');
 
 const argsDefault = {
@@ -48,6 +49,16 @@ const argsDefault = {
 };
 
 describe('HttpServiceSparqlEndpoint', () => {
+  let originalCluster: typeof cluster;
+  beforeAll(() => {
+    originalCluster = { ...cluster };
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line no-import-assign
+    Object.assign(cluster, originalCluster);
+  });
+
   beforeEach(() => {
     process.exit = <any> jest.fn();
 


### PR DESCRIPTION
Reset cluster module after use in HttpServiceSparqlEndpoint-test.