### PR TITLE
fix: use `globalThis` rather than `global`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     Headers: false,
     Request: false,
     XMLHttpRequest: false,
+    globalThis: false,
   },
   rules: {
     // Default

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,8 @@ module.exports = {
     }
   },
   globals: {
-    window: false,
+    window: "off",
+    global: "off",
     fetch: false,
     Headers: false,
     Request: false,

--- a/engines/query-sparql/test/QuerySparql-solid-test.ts
+++ b/engines/query-sparql/test/QuerySparql-solid-test.ts
@@ -20,7 +20,6 @@ const config = [{
 }];
 
 // Store global fetch to reset to after mock.
-// eslint-disable-next-line no-undef
 const globalFetch = globalThis.fetch;
 
 // Use an increased timeout, since the CSS server takes too much setup time.
@@ -109,7 +108,6 @@ describe('System test: QuerySparql over Solid Pods', () => {
 
     // Override global fetch with auth fetch
     // @ts-expect-error
-    // eslint-disable-next-line no-undef
     globalThis.fetch = jest.fn(authFetch);
   });
 
@@ -117,7 +115,6 @@ describe('System test: QuerySparql over Solid Pods', () => {
     await app.stop();
 
     // Reset global fetch. This is probably redundant, as jest clears the DOM after each file.
-    // eslint-disable-next-line no-undef
     globalThis.fetch = globalFetch;
   });
 

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment setup-polly-jest/jest-environment-node */
 
 // Needed to undo automock from actor-http-native, cleaner workarounds do not appear to be working.
-if (!global.window) {
+if (!globalThis.window) {
   jest.unmock('follow-redirects');
 }
 

--- a/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
+++ b/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
@@ -11,7 +11,7 @@ import { ActorDereferenceHttp } from '../lib/ActorDereferenceHttp';
 const streamifyString = require('streamify-string');
 
 // TODO: Remove when targeting NodeJS 18+
-global.ReadableStream = global.ReadableStream || require('web-streams-ponyfill').ReadableStream;
+globalThis.ReadableStream = globalThis.ReadableStream || require('web-streams-ponyfill').ReadableStream;
 
 describe('ActorDereferenceHttp', () => {
   let bus: any;

--- a/packages/actor-http-fetch/lib/ActorHttpFetch.ts
+++ b/packages/actor-http-fetch/lib/ActorHttpFetch.ts
@@ -23,9 +23,9 @@ export class ActorHttpFetch extends ActorHttp {
   }
 
   public static createUserAgent(): string {
-    return `Comunica/actor-http-fetch (${typeof global.navigator === 'undefined' ?
+    return `Comunica/actor-http-fetch (${typeof globalThis.navigator === 'undefined' ?
       `Node.js ${process.version}; ${process.platform}` :
-      `Browser-${global.navigator.userAgent}`})`;
+      `Browser-${globalThis.navigator.userAgent}`})`;
   }
 
   public async test(action: IActionHttp): Promise<IMediatorTypeTime> {

--- a/packages/actor-http-fetch/lib/FetchInitPreprocessor.ts
+++ b/packages/actor-http-fetch/lib/FetchInitPreprocessor.ts
@@ -28,7 +28,7 @@ export class FetchInitPreprocessor implements IFetchInitPreprocessor {
   public async createAbortController(): Promise<AbortController> {
     // Fallback to abort-controller for Node 14 backward compatibility
     /* istanbul ignore next */
-    const AbortController = global.AbortController || await import('abort-controller');
+    const AbortController = globalThis.AbortController || await import('abort-controller');
     return new AbortController();
   }
 }

--- a/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
+++ b/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
@@ -12,7 +12,7 @@ import { ActorHttpFetch } from '../lib/ActorHttpFetch';
 const streamifyString = require('streamify-string');
 
 // Mock fetch
-(<any> global).fetch = jest.fn((input: any, init: any) => {
+(<any> globalThis).fetch = jest.fn((input: any, init: any) => {
   return Promise.resolve({
     status: input.url === 'https://www.google.com/' ? 200 : 404,
     ...input.url === 'NOBODY' ? {} : { body: { destroy: jest.fn(), on: jest.fn() }},
@@ -46,13 +46,13 @@ describe('ActorHttpFetch', () => {
 
   describe('#createUserAgent', () => {
     it('should create a user agent in the browser', () => {
-      (<any> global).navigator = { userAgent: 'Dummy' };
+      (<any> globalThis).navigator = { userAgent: 'Dummy' };
       return expect(ActorHttpFetch.createUserAgent())
         .toEqual(`Comunica/actor-http-fetch (Browser-${globalThis.navigator.userAgent})`);
     });
 
     it('should create a user agent in Node.js', () => {
-      delete (<any> global).navigator;
+      delete (<any> globalThis).navigator;
       return expect(ActorHttpFetch.createUserAgent())
         .toEqual(`Comunica/actor-http-fetch (Node.js ${process.version}; ${process.platform})`);
     });

--- a/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
+++ b/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
@@ -48,7 +48,7 @@ describe('ActorHttpFetch', () => {
     it('should create a user agent in the browser', () => {
       (<any> global).navigator = { userAgent: 'Dummy' };
       return expect(ActorHttpFetch.createUserAgent())
-        .toEqual(`Comunica/actor-http-fetch (Browser-${global.navigator.userAgent})`);
+        .toEqual(`Comunica/actor-http-fetch (Browser-${globalThis.navigator.userAgent})`);
     });
 
     it('should create a user agent in Node.js', () => {

--- a/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
+++ b/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
@@ -122,7 +122,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should run without KeysHttp.includeCredentials', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       await actor.run({
         input: <Request> { url: 'https://www.google.com/' },
         context: new ActionContext({}),
@@ -132,7 +132,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should run with KeysHttp.includeCredentials', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       await actor.run({
         input: <Request> { url: 'https://www.google.com/' },
         context: new ActionContext({
@@ -147,7 +147,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should run with authorization', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       await actor.run({
         input: <Request> { url: 'https://www.google.com/' },
         context: new ActionContext({
@@ -167,7 +167,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should run with authorization and init.headers undefined', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       await actor.run({
         input: <Request> { url: 'https://www.google.com/' },
         init: {},
@@ -188,7 +188,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should run with authorization and already header in init', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
 
       await actor.run({
         input: <Request> { url: 'https://www.google.com/' },
@@ -255,7 +255,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should set no user agent if one has been set', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       await actor.run({
         input: <Request> { url: 'https://www.google.com/' },
         init: { headers: new Headers({ 'user-agent': 'b' }) },
@@ -266,7 +266,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should set a user agent if none has been set', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       await actor.run({
         input: <Request> { url: 'https://www.google.com/' },
         init: { headers: new Headers({}) },
@@ -288,7 +288,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should run with a Node.js body', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       const body = <any> new Readable();
       await actor.run({ input: <Request> { url: 'https://www.google.com/' }, init: { body }, context });
 
@@ -303,7 +303,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should run with a Web stream body', async() => {
-      const spy = jest.spyOn(global, 'fetch');
+      const spy = jest.spyOn(globalThis, 'fetch');
       const body = ActorHttp.toWebReadableStream(streamifyString('a'));
       await actor.run({ input: <Request> { url: 'https://www.google.com/' }, init: { body }, context });
 
@@ -340,7 +340,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should work with a large timeout', async() => {
-      jest.spyOn(global, 'clearTimeout');
+      jest.spyOn(globalThis, 'clearTimeout');
       await expect(actor.run({
         input: <Request> { url: 'https://www.google.com/' },
         context: new ActionContext({ [KeysHttp.httpTimeout.name]: 100_000 }),
@@ -349,7 +349,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should work with a large timeout with an error', async() => {
-      jest.spyOn(global, 'clearTimeout');
+      jest.spyOn(globalThis, 'clearTimeout');
       const customFetch = jest.fn(async(_, _init) => {
         throw new Error('foo');
       });
@@ -377,7 +377,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should work with a large timeout including body if there is no body', async() => {
-      jest.spyOn(global, 'clearTimeout');
+      jest.spyOn(globalThis, 'clearTimeout');
       await expect(actor.run({
         input: <Request> { url: 'NOBODY' },
         context: new ActionContext({ [KeysHttp.httpTimeout.name]: 100_000, [KeysHttp.httpBodyTimeout.name]: true }),
@@ -386,7 +386,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should work with a large timeout including body if the body is consumed', async() => {
-      jest.spyOn(global, 'clearTimeout');
+      jest.spyOn(globalThis, 'clearTimeout');
       const customFetch = jest.fn(async(_, _init) => {
         const body = Readable.from('foo');
         return Promise.resolve({
@@ -409,7 +409,7 @@ describe('ActorHttpFetch', () => {
     });
 
     it('should work with a large timeout including body if the body is cancelled', async() => {
-      jest.spyOn(global, 'clearTimeout');
+      jest.spyOn(globalThis, 'clearTimeout');
       const customFetch = jest.fn(async(_, _init) => {
         const body = Readable.from('foo');
         return Promise.resolve({

--- a/packages/actor-http-native/lib/ActorHttpNative.ts
+++ b/packages/actor-http-native/lib/ActorHttpNative.ts
@@ -20,9 +20,9 @@ export class ActorHttpNative extends ActorHttp {
   }
 
   public static createUserAgent(): string {
-    return `Comunica/actor-http-native (${typeof global.navigator === 'undefined' ?
+    return `Comunica/actor-http-native (${typeof globalThis.navigator === 'undefined' ?
       `Node.js ${process.version}; ${process.platform}` :
-      `Browser-${global.navigator.userAgent}`})`;
+      `Browser-${globalThis.navigator.userAgent}`})`;
   }
 
   public async test(action: IActionHttp): Promise<IMediatorTypeTime> {

--- a/packages/actor-http-native/test/ActorHttpNative-test.ts
+++ b/packages/actor-http-native/test/ActorHttpNative-test.ts
@@ -37,13 +37,13 @@ describe('ActorHttpNative', () => {
 
   describe('#createUserAgent', () => {
     it('should create a user agent in the browser', () => {
-      (<any> global).navigator = { userAgent: 'Dummy' };
+      (<any> globalThis).navigator = { userAgent: 'Dummy' };
       return expect(ActorHttpNative.createUserAgent())
         .toEqual(`Comunica/actor-http-native (Browser-${globalThis.navigator.userAgent})`);
     });
 
     it('should create a user agent in Node.js', () => {
-      delete (<any> global).navigator;
+      delete (<any> globalThis).navigator;
       return expect(ActorHttpNative.createUserAgent())
         .toEqual(`Comunica/actor-http-native (Node.js ${process.version}; ${process.platform})`);
     });

--- a/packages/actor-http-native/test/ActorHttpNative-test.ts
+++ b/packages/actor-http-native/test/ActorHttpNative-test.ts
@@ -39,7 +39,7 @@ describe('ActorHttpNative', () => {
     it('should create a user agent in the browser', () => {
       (<any> global).navigator = { userAgent: 'Dummy' };
       return expect(ActorHttpNative.createUserAgent())
-        .toEqual(`Comunica/actor-http-native (Browser-${global.navigator.userAgent})`);
+        .toEqual(`Comunica/actor-http-native (Browser-${globalThis.navigator.userAgent})`);
     });
 
     it('should create a user agent in Node.js', () => {

--- a/packages/actor-init-query/lib/ActorInitQuery-browser.ts
+++ b/packages/actor-init-query/lib/ActorInitQuery-browser.ts
@@ -5,7 +5,7 @@ import { ActorInitQueryBase } from './ActorInitQueryBase';
 /* istanbul ignore next */
 if (typeof process === 'undefined') {
   // Polyfills process.nextTick for readable-stream
-  global.process = require('process'); // eslint-disable-line import/no-nodejs-modules
+  globalThis.process = require('process'); // eslint-disable-line import/no-nodejs-modules
 }
 
 export class ActorInitQuery extends ActorInitQueryBase {}

--- a/packages/actor-rdf-resolve-hypermedia-sparql/test/RdfSourceSparql-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/test/RdfSourceSparql-test.ts
@@ -13,7 +13,7 @@ const streamifyString = require('streamify-string');
 const DF = new DataFactory();
 
 // TODO: Remove when targeting NodeJS 18+
-global.ReadableStream = global.ReadableStream || require('web-streams-ponyfill').ReadableStream;
+globalThis.ReadableStream = globalThis.ReadableStream || require('web-streams-ponyfill').ReadableStream;
 
 describe('RdfSourceSparql', () => {
   const context = new ActionContext({});

--- a/packages/bus-http/lib/ActorHttp.ts
+++ b/packages/bus-http/lib/ActorHttp.ts
@@ -2,8 +2,8 @@ import type { IAction, IActorArgs, IActorOutput, IActorTest, Mediate } from '@co
 import { Actor } from '@comunica/core';
 import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
 
-if (!global.ReadableStream) {
-  global.ReadableStream = require('web-streams-ponyfill').ReadableStream;
+if (!globalThis.ReadableStream) {
+  globalThis.ReadableStream = require('web-streams-ponyfill').ReadableStream;
 }
 
 const isStream = require('is-stream');

--- a/packages/jest/lib/index.ts
+++ b/packages/jest/lib/index.ts
@@ -13,4 +13,4 @@ declare global {
   }
 }
 
-(<any> global).expect.extend(matchers);
+(<any> globalThis).expect.extend(matchers);


### PR DESCRIPTION
`global` doesn't exist in browser environments.

`globalThis` refers to `global` in node and `window` in browser.

cc @constraintAutomaton