### PR TITLE
fix: don't cache QPF default graph as variable

### DIFF
--- a/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
@@ -203,10 +203,10 @@ export class RdfSourceQpf implements IQuadSource {
   protected getPatternId(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph: RDF.Term): string {
     /* eslint-disable id-length */
     return JSON.stringify({
-      s: subject.termType === 'Variable' ? '' : termToString(subject),
-      p: predicate.termType === 'Variable' ? '' : termToString(predicate),
-      o: object.termType === 'Variable' ? '' : termToString(object),
-      g: graph.termType === 'Variable' ? '' : termToString(graph),
+      s: subject.termType === 'Variable' ? '' : _termToString(subject),
+      p: predicate.termType === 'Variable' ? '' : _termToString(predicate),
+      o: object.termType === 'Variable' ? '' : _termToString(object),
+      g: graph.termType === 'Variable' ? '' : _termToString(graph),
     });
     /* eslint-enable id-length */
   }
@@ -225,4 +225,11 @@ export class RdfSourceQpf implements IQuadSource {
       return quads.clone();
     }
   }
+}
+
+function _termToString(term: RDF.Term): string {
+  return term.termType === 'DefaultGraph' ?
+    // Any character that cannot be present in a URL will do
+    '|' :
+    termToString(term);
 }

--- a/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
@@ -4,6 +4,7 @@ import type { IActorDereferenceRdfOutput } from '@comunica/bus-dereference-rdf';
 import { ActionContext, Bus } from '@comunica/core';
 import type * as RDF from '@rdfjs/types';
 import arrayifyStream from 'arrayify-stream';
+import { DataFactory as N3DF } from 'n3';
 import { DataFactory } from 'rdf-data-factory';
 import { RdfSourceQpf } from '../lib/RdfSourceQpf';
 
@@ -528,6 +529,48 @@ describe('RdfSourceQpf with a custom default graph', () => {
         quad('s2', 'p4', 'o2', 'CUSTOM_GRAPH'),
         quad('DEFAULT_GRAPH', 'defaultInSubject', 'o2', DF.defaultGraph()),
         quad('s1-', 'actualDefaultGraph', 'o1'),
+      ]);
+    });
+
+    it('should correctly correctly cache the default graph [rdf-data-factory, defaultGraph=DEFAULT_GRAPH]', async() => {
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, DF.defaultGraph()))).toBeRdfIsomorphic([
+      ]);
+
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, v))).toBeRdfIsomorphic([
+        quad('s1', 'p3', 'o1', 'CUSTOM_GRAPH'),
+      ]);
+    });
+
+    it('should correctly correctly cache the default graph [n3 DataFactory, defaultGraph=DEFAULT_GRAPH]', async() => {
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, N3DF.defaultGraph()))).toBeRdfIsomorphic([
+      ]);
+
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, v))).toBeRdfIsomorphic([
+        quad('s1', 'p3', 'o1', 'CUSTOM_GRAPH'),
+      ]);
+    });
+
+    it('should correctly correctly cache the default graph [rdf-data-factory, defaultGraph=undefined]', async() => {
+      // @ts-expect-error
+      delete source.defaultGraph;
+
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, DF.defaultGraph()))).toBeRdfIsomorphic([
+      ]);
+
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, v))).toBeRdfIsomorphic([
+        quad('s1', 'p3', 'o1', 'CUSTOM_GRAPH'),
+      ]);
+    });
+
+    it('should correctly correctly cache the default graph [n3 DataFactory, defaultGraph=undefined]', async() => {
+      // @ts-expect-error
+      delete source.defaultGraph;
+
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, N3DF.defaultGraph()))).toBeRdfIsomorphic([
+      ]);
+
+      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, v))).toBeRdfIsomorphic([
+        quad('s1', 'p3', 'o1', 'CUSTOM_GRAPH'),
       ]);
     });
   });

--- a/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
@@ -4,7 +4,6 @@ import type { IActorDereferenceRdfOutput } from '@comunica/bus-dereference-rdf';
 import { ActionContext, Bus } from '@comunica/core';
 import type * as RDF from '@rdfjs/types';
 import arrayifyStream from 'arrayify-stream';
-import { DataFactory as N3DF } from 'n3';
 import { DataFactory } from 'rdf-data-factory';
 import { RdfSourceQpf } from '../lib/RdfSourceQpf';
 
@@ -532,7 +531,7 @@ describe('RdfSourceQpf with a custom default graph', () => {
       ]);
     });
 
-    it('should correctly correctly cache the default graph [rdf-data-factory, defaultGraph=DEFAULT_GRAPH]', async() => {
+    it('should correctly correctly cache the default graph [defaultGraph=DEFAULT_GRAPH]', async() => {
       expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, DF.defaultGraph()))).toBeRdfIsomorphic([
       ]);
 
@@ -541,32 +540,11 @@ describe('RdfSourceQpf with a custom default graph', () => {
       ]);
     });
 
-    it('should correctly correctly cache the default graph [n3 DataFactory, defaultGraph=DEFAULT_GRAPH]', async() => {
-      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, N3DF.defaultGraph()))).toBeRdfIsomorphic([
-      ]);
-
-      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, v))).toBeRdfIsomorphic([
-        quad('s1', 'p3', 'o1', 'CUSTOM_GRAPH'),
-      ]);
-    });
-
-    it('should correctly correctly cache the default graph [rdf-data-factory, defaultGraph=undefined]', async() => {
+    it('should correctly correctly cache the default graph [defaultGraph=undefined]', async() => {
       // @ts-expect-error
       delete source.defaultGraph;
 
       expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, DF.defaultGraph()))).toBeRdfIsomorphic([
-      ]);
-
-      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, v))).toBeRdfIsomorphic([
-        quad('s1', 'p3', 'o1', 'CUSTOM_GRAPH'),
-      ]);
-    });
-
-    it('should correctly correctly cache the default graph [n3 DataFactory, defaultGraph=undefined]', async() => {
-      // @ts-expect-error
-      delete source.defaultGraph;
-
-      expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, N3DF.defaultGraph()))).toBeRdfIsomorphic([
       ]);
 
       expect(await arrayifyStream(source.match(v, DF.namedNode('p3'), v, v))).toBeRdfIsomorphic([


### PR DESCRIPTION
We observed where if we execute the query:

```
PREFIX ldp: <http://www.w3.org/ns/ldp#>
    SELECT * WHERE {
      GRAPH ?g {
        ?s ldp:contains ?o .
      }
    }
```

by itself over a QPF endpoint then the correct results are returned; but if we use the same engine to _first_ execute the query:

````
SELECT * WHERE { ?s <http://www.w3.org/ns/ldp#contains> ?o }
````

then no results are returned.

This is because variables, and the default graph have both been given and id of the empty string and so an empty stream of results was being cached when searching over the default graph with `SELECT * WHERE { ?s <http://www.w3.org/ns/ldp#contains> ?o }` and then this cached stream was incorrectly being re-used when executing the query

```
PREFIX ldp: <http://www.w3.org/ns/ldp#>
    SELECT * WHERE {
      GRAPH ?g {
        ?s ldp:contains ?o .
      }
    }
```
