### PR TITLE
Add source cache to string source actor

### DIFF
--- a/packages/actor-rdf-resolve-quad-pattern-string-source/README.md
+++ b/packages/actor-rdf-resolve-quad-pattern-string-source/README.md
@@ -44,5 +44,6 @@ After installing, this package can be added to your engine's configuration as fo
 
 ### Config Parameters
 
+* `cacheSize`: The maximum number of entries in the LRU cache, set to 0 to disable, defaults to 100.
 * `mediatorRdfParse`: A mediator over the [RDF Parse bus](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-parse).
 * `mediatorRdfResolveQuadPattern`: A mediator over the [RDF resolve quad pattern bus](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-resolve-quad-pattern).

--- a/packages/actor-rdf-resolve-quad-pattern-string-source/README.md
+++ b/packages/actor-rdf-resolve-quad-pattern-string-source/README.md
@@ -44,6 +44,6 @@ After installing, this package can be added to your engine's configuration as fo
 
 ### Config Parameters
 
-* `cacheSize`: The maximum number of entries in the LRU cache, set to 0 to disable, defaults to 100.
+* `cacheSize`: The maximum number of parsed stores in the LRU cache, set to 0 to disable, defaults to 100.
 * `mediatorRdfParse`: A mediator over the [RDF Parse bus](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-parse).
 * `mediatorRdfResolveQuadPattern`: A mediator over the [RDF resolve quad pattern bus](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-resolve-quad-pattern).

--- a/packages/actor-rdf-resolve-quad-pattern-string-source/lib/ActorRdfResolveQuadPatternStringSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-string-source/lib/ActorRdfResolveQuadPatternStringSource.ts
@@ -1,29 +1,33 @@
-import type { MediatorRdfParseHandle } from '@comunica/bus-rdf-parse';
-import {
-  getContextSource
-  , ActorRdfResolveQuadPattern,
-} from '@comunica/bus-rdf-resolve-quad-pattern';
+import type { IActionRdfParseHandle, MediatorRdfParseHandle } from '@comunica/bus-rdf-parse';
+import { getContextSource, ActorRdfResolveQuadPattern } from '@comunica/bus-rdf-resolve-quad-pattern';
 import type {
   IActionRdfResolveQuadPattern, IActorRdfResolveQuadPatternArgs, IActorRdfResolveQuadPatternOutput,
   MediatorRdfResolveQuadPattern,
 } from '@comunica/bus-rdf-resolve-quad-pattern';
 import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
 import type { IActorTest } from '@comunica/core';
-import type { IDataSourceSerialized } from '@comunica/types';
+import type { IActionContext, IDataSource, IDataSourceSerialized } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
+import LRUCache = require('lru-cache');
 import { storeStream } from 'rdf-store-stream';
 import { Readable } from 'readable-stream';
 
 /**
  * A comunica RDF Resolve Quad Pattern String Source RDF Resolve Quad Pattern Actor.
  */
-export class ActorRdfResolveQuadPatternStringSource extends ActorRdfResolveQuadPattern {
-  public static readonly sourceType = 'stringSource';
-  private readonly mediatorRdfParse: MediatorRdfParseHandle;
-  private readonly mediatorRdfResolveQuadPattern: MediatorRdfResolveQuadPattern;
+export class ActorRdfResolveQuadPatternStringSource extends ActorRdfResolveQuadPattern
+  implements IActorRdfResolveQuadPatternStringSourceArgs {
+  public readonly cacheSize: number;
+  public readonly mediatorRdfParse: MediatorRdfParseHandle;
+  public readonly mediatorRdfResolveQuadPattern: MediatorRdfResolveQuadPattern;
 
-  public constructor(args: IActorRdfResolveQuadPatternStringSource) {
+  public static readonly sourceType = 'stringSource';
+
+  private readonly cache?: LRUCache<IDataSource, Promise<RDF.Source>>;
+
+  public constructor(args: IActorRdfResolveQuadPatternStringSourceArgs) {
     super(args);
+    this.cache = this.cacheSize ? new LRUCache<IDataSource, Promise<RDF.Source>>({ max: this.cacheSize }) : undefined;
   }
 
   public async test(action: IActionRdfResolveQuadPattern): Promise<IActorTest> {
@@ -37,9 +41,26 @@ export class ActorRdfResolveQuadPatternStringSource extends ActorRdfResolveQuadP
     return true;
   }
 
-  public async run(action: IActionRdfResolveQuadPattern): Promise<IActorRdfResolveQuadPatternOutput> {
-    const source = <IDataSourceSerialized>getContextSource(action.context);
+  public run(action: IActionRdfResolveQuadPattern): Promise<IActorRdfResolveQuadPatternOutput> {
+    const source = <IDataSourceSerialized>getContextSource(action.context)!;
+    const rdfSourcePromise: Promise<RDF.Source> = this.cache?.get(source) ?? this.getRdfSource(action.context, source);
+    if (this.cache && !this.cache.has(source)) {
+      this.cache.set(source, rdfSourcePromise);
+    }
+    return new Promise((resolve, reject) => rdfSourcePromise
+      .then(rdfSource => {
+        const resolveQuadAction: IActionRdfResolveQuadPattern = {
+          pattern: action.pattern,
+          context: action.context.set(KeysRdfResolveQuadPattern.source, {
+            value: rdfSource,
+            type: 'rdfjsSource',
+          }),
+        };
+        resolve(this.mediatorRdfResolveQuadPattern.mediate(resolveQuadAction));
+      }).catch(reject));
+  }
 
+  protected async getRdfSource(context: IActionContext, source: IDataSourceSerialized): Promise<RDF.Source> {
     const textStream = new Readable({ objectMode: true });
     /* istanbul ignore next */
     textStream._read = () => {
@@ -48,24 +69,20 @@ export class ActorRdfResolveQuadPatternStringSource extends ActorRdfResolveQuadP
     textStream.push(source.value);
     textStream.push(null);
 
-    const parserResult = await this.mediatorRdfParse.mediate({
-      context: action.context,
+    const parseAction: IActionRdfParseHandle = {
+      context,
       handle: {
         metadata: { baseIRI: source.baseIRI },
         data: textStream,
-        context: action.context,
+        context,
       },
       handleMediaType: source.mediaType,
-    });
-
-    const resolveQuadAction: IActionRdfResolveQuadPattern = {
-      pattern: action.pattern,
-      context: action.context.set(KeysRdfResolveQuadPattern.source, {
-        value: <RDF.Source> await storeStream(parserResult.handle.data),
-        type: 'rdfjsSource',
-      }),
     };
-    return this.mediatorRdfResolveQuadPattern.mediate(resolveQuadAction);
+
+    const parseResult = await this.mediatorRdfParse.mediate(parseAction);
+    const rdfStore = await storeStream(parseResult.handle.data);
+
+    return rdfStore;
   }
 
   private isStringSource(datasource: any): datasource is IDataSourceSerialized {
@@ -79,12 +96,17 @@ export class ActorRdfResolveQuadPatternStringSource extends ActorRdfResolveQuadP
   }
 }
 
-export interface IActorRdfResolveQuadPatternStringSource extends IActorRdfResolveQuadPatternArgs {
+export interface IActorRdfResolveQuadPatternStringSourceArgs extends IActorRdfResolveQuadPatternArgs {
+  /**
+   * The maximum number of entries in the LRU cache, set to 0 to disable.
+   * @range {integer}
+   * @default {100}
+   */
+  cacheSize: number;
   /**
    * The quad pattern parser mediator.
    */
   mediatorRdfParse: MediatorRdfParseHandle;
-
   /**
    * The rdf resolve quad pattern mediator.
    */

--- a/packages/actor-rdf-resolve-quad-pattern-string-source/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-string-source/package.json
@@ -36,6 +36,9 @@
     "@comunica/bus-rdf-resolve-quad-pattern": "^2.6.0",
     "@comunica/context-entries": "^2.6.0",
     "@comunica/core": "^2.6.0",
+    "@comunica/types": "^2.6.0",
+    "@rdfjs/types": "^1.1.0",
+    "lru-cache": "^7.14.1",
     "rdf-store-stream": "^1.3.1",
     "readable-stream": "^4.2.0"
   },

--- a/packages/actor-rdf-resolve-quad-pattern-string-source/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-string-source/package.json
@@ -37,7 +37,7 @@
     "@comunica/context-entries": "^2.6.0",
     "@comunica/core": "^2.6.0",
     "@comunica/types": "^2.6.0",
-    "@rdfjs/types": "^1.1.0",
+    "@rdfjs/types": "*",
     "lru-cache": "^7.14.1",
     "rdf-store-stream": "^1.3.1",
     "readable-stream": "^4.2.0"


### PR DESCRIPTION
The changes here were inspired by #1143, where the string source actor was parsing the source separately for each pattern, which in turn made the blank node identifiers (after parsing) different for each pattern. Queries with multiple pattern would therefore not produce any results.

The following changes were made to `ActorRdfResolveQuadPatternStringSource`:
* Added a cache with the data source (object) as key and the (promise of) parsed RDF data as value, so any subsequent requests to resolve a pattern based on a string source will use the same parse result for the same source object.
* Added `cacheSize` parameter to configure the cache size, with default 100. When set to 0, the actor will not cache the results and the bug will reappear, but it might be interesting for someone to try it at some point, so I left it like that.
* Added `implements` to the actor definition for its own interface and adjusted some property definitions to match.

The following changes were made to the tests:
* Added a loop to the `run` function test, that attempts to make sure the actor produces expected results when it is run several (default two) times using the same string source object.
* Changed the mock RDF parse and pattern resolve mediators a little to account for that test case.

Also, I noticed that if the string source object is not the same, the previously cached parsing result will not be used. Even if the values would be identical, if the object is not the same, it will end up as a new entry in the cache.

Any feedback would be welcome. Thank you! :slightly_smiling_face: 