### PR TITLE
Feat/extended shaclc support

### DIFF
--- a/packages/actor-dereference-rdf-parse/lib/ActorDereferenceRdfParse.ts
+++ b/packages/actor-dereference-rdf-parse/lib/ActorDereferenceRdfParse.ts
@@ -13,6 +13,8 @@ export class ActorDereferenceRdfParse extends ActorDereferenceRdf {
    *   "turtle":   "text/turtle",
    *   "shaclc":   "text/shaclc",
    *   "shc":      "text/shaclc",
+   *   "shaclce":   "text/shaclc-ext",
+   *   "shce":      "text/shaclc-ext",
    *   "nt":       "application/n-triples",
    *   "ntriples": "application/n-triples",
    *   "nq":       "application/n-quads",

--- a/packages/actor-rdf-parse-shaclc/lib/ActorRdfParseShaclc.ts
+++ b/packages/actor-rdf-parse-shaclc/lib/ActorRdfParseShaclc.ts
@@ -17,10 +17,12 @@ export class ActorRdfParseShaclc extends ActorRdfParseFixedMediaTypes {
   /**
    * @param args -
    *   \ @defaultNested {{
-   *       "text/shaclc": 1.0
+   *       "text/shaclc": 1.0,
+   *       "text/shaclc-ext": 0.5
    *     }} mediaTypePriorities
    *   \ @defaultNested {{
-   *       "text/shaclc": "http://www.w3.org/ns/formats/Shaclc"
+   *       "text/shaclc": "http://www.w3.org/ns/formats/Shaclc",
+   *       "text/shaclc-ext": "http://www.w3.org/ns/formats/ShaclcExtended"
    *     }} mediaTypeFormats
    */
   public constructor(args: IActorRdfParseFixedMediaTypesArgs) {
@@ -29,7 +31,11 @@ export class ActorRdfParseShaclc extends ActorRdfParseFixedMediaTypes {
 
   public async runHandle(action: IActionRdfParse, mediaType: string, context: IActionContext):
   Promise<IActorRdfParseOutput> {
-    return { data: <any> wrap(toString(action.data).then(str => parse(str))), metadata: { triples: true }};
+    return {
+      data: <any> wrap(toString(action.data)
+        .then(str => parse(str, { extendedSyntax: mediaType === 'text/shaclc-ext' }))),
+      metadata: { triples: true },
+    };
   }
 }
 

--- a/packages/actor-rdf-parse-shaclc/package.json
+++ b/packages/actor-rdf-parse-shaclc/package.json
@@ -35,7 +35,7 @@
     "@comunica/bus-rdf-parse": "^2.5.1",
     "@comunica/types": "^2.5.1",
     "asynciterator": "^3.8.0",
-    "shaclc-parse": "^1.0.1"
+    "shaclc-parse": "^1.2.1"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-parse-shaclc/test/ActorRdfParseShaclc-test.ts
+++ b/packages/actor-rdf-parse-shaclc/test/ActorRdfParseShaclc-test.ts
@@ -106,6 +106,7 @@ describe('ActorRdfParseShaclc', () => {
       actor = new ActorRdfParseShaclc({ bus,
         mediaTypePriorities: {
           'text/shaclc': 1,
+          'text/shaclc-ext': 0.5,
         },
         mediaTypeFormats: {},
         name: 'actor' });
@@ -203,6 +204,7 @@ describe('ActorRdfParseShaclc', () => {
       it('should run', () => {
         return expect(actor.run({ mediaTypes: true, context })).resolves.toEqual({ mediaTypes: {
           'text/shaclc': 1,
+          'text/shaclc-ext': 0.5,
         }});
       });
 
@@ -230,6 +232,49 @@ describe('ActorRdfParseShaclc', () => {
         return expect(actor.run({ mediaTypes: true, context })).resolves.toEqual({ mediaTypes: {
           'text/shaclc': 0,
         }});
+      });
+
+      describe('text/shaclc-ext', () => {
+        beforeEach(() => {
+          input = stringToStream('BASE <http://example.org/basic-shape-iri>\n' +
+          'shape <http://example.org/test#TestShape>;\n' +
+          '<http://example.org/p> <http://example.org/p> {\n' +
+          '}');
+        });
+
+        it('should run on extended syntax with text/shaclc-ext', async() => {
+          const output: any = await actor.run({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'text/shaclc-ext',
+            context,
+          });
+          expect(await arrayifyStream(output.handle.data)).toEqualRdfQuadArray([
+            quad(
+              'http://example.org/test#TestShape',
+              'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+              'http://www.w3.org/ns/shacl#NodeShape',
+            ),
+            quad(
+              'http://example.org/test#TestShape',
+              'http://example.org/p',
+              'http://example.org/p',
+            ),
+            quad(
+              'http://example.org/basic-shape-iri',
+              'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+              'http://www.w3.org/2002/07/owl#Ontology',
+            ),
+          ]);
+        });
+
+        it('should reject on extended syntax with text/shaclc mediatype', async() => {
+          const output: any = await actor.run({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'text/shaclc',
+            context,
+          });
+          await expect(() => arrayifyStream(output.handle.data)).rejects.toThrowError();
+        });
       });
 
       it('should not have duplicate results on multiple read calls', () => {

--- a/packages/actor-rdf-serialize-shaclc/lib/ActorRdfSerializeShaclc.ts
+++ b/packages/actor-rdf-serialize-shaclc/lib/ActorRdfSerializeShaclc.ts
@@ -16,10 +16,12 @@ export class ActorRdfSerializeShaclc extends ActorRdfSerializeFixedMediaTypes {
   /**
    * @param args -
    *   \ @defaultNested {{
-   *       "text/shaclc": 1.0
+   *       "text/shaclc": 1.0,
+   *       "text/shaclc-ext": 0.5
    *     }} mediaTypePriorities
    *   \ @defaultNested {{
-   *       "text/shaclc": "http://www.w3.org/ns/formats/Shaclc"
+   *       "text/shaclc": "http://www.w3.org/ns/formats/Shaclc",
+   *       "text/shaclc-ext": "http://www.w3.org/ns/formats/ShaclcExtended"
    *     }} mediaTypeFormats
    */
   public constructor(args: IActorRdfSerializeFixedMediaTypesArgs) {
@@ -36,7 +38,10 @@ export class ActorRdfSerializeShaclc extends ActorRdfSerializeFixedMediaTypes {
     };
 
     try {
-      const { text } = await wrap(action.quadStream).toArray().then(quads => write(quads, { errorOnUnused: true }));
+      const { text } = await write(
+        await wrap(action.quadStream).toArray(),
+        { errorOnUnused: true, extendedSyntax: mediaType === 'text/shaclc-ext' },
+      );
       data.push(text);
     } catch (error: unknown) {
       // Push the error into the stream

--- a/packages/actor-rdf-serialize-shaclc/package.json
+++ b/packages/actor-rdf-serialize-shaclc/package.json
@@ -35,8 +35,8 @@
     "@comunica/bus-rdf-serialize": "^2.5.1",
     "@comunica/types": "^2.5.1",
     "asynciterator": "^3.8.0",
-    "readable-stream": "^4.2.0",
-    "shaclc-write": "^1.1.0"
+    "readable-stream": "^4.3.0",
+    "shaclc-write": "^1.4.1"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,6 +1249,15 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
+"@jeswr/prefixcc@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@jeswr/prefixcc/-/prefixcc-1.2.1.tgz#db4290930fd8f623204199075c6c710c47637faa"
+  integrity sha512-kBBXbqsaeh3Irp416h/RbelqJgIOp6X/OJJlYmLyr/9qlBYKTKSCuEv5/xjZ0Yf8Yec+QFRYBaOQ2JkMBSH7KA==
+  dependencies:
+    cross-fetch "^3.1.5"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
@@ -11948,6 +11957,16 @@ readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.2.0:
     events "^3.3.0"
     process "^0.11.10"
 
+readable-stream@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.3.0.tgz#0914d0c72db03b316c9733bb3461d64a3cc50cba"
+  integrity sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+
 readable-stream@~1.0.2:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
@@ -12556,19 +12575,20 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaclc-parse@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.0.1.tgz#1aadae2b6f2c05da1311c4c596fd5a081c4bddf9"
-  integrity sha512-iUO4K1+9E7vhg+2eyshS6GwnAafWSOh21krvainjyNdSzy6GpvggZjwTlBYPSnz2meBy+Nsw7z+NES5GR5gYIw==
+shaclc-parse@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.2.1.tgz#3e280ea4730eea92f00524c09e63b219f256a910"
+  integrity sha512-P1qwRWiQPcTooYNLK2a02VGQGrEw6PM7T4quii3aqTGkVoWpMl+Qsq/TnW6csDPxrnqxsiNAM/xSAmqGq3SSvQ==
   dependencies:
     "@rdfjs/types" "^1.1.0"
     n3 "^1.16.3"
 
-shaclc-write@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shaclc-write/-/shaclc-write-1.1.0.tgz#1ae6203dd32af71b20009e20fd86bf1cb1da2588"
-  integrity sha512-ggNqAkXohgIu4Qp7vebrz8obmih71g45AShzLz6hOCvHIZDA5mpBoo97hxLehGv24WktJMXHTZjqnB9bawheEQ==
+shaclc-write@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/shaclc-write/-/shaclc-write-1.4.1.tgz#bcce7020cdb2fa7163b2b799c45e6581cfb84751"
+  integrity sha512-w8vu/w/UYMrEiCZ9NY5gxiBQ6NYN7+xO5xuNNwb3g24INWWok62zrm5wvCw7ttDJd9v/iZ/z3FcXCs7FaKUJWw==
   dependencies:
+    "@jeswr/prefixcc" "^1.2.1"
     n3 "^1.16.3"
     rdf-string-ttl "^1.3.2"
 


### PR DESCRIPTION
Extends #1129 with support for [extended SHACL Compact Syntax](https://github.com/jeswr/shaclcjs#extended-shacl-compact-syntax) using the `text/shaclc-ext` mediaType. Opening as a separate PR as I realize that this may be a somewhat controversial addition.