### PR TITLE
Fix errors related to "[assignement of] read only property" and unit test when using node v19

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,8 +26,8 @@ module.exports = {
     '/engines/query-sparql/test/util.ts',
     // TODO: Remove this condition, once solid-client-authn supports node 18.
     ...(Number(process.versions.node.substring(0, 2)) >= 18
-     ? ["/engines/query-sparql/lib/QueryEngineFactory.ts"]
-     : []),
+    ? ["/engines/query-sparql/lib/QueryEngineFactory.ts"]
+    : []),
   ],
   testEnvironment: 'node',
   coverageThreshold: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,8 +26,8 @@ module.exports = {
     '/engines/query-sparql/test/util.ts',
     // TODO: Remove this condition, once solid-client-authn supports node 18.
     ...(Number(process.versions.node.substring(0, 2)) >= 18
-      ? ["/engines/query-sparql/lib/QueryEngineFactory.ts"]
-      : []),
+     ? ["/engines/query-sparql/lib/QueryEngineFactory.ts"]
+     : []),
   ],
   testEnvironment: 'node',
   coverageThreshold: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   testRegex: ['/test/.*-test.*.ts$'],
   // TODO: Remove this condition, once solid-client-authn supports node 18.
-  testPathIgnorePatterns: process.versions.node.startsWith("18")
+  testPathIgnorePatterns: Number(process.versions.node.substring(0, 2)) >= 18
     ? ['.*QuerySparql-solid-test.ts']
     : [],
   moduleFileExtensions: [
@@ -17,7 +17,7 @@ module.exports = {
       //isolatedModules: true
     },
   },
-  setupFilesAfterEnv: [ './setup-jest.js' ],
+  setupFilesAfterEnv: ['./setup-jest.js'],
   collectCoverage: true,
   coveragePathIgnorePatterns: [
     '/node_modules/',
@@ -25,9 +25,9 @@ module.exports = {
     'index.js',
     '/engines/query-sparql/test/util.ts',
     // TODO: Remove this condition, once solid-client-authn supports node 18.
-    ...(process.versions.node.startsWith("18")
-    ? ["/engines/query-sparql/lib/QueryEngineFactory.ts"]
-    : []),
+    ...(Number(process.versions.node.substring(0, 2)) >= 18
+      ? ["/engines/query-sparql/lib/QueryEngineFactory.ts"]
+      : []),
   ],
   testEnvironment: 'node',
   coverageThreshold: {

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -1724,7 +1724,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         httpRequestMock.headers = { 'content-type': 'application/x-www-form-urlencoded' };
 
         return expect(instance.parseBody(httpRequestMock)).rejects
-          .toThrowError(/(Invalid POST body with context received \('\{"a:"b"\}'\):) .+JSON (at position 5)/u);
+          .toThrowError('Invalid POST body with context received');
       });
 
       it('should reject if content-type is not application/[sparql-query|x-www-form-urlencoded]', () => {

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -1724,7 +1724,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         httpRequestMock.headers = { 'content-type': 'application/x-www-form-urlencoded' };
 
         return expect(instance.parseBody(httpRequestMock)).rejects
-          .toThrowError(`Invalid POST body with context received ('{"a:"b"}'): Unexpected token b in JSON at position 5`);
+          .toThrowError(RegExp(String.raw`Invalid POST body with context received \('{\"a:\"b\"}'\): .* at position 5`));
       });
 
       it('should reject if content-type is not application/[sparql-query|x-www-form-urlencoded]', () => {

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -1724,7 +1724,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         httpRequestMock.headers = { 'content-type': 'application/x-www-form-urlencoded' };
 
         return expect(instance.parseBody(httpRequestMock)).rejects
-          .toThrowError(RegExp(String.raw`Invalid POST body with context received \('{\"a:\"b\"}'\): .* at position 5`));
+          .toThrowError(/(Invalid POST body with context received \('\{"a:"b"\}'\):) .+JSON (at position 5)/u);
       });
 
       it('should reject if content-type is not application/[sparql-query|x-www-form-urlencoded]', () => {

--- a/packages/bus-http/lib/ActorHttp.ts
+++ b/packages/bus-http/lib/ActorHttp.ts
@@ -2,8 +2,9 @@ import type { IAction, IActorArgs, IActorOutput, IActorTest, Mediate } from '@co
 import { Actor } from '@comunica/core';
 import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
 
-// TODO: Remove when targeting NodeJS 18+
-global.ReadableStream = global.ReadableStream || require('web-streams-ponyfill').ReadableStream;
+if (!global.ReadableStream) {
+  global.ReadableStream = require('web-streams-ponyfill').ReadableStream;
+}
 
 const isStream = require('is-stream');
 const toWebReadableStream = require('readable-stream-node-to-web');


### PR DESCRIPTION
- global.ReadableStream is only modify when it is undefined
- Unit test related to solid-client-authn are ignore as the package doesn't support it
- Unit test of error modified to take into account the new error string of node v19
    - Before v19: `Invalid POST body with context received ('{"a:"b"}'): Expected ':' after property name in JSON at position 5`
    - v19: `Invalid POST body with context received ('{"a:"b"}'): Unexpected token b in JSON at position 5`



close #1141