### PR TITLE
fix: allow shaclc parser to pipe

### DIFF
--- a/packages/actor-rdf-parse-shaclc/package.json
+++ b/packages/actor-rdf-parse-shaclc/package.json
@@ -37,7 +37,8 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
     "shaclc-parse": "^1.3.0",
-    "stream-to-string": "^1.2.0"
+    "stream-to-string": "^1.2.0",
+    "readable-stream": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-parse-shaclc/test/ActorRdfParseShaclc-test.ts
+++ b/packages/actor-rdf-parse-shaclc/test/ActorRdfParseShaclc-test.ts
@@ -1,4 +1,4 @@
-import type { Readable } from 'stream';
+import { type Readable, PassThrough } from 'stream';
 import { KeysRdfParseHtmlScript } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import 'jest-rdf';
@@ -323,6 +323,33 @@ describe('ActorRdfParseShaclc', () => {
             output.handle.data.read();
             output.handle.data.read();
             expect(await arrayifyStream(output.handle.data)).toEqualRdfQuadArray([
+              quad(
+                'http://example.org/test#TestShape',
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                'http://www.w3.org/ns/shacl#NodeShape',
+              ),
+              quad(
+                'http://example.org/basic-shape-iri',
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                'http://www.w3.org/2002/07/owl#Ontology',
+              ),
+            ]);
+          });
+      });
+
+      it('should be able to pipe data', () => {
+        return actor.run({
+          handle: { data: input, context },
+          handleMediaType: 'text/shaclc',
+          context,
+        })
+          .then(async(output: any) => {
+            // Create a new readable
+            const readable = new PassThrough({ objectMode: true });
+
+            output.handle.data.pipe(readable);
+
+            expect(await arrayifyStream(readable)).toEqualRdfQuadArray([
               quad(
                 'http://example.org/test#TestShape',
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9529,7 +9529,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
+lru-cache@^7.14.1, lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   version "7.14.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
   integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==


### PR DESCRIPTION
This is needed to allow it to be used in packages like rdf-parse (see https://github.com/rubensworks/rdf-parse.js/pull/48/files)