### PR TITLE
Fix: localizeBlankNodes command line argument not assigned to context when false

### DIFF
--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -137,7 +137,7 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
     }
 
     // Set the blank node localization
-    if (args.localizeBlankNodes) {
+    if (args.localizeBlankNodes !== undefined) {
       context[KeysQueryOperation.localizeBlankNodes.name] = args.localizeBlankNodes;
     }
 


### PR DESCRIPTION
This should fix #1162. The issue seems to have been caused by the check for whether the args contain that entry, where it was using a simple if clause, so when it was actually set in the args but was false, the check would not pass and the false value would not be assigned to the context.