### PR TITLE
fix: destroy unused iterators

### DIFF
--- a/packages/actor-abstract-path/test/PathVariableObjectIterator-test.ts
+++ b/packages/actor-abstract-path/test/PathVariableObjectIterator-test.ts
@@ -28,14 +28,6 @@ describe('PathVariableObjectIterator', () => {
         return { type: 'bindings', bindingsStream };
       }),
     };
-    iterator = new PathVariableObjectIterator(
-      DF.namedNode('ex:s'),
-      FACTORY.createLink(DF.namedNode('ex:p')),
-      DF.namedNode('ex:g'),
-      new ActionContext(),
-      mediatorQueryOperation,
-      true,
-    );
   });
 
   it('destroys the iterator when an error occurs during mediation', async() => {
@@ -53,7 +45,11 @@ describe('PathVariableObjectIterator', () => {
 
     await expect(new Promise((resolve, reject) => {
       iterator.on('end', resolve);
-      iterator.on('error', reject);
+      iterator.on('error', e => {
+        iterator.close();
+        iterator.destroy();
+        reject(e);
+      });
     })).rejects.toThrow('mediatorQueryOperation rejection in PathVariableObjectIterator');
   });
 
@@ -82,6 +78,15 @@ describe('PathVariableObjectIterator', () => {
   });
 
   it('destroys runningOperations when closed', async() => {
+    iterator = new PathVariableObjectIterator(
+      DF.namedNode('ex:s'),
+      FACTORY.createLink(DF.namedNode('ex:p')),
+      DF.namedNode('ex:g'),
+      new ActionContext(),
+      mediatorQueryOperation,
+      true,
+    );
+
     iterator.read();
     await new Promise(setImmediate);
 

--- a/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
+++ b/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
@@ -116,6 +116,6 @@ export class BindingsToQuadsIterator extends MultiTransformIterator<Bindings, RD
   public _createTransformer(bindings: Bindings): AsyncIterator<RDF.Quad> {
     return new ArrayIterator(this.bindTemplate(
       bindings, this.template, this.blankNodeCounter++,
-    ));
+    ), { autoStart: false });
   }
 }

--- a/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
+++ b/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
@@ -455,7 +455,7 @@ describe('BindingsToQuadsIterator', () => {
         BF.bindings([
           [ DF.variable('a'), DF.namedNode('a3') ],
         ]),
-      ]));
+      ], { autoStart: false }));
     });
 
     it('should be transformed to a valid triple stream', async() => {
@@ -485,13 +485,16 @@ describe('BindingsToQuadsIterator', () => {
     });
 
     describe('#bindTemplate', () => {
-      it('should bind an empty template without variables, blank nodes and bindings', () => {
-        return expect(iterator.bindTemplate(BF.bindings(), [], 0))
+      it('should bind an empty template without variables, blank nodes and bindings', async() => {
+        expect(iterator.bindTemplate(BF.bindings(), [], 0))
           .toEqual([]);
+
+        // Consume the iterator
+        expect(await iterator.toArray()).toHaveLength(10);
       });
 
-      it('should bind a template without variables, blank nodes and bindings', () => {
-        return expect(iterator.bindTemplate(BF.bindings(), [
+      it('should bind a template without variables, blank nodes and bindings', async() => {
+        expect(iterator.bindTemplate(BF.bindings(), [
           DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
           DF.quad(DF.namedNode('s2'), DF.namedNode('p2'), DF.namedNode('o2')),
           DF.quad(DF.namedNode('s3'), DF.namedNode('p3'), DF.namedNode('o3')),
@@ -501,10 +504,13 @@ describe('BindingsToQuadsIterator', () => {
             DF.quad(DF.namedNode('s2'), DF.namedNode('p2'), DF.namedNode('o2')),
             DF.quad(DF.namedNode('s3'), DF.namedNode('p3'), DF.namedNode('o3')),
           ]);
+
+        // Consume the iterator
+        expect(await iterator.toArray()).toHaveLength(10);
       });
 
-      it('should bind a template with variables and bindings and without blank nodes', () => {
-        return expect(iterator.bindTemplate(BF.bindings([
+      it('should bind a template with variables and bindings and without blank nodes', async() => {
+        expect(iterator.bindTemplate(BF.bindings([
           [ DF.variable('a'), DF.namedNode('a') ],
           [ DF.variable('b'), DF.namedNode('b') ],
         ]), [
@@ -517,10 +523,13 @@ describe('BindingsToQuadsIterator', () => {
             DF.quad(DF.namedNode('s2'), DF.namedNode('b'), DF.namedNode('o2')),
             DF.quad(DF.namedNode('s3'), DF.namedNode('a'), DF.namedNode('b')),
           ]);
+
+        // Consume the iterator
+        expect(await iterator.toArray()).toHaveLength(10);
       });
 
-      it('should bind a template with variables and incomplete bindings and without blank nodes', () => {
-        return expect(iterator.bindTemplate(BF.bindings([
+      it('should bind a template with variables and incomplete bindings and without blank nodes', async() => {
+        expect(iterator.bindTemplate(BF.bindings([
           [ DF.variable('a'), DF.namedNode('a') ],
         ]), [
           DF.quad(DF.variable('a'), DF.namedNode('p1'), DF.namedNode('o1')),
@@ -530,10 +539,13 @@ describe('BindingsToQuadsIterator', () => {
           .toEqual([
             DF.quad(DF.namedNode('a'), DF.namedNode('p1'), DF.namedNode('o1')),
           ]);
+
+        // Consume the iterator
+        expect(await iterator.toArray()).toHaveLength(10);
       });
 
-      it('should bind a template with variables, bindings and blank nodes', () => {
-        return expect(iterator.bindTemplate(BF.bindings([
+      it('should bind a template with variables, bindings and blank nodes', async() => {
+        expect(iterator.bindTemplate(BF.bindings([
           [ DF.variable('a'), DF.namedNode('a') ],
           [ DF.variable('b'), DF.namedNode('b') ],
         ]), [
@@ -546,6 +558,9 @@ describe('BindingsToQuadsIterator', () => {
             DF.quad(DF.blankNode('bnode0'), DF.namedNode('b'), DF.blankNode('bnode0')),
             DF.quad(DF.blankNode('bnode0'), DF.namedNode('a'), DF.namedNode('b')),
           ]);
+
+        // Consume the iterator
+        expect(await iterator.toArray()).toHaveLength(10);
       });
     });
   });

--- a/packages/actor-query-operation-leftjoin/test/ActorQueryOperationLeftJoin-test.ts
+++ b/packages/actor-query-operation-leftjoin/test/ActorQueryOperationLeftJoin-test.ts
@@ -248,7 +248,6 @@ describe('ActorQueryOperationLeftJoin', () => {
           // Do nothing
         });
       });
-      // TODO: See if this should be closed on the error event
       output.bindingsStream.destroy();
     });
   });

--- a/packages/actor-query-operation-leftjoin/test/ActorQueryOperationLeftJoin-test.ts
+++ b/packages/actor-query-operation-leftjoin/test/ActorQueryOperationLeftJoin-test.ts
@@ -248,6 +248,8 @@ describe('ActorQueryOperationLeftJoin', () => {
           // Do nothing
         });
       });
+      // TODO: See if this should be closed on the error event
+      output.bindingsStream.destroy();
     });
   });
 });

--- a/packages/actor-query-operation-quadpattern/test/ActorQueryOperationQuadpattern-test.ts
+++ b/packages/actor-query-operation-quadpattern/test/ActorQueryOperationQuadpattern-test.ts
@@ -487,7 +487,7 @@ describe('ActorQueryOperationQuadpattern', () => {
         type: 'pattern',
       };
 
-      await actor.run({ operation, context: new ActionContext({ a: 'a', b: 'b' }) });
+      const result = await actor.run({ operation, context: new ActionContext({ a: 'a', b: 'b' }) });
       expect(mediatorResolveQuadPattern.mediate)
         .toHaveBeenCalledWith({
           context: new ActionContext({
@@ -497,6 +497,11 @@ describe('ActorQueryOperationQuadpattern', () => {
           }),
           pattern: operation,
         });
+
+      expect(result.type).toEqual('bindings');
+      if (result.type === 'bindings') {
+        await expect(result.bindingsStream).toEqualBindingsStream([]);
+      }
     });
 
     it('should run s ?p o under default non-union default graph semantics', async() => {

--- a/packages/actor-query-operation-union/test/ActorQueryOperationUnion-test.ts
+++ b/packages/actor-query-operation-union/test/ActorQueryOperationUnion-test.ts
@@ -13,9 +13,9 @@ const BF = new BindingsFactory();
 describe('ActorQueryOperationUnion', () => {
   let bus: any;
   let mediatorQueryOperation: any;
-  let op3: any;
-  let op2: any;
-  let op2Undef: any;
+  let op3: () => any;
+  let op2: () => any;
+  let op2Undef: () => any;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
@@ -28,7 +28,7 @@ describe('ActorQueryOperationUnion', () => {
         canContainUndefs: arg.operation.canContainUndefs,
       }),
     };
-    op3 = {
+    op3 = () => ({
       metadata: () => Promise.resolve({
         cardinality: { type: 'estimate', value: 3 },
         canContainUndefs: false,
@@ -40,8 +40,8 @@ describe('ActorQueryOperationUnion', () => {
         BF.bindings([[ DF.variable('a'), DF.literal('3') ]]),
       ], { autoStart: false }),
       type: 'bindings',
-    };
-    op2 = {
+    });
+    op2 = () => ({
       metadata: () => Promise.resolve({
         cardinality: { type: 'estimate', value: 2 },
         canContainUndefs: false,
@@ -52,8 +52,8 @@ describe('ActorQueryOperationUnion', () => {
         BF.bindings([[ DF.variable('b'), DF.literal('2') ]]),
       ], { autoStart: false }),
       type: 'bindings',
-    };
-    op2Undef = {
+    });
+    op2Undef = () => ({
       metadata: () => Promise.resolve({
         cardinality: { type: 'estimate', value: 2 },
         canContainUndefs: true,
@@ -64,7 +64,7 @@ describe('ActorQueryOperationUnion', () => {
         BF.bindings([[ DF.variable('b'), DF.literal('2') ]]),
       ]),
       type: 'bindings',
-    };
+    });
   });
 
   describe('The ActorQueryOperationUnion module', () => {
@@ -239,18 +239,25 @@ describe('ActorQueryOperationUnion', () => {
       actor = new ActorQueryOperationUnion({ name: 'actor', bus, mediatorQueryOperation });
     });
 
-    it('should test on union', () => {
-      const op: any = { operation: { type: 'union', input: [ op3, op2 ]}};
-      return expect(actor.test(op)).resolves.toBeTruthy();
+    it('should test on union', async() => {
+      const input = [ op3(), op2() ];
+      await expect(actor.test(<any> {
+        operation: { type: 'union', input, context: new ActionContext() },
+      })).resolves.toBeTruthy();
+      input.forEach(op => op.stream.destroy());
     });
 
-    it('should not test on non-union', () => {
-      const op: any = { operation: { type: 'some-other-type', input: [ op3, op2 ]}, context: new ActionContext() };
-      return expect(actor.test(op)).rejects.toBeTruthy();
+    it('should not test on non-union', async() => {
+      const input = [ op3(), op2() ];
+      await expect(actor.test(<any> {
+        operation: { type: 'some-other-type', input },
+        context: new ActionContext(),
+      })).rejects.toBeTruthy();
+      input.forEach(op => op.stream.destroy());
     });
 
     it('should run on two streams', () => {
-      const op: any = { operation: { type: 'union', input: [ op3, op2 ]}, context: new ActionContext() };
+      const op: any = { operation: { type: 'union', input: [ op3(), op2() ]}, context: new ActionContext() };
       return actor.run(op).then(async(output: IQueryOperationResultBindings) => {
         expect(await output.metadata()).toEqual({
           cardinality: { type: 'estimate', value: 5 },
@@ -269,8 +276,10 @@ describe('ActorQueryOperationUnion', () => {
     });
 
     it('should run on three streams', () => {
-      const op: any = { operation: { type: 'union', input: [ op3, op2, op2Undef ]}, context: new ActionContext() };
-      return actor.run(op).then(async(output: IQueryOperationResultBindings) => {
+      return actor.run(<any> {
+        operation: { type: 'union', input: [ op3(), op2(), op2Undef() ]},
+        context: new ActionContext(),
+      }).then(async(output: IQueryOperationResultBindings) => {
         expect(await output.metadata()).toEqual({
           cardinality: { type: 'estimate', value: 7 },
           canContainUndefs: true,
@@ -290,7 +299,7 @@ describe('ActorQueryOperationUnion', () => {
     });
 
     it('should run with a right stream with undefs', () => {
-      const op: any = { operation: { type: 'union', input: [ op3, op2Undef ]}, context: new ActionContext() };
+      const op: any = { operation: { type: 'union', input: [ op3(), op2Undef() ]}, context: new ActionContext() };
       return actor.run(op).then(async(output: IQueryOperationResultBindings) => {
         expect(await output.metadata()).toEqual({
           cardinality: { type: 'estimate', value: 5 },

--- a/packages/actor-query-result-serialize-simple/test/ActorQueryResultSerializeSimple-test.ts
+++ b/packages/actor-query-result-serialize-simple/test/ActorQueryResultSerializeSimple-test.ts
@@ -1,8 +1,9 @@
 import { Readable } from 'stream';
 import { BindingsFactory } from '@comunica/bindings-factory';
 import { ActionContext, Bus } from '@comunica/core';
-import type { BindingsStream, IActionContext } from '@comunica/types';
+import type { Bindings, BindingsStream, IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
+import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorQueryResultSerializeSimple } from '../lib/ActorQueryResultSerializeSimple';
@@ -39,8 +40,8 @@ describe('ActorQueryResultSerializeSimple', () => {
 
   describe('An ActorQueryResultSerializeSimple instance', () => {
     let actor: ActorQueryResultSerializeSimple;
-    let bindingsStream: BindingsStream;
-    let quadStream: RDF.Stream;
+    let bindingsStream: () => BindingsStream;
+    let quadStream: () => RDF.Stream & AsyncIterator<Bindings>;
     let streamError: Readable;
 
     beforeEach(() => {
@@ -50,7 +51,7 @@ describe('ActorQueryResultSerializeSimple', () => {
         },
         mediaTypeFormats: {},
         name: 'actor' });
-      bindingsStream = new ArrayIterator([
+      bindingsStream = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -58,7 +59,7 @@ describe('ActorQueryResultSerializeSimple', () => {
           [ DF.variable('k2'), DF.namedNode('v2') ],
         ]),
       ]);
-      quadStream = new ArrayIterator([
+      quadStream = () => new ArrayIterator([
         quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
         quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
       ]);
@@ -79,22 +80,27 @@ describe('ActorQueryResultSerializeSimple', () => {
     });
 
     describe('for serializing', () => {
-      it('should test on simple quads', () => {
-        return expect(actor.test({
-          handle: <any> { type: 'quads', quadStream, context },
+      it('should test on simple quads', async() => {
+        const stream = quadStream();
+        await expect(actor.test({
+          handle: <any> { type: 'quads', quadStream: stream, context },
           handleMediaType: 'simple',
           context,
         }))
           .resolves.toBeTruthy();
+        stream.destroy();
       });
 
-      it('should test on simple bindings', () => {
-        return expect(actor.test({
-          handle: <any> { type: 'bindings', bindingsStream, context },
+      it('should test on simple bindings', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test({
+          handle: <any> { type: 'bindings', bindingsStream: stream, context },
           handleMediaType: 'simple',
           context,
         }))
           .resolves.toBeTruthy();
+
+        stream.destroy();
       });
 
       it('should test on simple booleans', () => {
@@ -111,13 +117,15 @@ describe('ActorQueryResultSerializeSimple', () => {
           .resolves.toBeTruthy();
       });
 
-      it('should not test on N-Triples', () => {
-        return expect(actor.test({
-          handle: <any> { type: 'quads', quadStream, context },
+      it('should not test on N-Triples', async() => {
+        const stream = quadStream();
+        await expect(actor.test({
+          handle: <any> { type: 'quads', quadStream: stream, context },
           handleMediaType: 'application/n-triples',
           context,
         }))
           .rejects.toBeTruthy();
+        stream.destroy();
       });
 
       it('should not test on unknown types', () => {
@@ -129,7 +137,11 @@ describe('ActorQueryResultSerializeSimple', () => {
 
       it('should run on a bindings stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'bindings', bindingsStream, context }, handleMediaType: 'simple', context },
+          {
+            handle: <any> { type: 'bindings', bindingsStream: bindingsStream(), context },
+            handleMediaType: 'simple',
+            context,
+          },
         ))).handle.data)).toEqual(
           `?k1: v1
 
@@ -141,7 +153,7 @@ describe('ActorQueryResultSerializeSimple', () => {
 
       it('should run on a quad stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'quads', quadStream, context }, handleMediaType: 'simple', context },
+          { handle: <any> { type: 'quads', quadStream: quadStream(), context }, handleMediaType: 'simple', context },
         ))).handle.data)).toEqual(
           `subject: http://example.org/a
 predicate: http://example.org/b

--- a/packages/actor-query-result-serialize-sparql-json/test/ActorQueryResultSerializeSparqlJson-test.ts
+++ b/packages/actor-query-result-serialize-sparql-json/test/ActorQueryResultSerializeSparqlJson-test.ts
@@ -4,6 +4,7 @@ import type { ActorHttpInvalidateListenable, IInvalidateListener } from '@comuni
 import { ActionContext, Bus } from '@comunica/core';
 import type { BindingsStream, IActionContext, MetadataBindings } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
+import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActionObserverHttp, ActorQueryResultSerializeSparqlJson } from '..';
@@ -73,11 +74,11 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
   describe('An ActorQueryResultSerializeSparqlJson instance', () => {
     let httpObserver: ActionObserverHttp;
     let actor: ActorQueryResultSerializeSparqlJson;
-    let bindingsStream: BindingsStream;
-    let bindingsStreamPartial: BindingsStream;
+    let bindingsStream: () => BindingsStream;
+    let bindingsStreamPartial: () => BindingsStream;
     let bindingsStreamEmpty: BindingsStream;
     let bindingsStreamError: BindingsStream;
-    let quadStream: RDF.Stream;
+    let quadStream: () => RDF.Stream & AsyncIterator<RDF.Quad>;
     let metadata: MetadataBindings;
     let httpInvalidator: ActorHttpInvalidateListenable;
     let lastListener: IInvalidateListener;
@@ -103,7 +104,7 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
         emitMetadata: true,
         httpObserver,
       });
-      bindingsStream = new ArrayIterator([
+      bindingsStream = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -111,7 +112,7 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
           [ DF.variable('k2'), DF.namedNode('v2') ],
         ]),
       ]);
-      bindingsStreamPartial = new ArrayIterator([
+      bindingsStreamPartial = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -124,7 +125,7 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
       (<any> bindingsStreamEmpty)._read = <any> (() => { bindingsStreamEmpty.emit('end'); });
       bindingsStreamError = <any> new PassThrough();
       (<any> bindingsStreamError)._read = <any> (() => { bindingsStreamError.emit('error', new Error('SpJson')); });
-      quadStream = new ArrayIterator([
+      quadStream = () => new ArrayIterator([
         quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
         quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
       ]);
@@ -165,17 +166,20 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
           .resolves.toBeTruthy();
       });
 
-      it('should not test on N-Triples', () => {
-        return expect(actor.test({ context,
-          handle: <any> { bindingsStream, type: 'bindings' },
+      it('should not test on N-Triples', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test({ context,
+          handle: <any> { bindingsStream: stream, type: 'bindings' },
           handleMediaType: 'application/n-triples' }))
           .rejects.toBeTruthy();
+
+        stream.destroy();
       });
 
       it('should run on a bindings stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
           { context,
-            handle: <any> { bindingsStream, type: 'bindings', metadata: async() => metadata },
+            handle: <any> { bindingsStream: bindingsStream(), type: 'bindings', metadata: async() => metadata },
             handleMediaType: 'json' },
         ))).handle.data)).toEqual(
           `{"head": {"vars":["k1","k2"]},
@@ -193,7 +197,7 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
         (<any> httpObserver).onRun(null, null, null);
         expect(await stringifyStream((<any> (await actor.run(
           { context,
-            handle: <any> { bindingsStream, type: 'bindings', metadata: async() => metadata },
+            handle: <any> { bindingsStream: bindingsStream(), type: 'bindings', metadata: async() => metadata },
             handleMediaType: 'json' },
         ))).handle.data)).toEqual(
           `{"head": {"vars":["k1","k2"]},
@@ -214,7 +218,7 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
         (<any> httpObserver).onRun(null, null, null);
         expect(await stringifyStream((<any> (await actor.run(
           { context,
-            handle: <any> { bindingsStream, type: 'bindings', metadata: async() => metadata },
+            handle: <any> { bindingsStream: bindingsStream(), type: 'bindings', metadata: async() => metadata },
             handleMediaType: 'json' },
         ))).handle.data)).toEqual(
           `{"head": {"vars":["k1","k2"]},
@@ -240,7 +244,7 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
         });
         expect(await stringifyStream((<any> (await actor.run(
           { context,
-            handle: <any> { bindingsStream, type: 'bindings', metadata: async() => metadata },
+            handle: <any> { bindingsStream: bindingsStream(), type: 'bindings', metadata: async() => metadata },
             handleMediaType: 'json' },
         ))).handle.data)).toEqual(
           `{"head": {"vars":["k1","k2"]},
@@ -255,7 +259,11 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
       it('should run on a bindings stream without variables', async() => {
         expect(await stringifyStream((<any> (await actor.run(
           { context,
-            handle: <any> { bindingsStream, type: 'bindings', metadata: async() => ({ variables: []}) },
+            handle: <any> {
+              bindingsStream: bindingsStream(),
+              type: 'bindings',
+              metadata: async() => ({ variables: []}),
+            },
             handleMediaType: 'json' },
         ))).handle.data)).toEqual(
           `{"head": {},
@@ -272,7 +280,7 @@ describe('ActorQueryResultSerializeSparqlJson', () => {
         expect(await stringifyStream((<any> (await actor.run(
           { context,
             handle: <any> {
-              bindingsStream: bindingsStreamPartial,
+              bindingsStream: bindingsStreamPartial(),
               type: 'bindings',
               metadata: async() => ({ variables: []}),
             },

--- a/packages/actor-query-result-serialize-sparql-tsv/test/ActorQueryResultSerializeSparqlTsv-test.ts
+++ b/packages/actor-query-result-serialize-sparql-tsv/test/ActorQueryResultSerializeSparqlTsv-test.ts
@@ -99,9 +99,9 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
 
   describe('An ActorQueryResultSerializeSparqlTsv instance', () => {
     let actor: ActorQueryResultSerializeSparqlTsv;
-    let bindingsStream: BindingsStream;
-    let bindingsStreamPartial: BindingsStream;
-    let bindingsStreamMixed: BindingsStream;
+    let bindingsStream: () => BindingsStream;
+    let bindingsStreamPartial: () => BindingsStream;
+    let bindingsStreamMixed: () => BindingsStream;
     let bindingsStreamEmpty: BindingsStream;
     let bindingsStreamError: BindingsStream;
     let metadata: MetadataBindings;
@@ -113,7 +113,7 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
         },
         mediaTypeFormats: {},
         name: 'actor' });
-      bindingsStream = new ArrayIterator([
+      bindingsStream = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -121,7 +121,7 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
           [ DF.variable('k2'), DF.namedNode('v2') ],
         ]),
       ]);
-      bindingsStreamPartial = new ArrayIterator([
+      bindingsStreamPartial = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -130,7 +130,7 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
         ]),
         BF.bindings(),
       ]);
-      bindingsStreamMixed = new ArrayIterator([
+      bindingsStreamMixed = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.literal('v"') ],
           [ DF.variable('k2'), DF.defaultGraph() ],
@@ -167,11 +167,14 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
           .rejects.toBeTruthy();
       });
 
-      it('should test on text/tab-separated-values bindings', () => {
-        return expect(actor.test({ handle: <any> { bindingsStream, type: 'bindings', context },
+      it('should test on text/tab-separated-values bindings', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test({ handle: <any> { bindingsStream: stream, type: 'bindings', context },
           handleMediaType: 'text/tab-separated-values',
           context }))
           .resolves.toBeTruthy();
+
+        stream.destroy();
       });
 
       it('should not test on sparql-results+tsv booleans', () => {
@@ -181,18 +184,26 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
           .rejects.toBeTruthy();
       });
 
-      it('should not test on N-Triples', () => {
-        return expect(actor.test({ handle: <any> { bindingsStream, type: 'bindings', context },
+      it('should not test on N-Triples', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test({ handle: <any> { bindingsStream: stream, type: 'bindings', context },
           handleMediaType: 'application/n-triples',
           context }))
           .rejects.toBeTruthy();
+
+        stream.destroy();
       });
 
       it('should run on a bindings stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { bindingsStream, type: 'bindings', metadata: async() => metadata, context },
-            handleMediaType: 'text/tab-separated-values',
-            context },
+          { handle: <any> {
+            bindingsStream: bindingsStream(),
+            type: 'bindings',
+            metadata: async() => metadata,
+            context,
+          },
+          handleMediaType: 'text/tab-separated-values',
+          context },
         ))).handle.data)).toEqual(
           `k1\tk2
 <v1>\t
@@ -203,9 +214,14 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
 
       it('should run on a bindings stream without variables', async() => {
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { bindingsStream, type: 'bindings', metadata: async() => ({ variables: []}), context },
-            handleMediaType: 'text/tab-separated-values',
-            context },
+          { handle: <any> {
+            bindingsStream: bindingsStream(),
+            type: 'bindings',
+            metadata: async() => ({ variables: []}),
+            context,
+          },
+          handleMediaType: 'text/tab-separated-values',
+          context },
         ))).handle.data)).toEqual(
           `
 
@@ -217,7 +233,7 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
       it('should run on a bindings stream with unbound variables', async() => {
         expect(await stringifyStream((<any> (await actor.run(
           { handle: <any> {
-            bindingsStream: bindingsStreamPartial,
+            bindingsStream: bindingsStreamPartial(),
             type: 'bindings',
             metadata: async() => ({ variables: [ DF.variable('k3') ]}),
             context,
@@ -236,7 +252,10 @@ describe('ActorQueryResultSerializeSparqlTsv', () => {
 
     it('should run on a bindings stream containing values with special characters', async() => {
       expect(await stringifyStream((<any> (await actor.run({
-        handle: <any> { bindingsStream: bindingsStreamMixed, type: 'bindings', metadata: async() => metadata, context },
+        handle: <any> { bindingsStream: bindingsStreamMixed(),
+          type: 'bindings',
+          metadata: async() => metadata,
+          context },
         handleMediaType: 'text/tab-separated-values',
         context,
       }))).handle.data)).toEqual(

--- a/packages/actor-query-result-serialize-sparql-xml/test/ActorQueryResultSerializeSparqlXml-test.ts
+++ b/packages/actor-query-result-serialize-sparql-xml/test/ActorQueryResultSerializeSparqlXml-test.ts
@@ -3,6 +3,7 @@ import { BindingsFactory } from '@comunica/bindings-factory';
 import { ActionContext, Bus } from '@comunica/core';
 import type { BindingsStream, IActionContext, MetadataBindings } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
+import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorQueryResultSerializeSparqlXml } from '../lib/ActorQueryResultSerializeSparqlXml';
@@ -98,10 +99,10 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
 
   describe('An ActorQueryResultSerializeSparqlXml instance', () => {
     let actor: ActorQueryResultSerializeSparqlXml;
-    let bindingsStream: BindingsStream;
-    let bindingsStreamPartial: BindingsStream;
+    let bindingsStream: () => BindingsStream;
+    let bindingsStreamPartial: () => BindingsStream;
     let bindingsStreamError: BindingsStream;
-    let quadStream: RDF.Stream;
+    let quadStream: () => RDF.Stream & AsyncIterator<RDF.Quad>;
     let metadata: MetadataBindings;
 
     beforeEach(() => {
@@ -111,7 +112,7 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
         },
         mediaTypeFormats: {},
         name: 'actor' });
-      bindingsStream = new ArrayIterator([
+      bindingsStream = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -119,7 +120,7 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
           [ DF.variable('k2'), DF.namedNode('v2') ],
         ]),
       ], { autoStart: false });
-      bindingsStreamPartial = new ArrayIterator([
+      bindingsStreamPartial = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -130,7 +131,7 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
       ], { autoStart: false });
       bindingsStreamError = <any> new PassThrough();
       (<any> bindingsStreamError)._read = <any> (() => { bindingsStreamError.emit('error', new Error('SpXml')); });
-      quadStream = new ArrayIterator([
+      quadStream = () => new ArrayIterator([
         quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
         quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
       ]);
@@ -150,18 +151,28 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
     });
 
     describe('for serializing', () => {
-      it('should not test on quad streams', () => {
-        return expect(actor.test(
-          { context, handle: <any> { type: 'quads', quadStream }, handleMediaType: 'sparql-results+xml' },
+      it('should not test on quad streams', async() => {
+        const stream = quadStream();
+        await expect(actor.test(
+          { context, handle: <any> { type: 'quads', quadStream: stream }, handleMediaType: 'sparql-results+xml' },
         ))
           .rejects.toBeTruthy();
+
+        stream.destroy();
       });
 
-      it('should test on sparql-results+xml bindings', () => {
-        return expect(actor.test(
-          { context, handle: <any> { type: 'bindings', bindingsStream }, handleMediaType: 'sparql-results+xml' },
+      it('should test on sparql-results+xml bindings', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test(
+          {
+            context,
+            handle: <any> { type: 'bindings', bindingsStream: stream },
+            handleMediaType: 'sparql-results+xml',
+          },
         ))
           .resolves.toBeTruthy();
+
+        stream.destroy();
       });
 
       it('should test on sparql-results+xml booleans', () => {
@@ -173,17 +184,24 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
           .resolves.toBeTruthy();
       });
 
-      it('should not test on N-Triples', () => {
-        return expect(actor.test(
-          { context, handle: <any> { type: 'bindings', bindingsStream }, handleMediaType: 'application/n-triples' },
+      it('should not test on N-Triples', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test(
+          {
+            context,
+            handle: <any> { type: 'bindings', bindingsStream: stream },
+            handleMediaType: 'application/n-triples',
+          },
         ))
           .rejects.toBeTruthy();
+
+        stream.destroy();
       });
 
       it('should run on a bindings stream', async() => {
         expect(await stringifyStream((<any> (await actor.run({
           context,
-          handle: <any> { type: 'bindings', bindingsStream, metadata: async() => metadata },
+          handle: <any> { type: 'bindings', bindingsStream: bindingsStream(), metadata: async() => metadata },
           handleMediaType: 'xml',
         })))
           .handle.data)).toEqual(
@@ -213,7 +231,7 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
       it('should run on a bindings stream without variables', async() => {
         expect(await stringifyStream((<any> (await actor.run({
           context,
-          handle: <any> { type: 'bindings', bindingsStream, metadata: async() => ({ variables: []}) },
+          handle: <any> { type: 'bindings', bindingsStream: bindingsStream(), metadata: async() => ({ variables: []}) },
           handleMediaType: 'xml',
         })))
           .handle.data)).toEqual(
@@ -243,7 +261,7 @@ describe('ActorQueryResultSerializeSparqlXml', () => {
           context,
           handle: <any> {
             type: 'bindings',
-            bindingsStream: bindingsStreamPartial,
+            bindingsStream: bindingsStreamPartial(),
             metadata: async() => ({ variables: []}),
           },
           handleMediaType: 'xml',

--- a/packages/actor-query-result-serialize-stats/test/ActorQueryResultSerializeStats-test.ts
+++ b/packages/actor-query-result-serialize-stats/test/ActorQueryResultSerializeStats-test.ts
@@ -4,6 +4,7 @@ import type { ActorHttpInvalidateListenable, IInvalidateListener } from '@comuni
 import { ActionContext, Bus } from '@comunica/core';
 import type { BindingsStream, IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
+import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActionObserverHttp, ActorQueryResultSerializeStats } from '..';
@@ -40,8 +41,8 @@ describe('ActorQueryResultSerializeStats', () => {
   describe('An ActorQueryResultSerializeStats instance', () => {
     let httpObserver: ActionObserverHttp;
     let actor: ActorQueryResultSerializeStats;
-    let bindingsStream: BindingsStream;
-    let quadStream: RDF.Stream;
+    let bindingsStream: () => BindingsStream;
+    let quadStream: () => RDF.Stream & AsyncIterator<RDF.Quad>;
     let streamError: Readable;
     let httpInvalidator: ActorHttpInvalidateListenable;
     let lastListener: IInvalidateListener;
@@ -67,7 +68,7 @@ describe('ActorQueryResultSerializeStats', () => {
         httpObserver,
       });
 
-      bindingsStream = new ArrayIterator([
+      bindingsStream = () => new ArrayIterator([
         BF.bindings([
           [ DF.variable('k1'), DF.namedNode('v1') ],
         ]),
@@ -75,7 +76,7 @@ describe('ActorQueryResultSerializeStats', () => {
           [ DF.variable('k2'), DF.namedNode('v2') ],
         ]),
       ]);
-      quadStream = new ArrayIterator([
+      quadStream = () => new ArrayIterator([
         quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
         quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
       ]);
@@ -105,17 +106,21 @@ describe('ActorQueryResultSerializeStats', () => {
         actor.delay = () => 3.14;
       });
 
-      it('should test on table', () => {
-        return expect(actor.test({ handle: <any> { type: 'quads', quadStream },
+      it('should test on table', async() => {
+        const stream = quadStream();
+        await expect(actor.test({ handle: <any> { type: 'quads', quadStream: stream },
           handleMediaType: 'debug',
           context })).resolves.toBeTruthy();
+        stream.destroy();
       });
 
-      it('should not test on N-Triples', () => {
-        return expect(actor.test({ handle: <any> { type: 'quads', quadStream },
+      it('should not test on N-Triples', async() => {
+        const stream = quadStream();
+        await expect(actor.test({ handle: <any> { type: 'quads', quadStream: stream },
           handleMediaType: 'application/n-triples',
           context }))
           .rejects.toBeTruthy();
+        stream.destroy();
       });
 
       it('should not test on unknown types', () => {
@@ -127,7 +132,7 @@ describe('ActorQueryResultSerializeStats', () => {
 
       it('should run on a bindings stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'bindings', bindingsStream }, handleMediaType: 'debug', context },
+          { handle: <any> { type: 'bindings', bindingsStream: bindingsStream() }, handleMediaType: 'debug', context },
         )
         )).handle.data)).toEqual(
           `Result,Delay (ms),HTTP requests
@@ -142,7 +147,7 @@ TOTAL,3.14,0
         (<any> httpObserver).onRun(null, null, null);
         (<any> httpObserver).onRun(null, null, null);
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'bindings', bindingsStream }, handleMediaType: 'debug', context },
+          { handle: <any> { type: 'bindings', bindingsStream: bindingsStream() }, handleMediaType: 'debug', context },
         )
         )).handle.data)).toEqual(
           `Result,Delay (ms),HTTP requests
@@ -160,7 +165,7 @@ TOTAL,3.14,2
         (<any> httpObserver).onRun(null, null, null);
         (<any> httpObserver).onRun(null, null, null);
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'bindings', bindingsStream }, handleMediaType: 'debug', context },
+          { handle: <any> { type: 'bindings', bindingsStream: bindingsStream() }, handleMediaType: 'debug', context },
         )
         )).handle.data)).toEqual(
           `Result,Delay (ms),HTTP requests
@@ -173,7 +178,7 @@ TOTAL,3.14,2
 
       it('should run on a quad stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'quads', quadStream },
+          { handle: <any> { type: 'quads', quadStream: quadStream() },
             handleMediaType: 'debug',
             context },
         ))).handle.data)).toEqual(

--- a/packages/actor-query-result-serialize-tree/test/ActorQueryResultSerializeTree-test.ts
+++ b/packages/actor-query-result-serialize-tree/test/ActorQueryResultSerializeTree-test.ts
@@ -4,6 +4,7 @@ import { KeysInitQuery } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import type { BindingsStream, IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
+import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorQueryResultSerializeTree, bindingsStreamToGraphQl } from '..';
@@ -16,7 +17,6 @@ const stringifyStream = require('stream-to-string');
 describe('ActorQueryResultSerializeTree', () => {
   let bus: any;
   let context: IActionContext;
-
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     context = new ActionContext();
@@ -45,8 +45,8 @@ describe('ActorQueryResultSerializeTree', () => {
 
   describe('An ActorQueryResultSerializeTree instance', () => {
     let actor: ActorQueryResultSerializeTree;
-    let bindingsStream: BindingsStream;
-    let quadStream: RDF.Stream;
+    let bindingsStream: () => BindingsStream;
+    let quadStream: () => RDF.Stream & AsyncIterator<RDF.Quad>;
     let streamError: Readable;
     let variables: RDF.Variable[];
 
@@ -54,11 +54,11 @@ describe('ActorQueryResultSerializeTree', () => {
       actor = new ActorQueryResultSerializeTree(
         { bus, name: 'actor', mediaTypePriorities: { tree: 1 }, mediaTypeFormats: {}},
       );
-      bindingsStream = new ArrayIterator([
+      bindingsStream = () => new ArrayIterator([
         BF.bindings([[ DF.variable('k1'), DF.literal('v1') ]]),
         BF.bindings([[ DF.variable('k2'), DF.literal('v2') ]]),
       ]);
-      quadStream = new ArrayIterator([
+      quadStream = () => new ArrayIterator([
         quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
         quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
       ]);
@@ -78,24 +78,33 @@ describe('ActorQueryResultSerializeTree', () => {
     });
 
     describe('for serializing', () => {
-      it('should test on tree', () => {
-        return expect(actor.test({ handle: <any> { type: 'bindings', bindingsStream, context },
+      it('should test on tree', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test({ handle: <any> { type: 'bindings', bindingsStream: stream, context },
           handleMediaType: 'tree',
           context })).resolves.toBeTruthy();
+
+        stream.destroy();
       });
 
-      it('should not test on tree with a quad stream', () => {
-        return expect(actor.test({ handle: <any> { type: 'quads', quadStream, context },
+      it('should not test on tree with a quad stream', async() => {
+        const stream = quadStream();
+        await expect(actor.test({ handle: <any> { type: 'quads', quadStream: stream, context },
           handleMediaType: 'tree',
           context }))
           .rejects.toBeTruthy();
+
+        stream.destroy();
       });
 
-      it('should not test on N-Triples', () => {
-        return expect(actor.test({ handle: <any> { type: 'bindings', bindingsStream, context },
+      it('should not test on N-Triples', async() => {
+        const stream = bindingsStream();
+        await expect(actor.test({ handle: <any> { type: 'bindings', bindingsStream: stream, context },
           handleMediaType: 'application/n-triples',
           context }))
           .rejects.toBeTruthy();
+
+        stream.destroy();
       });
 
       it('should not test on unknown types', () => {
@@ -107,7 +116,7 @@ describe('ActorQueryResultSerializeTree', () => {
 
       it('should run on a bindings stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'bindings', bindingsStream, variables, context },
+          { handle: <any> { type: 'bindings', bindingsStream: bindingsStream(), variables, context },
             handleMediaType: 'tree',
             context },
         ))).handle.data)).toEqual(
@@ -129,7 +138,7 @@ describe('ActorQueryResultSerializeTree', () => {
           [KeysInitQuery.graphqlSingularizeVariables.name]: { k1: true, k2: false },
         });
         expect(await stringifyStream((<any> (await actor.run(
-          { handle: <any> { type: 'bindings', bindingsStream, variables, context },
+          { handle: <any> { type: 'bindings', bindingsStream: bindingsStream(), variables, context },
             handleMediaType: 'tree',
             context },
         ))).handle.data)).toEqual(

--- a/packages/actor-rdf-join-inner-hash/test/ActorRdfJoinHash-test.ts
+++ b/packages/actor-rdf-join-inner-hash/test/ActorRdfJoinHash-test.ts
@@ -53,6 +53,7 @@ describe('ActorRdfJoinHash', () => {
     let action: IActionRdfJoin;
     let variables0: RDF.Variable[];
     let variables1: RDF.Variable[];
+    let iterators: ArrayIterator<Bindings>[];
 
     beforeEach(() => {
       mediatorJoinSelectivity = <any> {
@@ -61,12 +62,16 @@ describe('ActorRdfJoinHash', () => {
       actor = new ActorRdfJoinHash({ name: 'actor', bus, mediatorJoinSelectivity });
       variables0 = [];
       variables1 = [];
+      iterators = [
+        new ArrayIterator<Bindings>([], { autoStart: false }),
+        new ArrayIterator<Bindings>([], { autoStart: false }),
+      ];
       action = {
         type: 'inner',
         entries: [
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[0],
               metadata: () => Promise.resolve(
                 {
                   cardinality: { type: 'estimate', value: 4 },
@@ -82,7 +87,7 @@ describe('ActorRdfJoinHash', () => {
           },
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[1],
               metadata: () => Promise.resolve(
                 {
                   cardinality: { type: 'estimate', value: 5 },
@@ -101,18 +106,19 @@ describe('ActorRdfJoinHash', () => {
       };
     });
 
-    it('should only handle 2 streams', () => {
+    it('should only handle 2 streams', async() => {
       action.entries.push(<any> {});
-      return expect(actor.test(action)).rejects.toBeTruthy();
+      await expect(actor.test(action)).rejects.toBeTruthy();
+      iterators.forEach(iter => iter.destroy());
     });
 
-    it('should fail on undefs in left stream', () => {
+    it('should fail on undefs in left stream', async() => {
       action = {
         type: 'inner',
         entries: [
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[0],
               metadata: () => Promise.resolve(
                 {
                   cardinality: { type: 'estimate', value: 4 },
@@ -128,7 +134,7 @@ describe('ActorRdfJoinHash', () => {
           },
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[1],
               metadata: () => Promise.resolve(
                 {
                   cardinality: { type: 'estimate', value: 5 },
@@ -145,17 +151,19 @@ describe('ActorRdfJoinHash', () => {
         ],
         context,
       };
-      return expect(actor.test(action)).rejects
+      await expect(actor.test(action)).rejects
         .toThrow(new Error('Actor actor can not join streams containing undefs'));
+
+      iterators.forEach(iter => iter.destroy());
     });
 
-    it('should fail on undefs in right stream', () => {
+    it('should fail on undefs in right stream', async() => {
       action = {
         type: 'inner',
         entries: [
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[0],
               metadata: () => Promise.resolve(
                 {
                   cardinality: { type: 'estimate', value: 4 },
@@ -171,7 +179,7 @@ describe('ActorRdfJoinHash', () => {
           },
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[1],
               metadata: () => Promise.resolve({
                 cardinality: { type: 'estimate', value: 5 },
                 pageSize: 100,
@@ -186,17 +194,19 @@ describe('ActorRdfJoinHash', () => {
         ],
         context,
       };
-      return expect(actor.test(action)).rejects
+      await expect(actor.test(action)).rejects
         .toThrow(new Error('Actor actor can not join streams containing undefs'));
+
+      iterators.forEach(iter => iter.destroy());
     });
 
-    it('should fail on undefs in left and right stream', () => {
+    it('should fail on undefs in left and right stream', async() => {
       action = {
         type: 'inner',
         entries: [
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[0],
               metadata: () => Promise.resolve({
                 cardinality: { type: 'estimate', value: 4 },
                 pageSize: 100,
@@ -210,7 +220,7 @@ describe('ActorRdfJoinHash', () => {
           },
           {
             output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
+              bindingsStream: iterators[1],
               metadata: () => Promise.resolve({
                 cardinality: { type: 'estimate', value: 5 },
                 pageSize: 100,
@@ -225,8 +235,10 @@ describe('ActorRdfJoinHash', () => {
         ],
         context,
       };
-      return expect(actor.test(action)).rejects
+      await expect(actor.test(action)).rejects
         .toThrow(new Error('Actor actor can not join streams containing undefs'));
+
+      iterators.forEach(iter => iter.destroy());
     });
 
     it('should generate correct test metadata', async() => {
@@ -237,16 +249,20 @@ describe('ActorRdfJoinHash', () => {
           blockingItems: 4,
           requestTime: 1.4,
         });
+
+      iterators.forEach(iter => iter.destroy());
     });
 
     it('should generate correct metadata', async() => {
       await actor.run(action).then(async(result: IQueryOperationResultBindings) => {
-        return expect((<any> result).metadata()).resolves.toHaveProperty('cardinality',
+        await expect((<any> result).metadata()).resolves.toHaveProperty('cardinality',
           {
             type: 'estimate',
             value: (await (<any> action.entries[0].output).metadata()).cardinality.value *
           (await (<any> action.entries[1].output).metadata()).cardinality.value,
           });
+
+        await expect(result.bindingsStream.toArray()).resolves.toEqual([]);
       });
     });
 
@@ -259,6 +275,9 @@ describe('ActorRdfJoinHash', () => {
     });
 
     it('should join bindings with matching values', () => {
+      // Close the iterators already declared since we will not be using them
+      iterators.forEach(iter => iter.destroy());
+
       action.entries[0].output.bindingsStream = new ArrayIterator([
         BF.bindings([
           [ DF.variable('a'), DF.literal('a') ],
@@ -291,6 +310,9 @@ describe('ActorRdfJoinHash', () => {
     });
 
     it('should not join bindings with incompatible values', () => {
+      // Close the iterators already declared since we will not be using them
+      iterators.forEach(iter => iter.destroy());
+
       action.entries[0].output.bindingsStream = new ArrayIterator([
         BF.bindings([
           [ DF.variable('a'), DF.literal('a') ],
@@ -316,6 +338,9 @@ describe('ActorRdfJoinHash', () => {
     });
 
     it('should join multiple bindings', () => {
+      // Close the iterators already declared since we will not be using them
+      iterators.forEach(iter => iter.destroy());
+
       action.entries[0].output.bindingsStream = new ArrayIterator([
         BF.bindings([
           [ DF.variable('a'), DF.literal('1') ],

--- a/packages/actor-rdf-join-inner-symmetrichash/test/ActorRdfJoinSymmetricHash-test.ts
+++ b/packages/actor-rdf-join-inner-symmetrichash/test/ActorRdfJoinSymmetricHash-test.ts
@@ -93,130 +93,68 @@ describe('ActorRdfJoinSymmetricHash', () => {
       };
     });
 
-    it('should only handle 2 streams', () => {
-      action.entries.push(<any> {});
-      return expect(actor.test(action)).rejects.toBeTruthy();
-    });
+    describe('should test', () => {
+      afterEach(() => {
+        action.entries.forEach(({ output }) => output?.bindingsStream.destroy());
+      });
 
-    it('should fail on undefs in left stream', () => {
-      action = {
-        type: 'inner',
-        entries: [
-          {
-            output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
-              metadata: () => Promise.resolve({
-                cardinality: { type: 'estimate', value: 4 },
-                canContainUndefs: true,
-                variables: [],
-              }),
-              type: 'bindings',
-            },
-            operation: <any> {},
-          },
-          {
-            output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
-              metadata: () => Promise.resolve({
-                cardinality: { type: 'estimate', value: 5 },
-                canContainUndefs: false,
-                variables: [],
-              }),
-              type: 'bindings',
-            },
-            operation: <any> {},
-          },
-        ],
-        context,
-      };
-      return expect(actor.test(action)).rejects
-        .toThrow(new Error('Actor actor can not join streams containing undefs'));
-    });
+      it('should only handle 2 streams', () => {
+        action.entries.push(<any> {});
+        return expect(actor.test(action)).rejects.toBeTruthy();
+      });
 
-    it('should fail on undefs in right stream', () => {
-      action = {
-        type: 'inner',
-        entries: [
-          {
-            output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
-              metadata: () => Promise.resolve({
-                cardinality: { type: 'estimate', value: 4 },
-                canContainUndefs: false,
-                variables: [],
-              }),
-              type: 'bindings',
-            },
-            operation: <any> {},
-          },
-          {
-            output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
-              metadata: () => Promise.resolve({
-                cardinality: { type: 'estimate', value: 5 },
-                canContainUndefs: true,
-                variables: [],
-              }),
-              type: 'bindings',
-            },
-            operation: <any> {},
-          },
-        ],
-        context,
-      };
-      return expect(actor.test(action)).rejects
-        .toThrow(new Error('Actor actor can not join streams containing undefs'));
-    });
+      it('should fail on undefs in left stream', () => {
+        action.entries[0].output.metadata = () => Promise.resolve({
+          cardinality: { type: 'estimate', value: 4 },
+          canContainUndefs: true,
+          variables: [],
+        });
+        return expect(actor.test(action)).rejects
+          .toThrow(new Error('Actor actor can not join streams containing undefs'));
+      });
 
-    it('should fail on undefs in left and right stream', () => {
-      action = {
-        type: 'inner',
-        entries: [
-          {
-            output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
-              metadata: () => Promise.resolve({
-                cardinality: { type: 'estimate', value: 4 },
-                canContainUndefs: true,
-                variables: [],
-              }),
-              type: 'bindings',
-            },
-            operation: <any> {},
-          },
-          {
-            output: {
-              bindingsStream: new ArrayIterator([], { autoStart: false }),
-              metadata: () => Promise.resolve({
-                cardinality: { type: 'estimate', value: 5 },
-                canContainUndefs: true,
-                variables: [],
-              }),
-              type: 'bindings',
-            },
-            operation: <any> {},
-          },
-        ],
-        context,
-      };
-      return expect(actor.test(action)).rejects
-        .toThrow(new Error('Actor actor can not join streams containing undefs'));
-    });
+      it('should fail on undefs in right stream', () => {
+        action.entries[1].output.metadata = () => Promise.resolve({
+          cardinality: { type: 'estimate', value: 4 },
+          canContainUndefs: true,
+          variables: [],
+        });
+        return expect(actor.test(action)).rejects
+          .toThrow(new Error('Actor actor can not join streams containing undefs'));
+      });
 
-    it('should generate correct test metadata', async() => {
-      await expect(actor.test(action)).resolves.toHaveProperty('iterations',
-        (await (<any> action.entries[0].output).metadata()).cardinality.value +
-        (await (<any> action.entries[1].output).metadata()).cardinality.value);
+      it('should fail on undefs in left and right stream', () => {
+        action.entries[0].output.metadata = () => Promise.resolve({
+          cardinality: { type: 'estimate', value: 4 },
+          canContainUndefs: true,
+          variables: [],
+        });
+        action.entries[1].output.metadata = () => Promise.resolve({
+          cardinality: { type: 'estimate', value: 4 },
+          canContainUndefs: true,
+          variables: [],
+        });
+        return expect(actor.test(action)).rejects
+          .toThrow(new Error('Actor actor can not join streams containing undefs'));
+      });
+
+      it('should generate correct test metadata', async() => {
+        await expect(actor.test(action)).resolves.toHaveProperty('iterations',
+          (await (<any> action.entries[0].output).metadata()).cardinality.value +
+          (await (<any> action.entries[1].output).metadata()).cardinality.value);
+      });
     });
 
     it('should generate correct metadata', async() => {
       await actor.run(action).then(async(result: IQueryOperationResultBindings) => {
-        return expect((<any> result).metadata()).resolves.toHaveProperty('cardinality',
+        await expect((<any> result).metadata()).resolves.toHaveProperty('cardinality',
           {
             type: 'estimate',
             value: (await (<any> action.entries[0].output).metadata()).cardinality.value *
           (await (<any> action.entries[1].output).metadata()).cardinality.value,
           });
+
+        await expect(result.bindingsStream.toArray()).resolves.toEqual([]);
       });
     });
 
@@ -232,6 +170,9 @@ describe('ActorRdfJoinSymmetricHash', () => {
     });
 
     it('should join bindings with matching values', () => {
+      // Close of the bindings streams that we are not going to use
+      action.entries.forEach(({ output }) => output?.bindingsStream.destroy());
+
       action.entries[0].output.bindingsStream = new ArrayIterator([
         BF.bindings([
           [ DF.variable('a'), DF.literal('a') ],
@@ -263,6 +204,9 @@ describe('ActorRdfJoinSymmetricHash', () => {
     });
 
     it('should not join bindings with incompatible values', () => {
+      // Close of the bindings streams that we are not going to use
+      action.entries.forEach(({ output }) => output?.bindingsStream.destroy());
+
       action.entries[0].output.bindingsStream = new ArrayIterator([
         BF.bindings([
           [ DF.variable('a'), DF.literal('a') ],
@@ -288,6 +232,9 @@ describe('ActorRdfJoinSymmetricHash', () => {
     });
 
     it('should join multiple bindings', () => {
+      // Close of the bindings streams that we are not going to use
+      action.entries.forEach(({ output }) => output?.bindingsStream.destroy());
+
       action.entries[0].output.bindingsStream = new ArrayIterator([
         BF.bindings([
           [ DF.variable('a'), DF.literal('1') ],

--- a/packages/actor-rdf-join-minus-hash-undef/lib/ActorRdfJoinMinusHashUndef.ts
+++ b/packages/actor-rdf-join-minus-hash-undef/lib/ActorRdfJoinMinusHashUndef.ts
@@ -63,6 +63,9 @@ export class ActorRdfJoinMinusHashUndef extends ActorRdfJoin {
         },
       };
     }
+    // Destroy the buffer stream since it is not needed when
+    // there are no common variables.
+    buffer.bindingsStream.destroy();
     return {
       result: output,
     };

--- a/packages/actor-rdf-join-minus-hash-undef/test/ActorRdfJoinMinusHashUndef-test.ts
+++ b/packages/actor-rdf-join-minus-hash-undef/test/ActorRdfJoinMinusHashUndef-test.ts
@@ -14,51 +14,11 @@ const BF = new BindingsFactory();
 
 describe('ActorRdfJoinMinusHashUndef', () => {
   let bus: any;
-  let left: any;
-  let right: any;
-  let rightNoCommons: any;
   let context: IActionContext;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     context = new ActionContext();
-    left = {
-      metadata: () => Promise.resolve({
-        cardinality: { type: 'estimate', value: 3 },
-        canContainUndefs: false,
-        variables: [ DF.variable('a') ],
-      }),
-      stream: new ArrayIterator([
-        BF.bindings([[ DF.variable('a'), DF.literal('1') ]]),
-        BF.bindings([[ DF.variable('a'), DF.literal('2') ]]),
-        BF.bindings([[ DF.variable('a'), DF.literal('3') ]]),
-      ]),
-      type: 'bindings',
-    };
-    rightNoCommons = {
-      metadata: () => Promise.resolve({
-        cardinality: { type: 'estimate', value: 2 },
-        canContainUndefs: false,
-        variables: [ DF.variable('b') ],
-      }),
-      stream: new ArrayIterator([
-        BF.bindings([[ DF.variable('b'), DF.literal('1') ]]),
-        BF.bindings([[ DF.variable('b'), DF.literal('2') ]]),
-      ]),
-      type: 'bindings',
-    };
-    right = {
-      metadata: () => Promise.resolve({
-        cardinality: { type: 'estimate', value: 2 },
-        canContainUndefs: false,
-        variables: [ DF.variable('a') ],
-      }),
-      stream: new ArrayIterator([
-        BF.bindings([[ DF.variable('a'), DF.literal('1') ]]),
-        BF.bindings([[ DF.variable('a'), DF.literal('2') ]]),
-      ]),
-      type: 'bindings',
-    };
   });
 
   describe('An ActorRdfJoinMinusHashUndef instance', () => {

--- a/packages/actor-rdf-join-minus-hash/lib/ActorRdfJoinMinusHash.ts
+++ b/packages/actor-rdf-join-minus-hash/lib/ActorRdfJoinMinusHash.ts
@@ -56,6 +56,9 @@ export class ActorRdfJoinMinusHash extends ActorRdfJoin {
         },
       };
     }
+    // Destroy the buffer stream since it is not needed when
+    // there are no common variables.
+    buffer.bindingsStream.destroy();
     return {
       result: output,
     };

--- a/packages/actor-rdf-resolve-hypermedia-none/test/ActorRdfResolveHypermediaNone-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-none/test/ActorRdfResolveHypermediaNone-test.ts
@@ -3,7 +3,9 @@ import { ActorRdfResolveHypermedia } from '@comunica/bus-rdf-resolve-hypermedia'
 import { ActionContext, Bus } from '@comunica/core';
 import 'jest-rdf';
 import type { IActionContext } from '@comunica/types';
+import type * as RDF from '@rdfjs/types';
 import arrayifyStream from 'arrayify-stream';
+import type { AsyncIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorRdfResolveHypermediaNone } from '../lib/ActorRdfResolveHypermediaNone';
 
@@ -58,11 +60,12 @@ describe('ActorRdfResolveHypermediaNone', () => {
       ]);
       const { source } = await actor.run({ metadata: <any> null, quads, url: '', context });
       expect(source.match).toBeTruthy();
+      let stream: AsyncIterator<RDF.Quad>;
       await expect(new Promise((resolve, reject) => {
-        const stream = source.match(v, v, v, v);
+        stream = source.match(v, v, v, v);
         stream.getProperty('metadata', resolve);
       })).resolves.toEqual({ cardinality: { type: 'exact', value: 2 }, canContainUndefs: false });
-      expect(await arrayifyStream(source.match(v, v, v, v))).toEqualRdfQuadArray([
+      expect(await arrayifyStream(stream!)).toEqualRdfQuadArray([
         quad('s1', 'p1', 'o1'),
         quad('s2', 'p2', 'o2'),
       ]);

--- a/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
@@ -69,22 +69,6 @@ describe('RdfSourceQpf', () => {
       },
     };
 
-    source = new RdfSourceQpf(
-      mediatorMetadata,
-      mediatorMetadataExtract,
-      mediatorDereferenceRdf,
-      's',
-      'p',
-      'o',
-      'g',
-      metadata,
-      new ActionContext(),
-      streamifyArray([
-        quad('s1', 'p1', 'o1'),
-        quad('s2', 'p2', 'o2'),
-      ]),
-    );
-
     S = DF.namedNode('S');
     P = DF.namedNode('P');
     O = DF.namedNode('O');
@@ -138,6 +122,24 @@ describe('RdfSourceQpf', () => {
   });
 
   describe('getSearchForm', () => {
+    beforeEach(() => {
+      source = new RdfSourceQpf(
+        mediatorMetadata,
+        mediatorMetadataExtract,
+        mediatorDereferenceRdf,
+        's',
+        'p',
+        'o',
+        'g',
+        metadata,
+        new ActionContext(),
+        streamifyArray([
+          quad('s1', 'p1', 'o1'),
+          quad('s2', 'p2', 'o2'),
+        ]),
+      );
+    });
+
     it('should return a searchForm', () => {
       return expect(source.getSearchForm(metadata)).toEqual(metadata.searchForms.values[0]);
     });
@@ -189,6 +191,24 @@ describe('RdfSourceQpf', () => {
   });
 
   describe('createFragmentUri', () => {
+    beforeEach(() => {
+      source = new RdfSourceQpf(
+        mediatorMetadata,
+        mediatorMetadataExtract,
+        mediatorDereferenceRdf,
+        's',
+        'p',
+        'o',
+        'g',
+        metadata,
+        new ActionContext(),
+        streamifyArray([
+          quad('s1', 'p1', 'o1'),
+          quad('s2', 'p2', 'o2'),
+        ]),
+      );
+    });
+
     it('should create a valid fragment URI with materialized terms', () => {
       return expect(source.createFragmentUri(metadata.searchForms.values[0],
         DF.namedNode('S'),
@@ -209,6 +229,24 @@ describe('RdfSourceQpf', () => {
   });
 
   describe('match', () => {
+    beforeEach(() => {
+      source = new RdfSourceQpf(
+        mediatorMetadata,
+        mediatorMetadataExtract,
+        mediatorDereferenceRdf,
+        's',
+        'p',
+        'o',
+        'g',
+        metadata,
+        new ActionContext(),
+        streamifyArray([
+          quad('s1', 'p1', 'o1'),
+          quad('s2', 'p2', 'o2'),
+        ]),
+      );
+    });
+
     it('should return a copy of the initial quads for the empty pattern', async() => {
       expect(await arrayifyStream(source.match(v, v, v, v))).toBeRdfIsomorphic([
         quad('s1', 'p1', 'o1'),

--- a/packages/actor-rdf-resolve-hypermedia-sparql/test/RdfSourceSparql-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/test/RdfSourceSparql-test.ts
@@ -191,6 +191,11 @@ describe('RdfSourceSparql', () => {
       );
       expect(await new Promise(resolve => stream.getProperty('metadata', resolve)))
         .toEqual({ cardinality: 3, canContainUndefs: true });
+      await expect(stream.toArray()).resolves.toEqual([
+        quad('s', 'p1', 'o'),
+        quad('s', 'p2', 'o'),
+        quad('s', 'p3', 'o'),
+      ]);
     });
 
     it('should emit an error on server errors', async() => {

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -276,7 +276,6 @@ export class FederatedQuadSource implements IQuadSource {
       return data;
     }));
 
-    // TODO: Work out why things don't get properly closed with it = new UnionIterator(proxyIt);
     // Take the union of all source streams
     const it = new ClosableTransformIterator(async() => new UnionIterator(await proxyIt), {
       autoStart: false,

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -276,6 +276,7 @@ export class FederatedQuadSource implements IQuadSource {
       return data;
     }));
 
+    // TODO: Work out why things don't get properly closed with it = new UnionIterator(proxyIt);
     // Take the union of all source streams
     const it = new ClosableTransformIterator(async() => new UnionIterator(await proxyIt), {
       autoStart: false,

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/ActorRdfResolveQuadPatternFederated-test.ts
@@ -128,7 +128,7 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
         });
     });
 
-    it('should run when only metadata is called', () => {
+    it('should run when only metadata is called', async() => {
       const pattern = squad('?s', 'p', 'o', '?g');
       context = new ActionContext({
         '@comunica/bus-rdf-resolve-quad-pattern:sources':
@@ -137,8 +137,15 @@ describe('ActorRdfResolveQuadPatternFederated', () => {
             { type: 'nonEmptySource', value: 'I will not be empty' },
           ],
       });
-      return expect(actor.run({ pattern, context })
-        .then(output => new Promise(resolve => output.data.getProperty('metadata', resolve))))
+      const { data } = await actor.run({ pattern, context });
+      expect(await arrayifyStream(data)).toBeRdfIsomorphic([
+        squad('s1', 'p1', 'o1'),
+        squad('s1', 'p1', 'o1'),
+        squad('s1', 'p1', 'o2'),
+        squad('s1', 'p1', 'o2'),
+      ]);
+
+      await expect(new Promise(resolve => data.getProperty('metadata', resolve)))
         .resolves.toEqual({ cardinality: { type: 'estimate', value: 4 }, canContainUndefs: false });
     });
 

--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/test/MediatedLinkedRdfSourcesAsyncRdfIterator-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/test/MediatedLinkedRdfSourcesAsyncRdfIterator-test.ts
@@ -103,7 +103,7 @@ describe('MediatedLinkedRdfSourcesAsyncRdfIterator', () => {
 
     afterEach(() => {
       // This is here since the MediatedLinkedRdfSourcesAsyncRdfIterator is never fully consumed
-      // **THIS IS AN ALARM BELL** do not merge without checking this
+      // This should not be needed, see https://github.com/comunica/comunica/issues/1197
       source.destroy();
     });
 

--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/test/MediatedLinkedRdfSourcesAsyncRdfIterator-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/test/MediatedLinkedRdfSourcesAsyncRdfIterator-test.ts
@@ -101,6 +101,12 @@ describe('MediatedLinkedRdfSourcesAsyncRdfIterator', () => {
       );
     });
 
+    afterEach(() => {
+      // This is here since the MediatedLinkedRdfSourcesAsyncRdfIterator is never fully consumed
+      // **THIS IS AN ALARM BELL** do not merge without checking this
+      source.destroy();
+    });
+
     describe('close', () => {
       it('should not end an undefined aggregated store', async() => {
         source.close();
@@ -167,6 +173,7 @@ describe('MediatedLinkedRdfSourcesAsyncRdfIterator', () => {
         expect(await source.getLinkQueue()).toBe(queue);
         expect(await source.getLinkQueue()).toBe(queue);
         expect(await source.getLinkQueue()).toBe(queue);
+        source.destroy();
       });
 
       it('should throw on a rejecting mediator', async() => {

--- a/packages/actor-rdf-serialize-n3/test/ActorRdfSerializeN3-test.ts
+++ b/packages/actor-rdf-serialize-n3/test/ActorRdfSerializeN3-test.ts
@@ -1,7 +1,9 @@
 import { Readable } from 'stream';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
+import type * as RDF from '@rdfjs/types';
 import { ArrayIterator } from 'asynciterator';
+import type { AsyncIterator } from 'asynciterator';
 import { ActorRdfSerializeN3 } from '../lib/ActorRdfSerializeN3';
 
 const quad = require('rdf-quad');
@@ -33,7 +35,7 @@ describe('ActorRdfSerializeN3', () => {
 
   describe('An ActorRdfSerializeN3 instance', () => {
     let actor: ActorRdfSerializeN3;
-    let quadStream: any;
+    let quadStream: () => RDF.Stream & AsyncIterator<RDF.Quad>;
     let quadStreamPipeable: any;
     let quadsError: any;
 
@@ -49,7 +51,7 @@ describe('ActorRdfSerializeN3', () => {
 
     describe('for serializing', () => {
       beforeEach(() => {
-        quadStream = new ArrayIterator([
+        quadStream = () => new ArrayIterator([
           quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
           quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
         ]);
@@ -61,24 +63,46 @@ describe('ActorRdfSerializeN3', () => {
         quadsError._read = () => quadsError.emit('error', new Error('SerializeN3'));
       });
 
-      it('should test on application/trig', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'application/trig', context }))
-          .resolves.toBeTruthy();
-      });
+      describe('quad stream tests', () => {
+        let stream: RDF.Stream & AsyncIterator<RDF.Quad>;
+        beforeEach(() => {
+          stream = quadStream();
+        });
+        afterEach(() => {
+          stream.destroy();
+        });
 
-      it('should test on text/turtle', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'text/turtle', context }))
-          .resolves.toBeTruthy();
-      });
+        it('should test on application/trig', () => {
+          return expect(actor.test({
+            handle: { quadStream: stream, context },
+            handleMediaType: 'application/trig',
+            context,
+          }))
+            .resolves.toBeTruthy();
+        });
 
-      it('should not test on application/json', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'application/json', context }))
-          .rejects.toBeTruthy();
+        it('should test on text/turtle', () => {
+          return expect(actor.test({
+            handle: { quadStream: stream, context },
+            handleMediaType: 'text/turtle',
+            context,
+          }))
+            .resolves.toBeTruthy();
+        });
+
+        it('should not test on application/json', () => {
+          return expect(actor.test({
+            handle: { quadStream: stream, context },
+            handleMediaType: 'application/json',
+            context,
+          }))
+            .rejects.toBeTruthy();
+        });
       });
 
       it('should run', async() => {
         const output: any = await actor
-          .run({ handle: { quadStream, context }, handleMediaType: 'text/turtle', context });
+          .run({ handle: { quadStream: quadStream(), context }, handleMediaType: 'text/turtle', context });
         expect(await stringifyStream(output.handle.data)).toEqual(
           `<http://example.org/a> <http://example.org/b> <http://example.org/c>;
     <http://example.org/d> <http://example.org/e>.
@@ -97,25 +121,29 @@ describe('ActorRdfSerializeN3', () => {
       });
 
       it('should run and output triples for text/turtle', async() => {
-        expect((<any> (await actor.run({ handle: { quadStream, context }, handleMediaType: 'text/turtle', context })))
+        expect((<any> (await actor.run({
+          handle: { quadStream: quadStream(), context },
+          handleMediaType: 'text/turtle',
+          context,
+        })))
           .handle.triples).toBeTruthy();
       });
 
       it('should run and output triples for application/n-triples', async() => {
         expect((<any> (await actor
-          .run({ handle: { quadStream, context }, handleMediaType: 'application/n-triples', context })))
+          .run({ handle: { quadStream: quadStream(), context }, handleMediaType: 'application/n-triples', context })))
           .handle.triples).toBeTruthy();
       });
 
       it('should run and output triples for text/n3', async() => {
         expect((<any> (await actor
-          .run({ handle: { quadStream, context }, handleMediaType: 'text/n3', context })))
+          .run({ handle: { quadStream: quadStream(), context }, handleMediaType: 'text/n3', context })))
           .handle.triples).toBeTruthy();
       });
 
       it('should run and output non-triples for application/trig', async() => {
         expect((<any> (await actor
-          .run({ handle: { quadStream, context }, handleMediaType: 'application/trig', context })))
+          .run({ handle: { quadStream: quadStream(), context }, handleMediaType: 'application/trig', context })))
           .handle.triples).toBeFalsy();
       });
 

--- a/packages/actor-rdf-serialize-shaclc/test/ActorRdfSerializeShaclc-test.ts
+++ b/packages/actor-rdf-serialize-shaclc/test/ActorRdfSerializeShaclc-test.ts
@@ -63,29 +63,35 @@ describe('ActorRdfSerializeShaclc', () => {
         quadsError._read = () => quadsError.emit('error', new Error('SerializeShaclc'));
       });
 
-      it('should test on text/shaclc', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'text/shaclc', context }))
-          .resolves.toBeTruthy();
-      });
+      describe('should test', () => {
+        afterEach(() => {
+          quadStream.destroy();
+        });
 
-      it('should test on text/shaclc-ext', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'text/shaclc-ext', context }))
-          .resolves.toBeTruthy();
-      });
+        it('should test on text/shaclc', () => {
+          return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'text/shaclc', context }))
+            .resolves.toBeTruthy();
+        });
 
-      it('should not test on application/trig', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'application/trig', context }))
-          .rejects.toBeTruthy();
-      });
+        it('should test on text/shaclc-ext', () => {
+          return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'text/shaclc-ext', context }))
+            .resolves.toBeTruthy();
+        });
 
-      it('should not test on text/turtle', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'text/turtle', context }))
-          .rejects.toBeTruthy();
-      });
+        it('should not test on application/trig', () => {
+          return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'application/trig', context }))
+            .rejects.toBeTruthy();
+        });
 
-      it('should not test on application/json', () => {
-        return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'application/json', context }))
-          .rejects.toBeTruthy();
+        it('should not test on text/turtle', () => {
+          return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'text/turtle', context }))
+            .rejects.toBeTruthy();
+        });
+
+        it('should not test on application/json', () => {
+          return expect(actor.test({ handle: { quadStream, context }, handleMediaType: 'application/json', context }))
+            .rejects.toBeTruthy();
+        });
       });
 
       it('should run', async() => {
@@ -169,6 +175,9 @@ describe('ActorRdfSerializeShaclc', () => {
           { handle: { quadStream: quadsError, context }, handleMediaType: 'application/trig', context },
         )))
           .handle.data)).rejects.toBeTruthy();
+
+        // Close the quadStream since we didn't use it
+        quadStream.destroy();
       });
     });
 


### PR DESCRIPTION
This is the result of testing which `AsyncIterator`s were left open at the end of tests and destroying them. In most cases they were test iterators that were not fully consumed - but there were also some cases such as performing `minus` operations where iterators were being left open in the component itself.