### PR TITLE
fix: use process shim

### DIFF
--- a/engines/query-sparql-file/bin/http.ts
+++ b/engines/query-sparql-file/bin/http.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import process = require('process');
 import { HttpServiceSparqlEndpoint } from '@comunica/actor-init-query';
 
 const defaultConfigPath = `${__dirname}/../config/config-default.json`;

--- a/engines/query-sparql-file/bin/http.ts
+++ b/engines/query-sparql-file/bin/http.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-import process = require('process');
 import { HttpServiceSparqlEndpoint } from '@comunica/actor-init-query';
+
+const process: NodeJS.Process = require('process/');
 
 const defaultConfigPath = `${__dirname}/../config/config-default.json`;
 

--- a/engines/query-sparql-file/package.json
+++ b/engines/query-sparql-file/package.json
@@ -173,7 +173,8 @@
     "@comunica/mediator-number": "^2.6.8",
     "@comunica/mediator-race": "^2.6.8",
     "@comunica/runner": "^2.6.8",
-    "@comunica/runner-cli": "^2.6.8"
+    "@comunica/runner-cli": "^2.6.8",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "npm run build:ts",

--- a/engines/query-sparql/bin/http.ts
+++ b/engines/query-sparql/bin/http.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import process = require('process');
 import { HttpServiceSparqlEndpoint } from '@comunica/actor-init-query';
 
 const defaultConfigPath = `${__dirname}/../config/config-default.json`;

--- a/engines/query-sparql/bin/http.ts
+++ b/engines/query-sparql/bin/http.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-import process = require('process');
 import { HttpServiceSparqlEndpoint } from '@comunica/actor-init-query';
+
+const process: NodeJS.Process = require('process/');
 
 const defaultConfigPath = `${__dirname}/../config/config-default.json`;
 

--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -171,7 +171,8 @@
     "@comunica/mediator-number": "^2.6.8",
     "@comunica/mediator-race": "^2.6.8",
     "@comunica/runner": "^2.6.8",
-    "@comunica/runner-cli": "^2.6.8"
+    "@comunica/runner-cli": "^2.6.8",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "npm run build:ts",

--- a/lerna.js
+++ b/lerna.js
@@ -21,7 +21,7 @@ async function depInfo({ location, name }, log) {
         dependencies = dependencies.filter(dep => dep !== 'process');
       } else {
         // If it is *not* declared in teh dependencies then mark it as missing
-        missing['process'] ??= [];
+        missing['process'] = missing['process'] || [];
       }
   }
 

--- a/lerna.js
+++ b/lerna.js
@@ -12,11 +12,17 @@ async function depInfo({ location, name }, log) {
 
   let {dependencies, devDependencies, missing, using} = await checkDeps(location, { ignorePatterns: ignore }, val => val);
 
-  if (dependencies.includes('process') && Object.values(using).flat().some(file => 
+  if (Object.values(using).flat().some(file => 
     readFileSync(file, 'utf8').toString().includes('import process = require(\'process\')') ||
     readFileSync(file, 'utf8').toString().includes('const process = require(\"process\")')
     )) {
-      dependencies = dependencies.filter(dep => dep !== 'process');
+      if (dependencies.includes('process')) {
+        // If we know it exists and is in the dependency array, remove it so that no errors are thrown
+        dependencies = dependencies.filter(dep => dep !== 'process');
+      } else {
+        // If it is *not* declared in teh dependencies then mark it as missing
+        missing['process'] ??= [];
+      }
   }
 
   return {

--- a/lerna.js
+++ b/lerna.js
@@ -14,7 +14,7 @@ async function depInfo({ location, name }, log) {
 
   if (dependencies.includes('process') && Object.values(using).flat().some(file => 
     readFileSync(file, 'utf8').toString().includes('import process = require(\'process\')') ||
-    readFileSync(file, 'utf8').toString().includes('const process = require(\'process\')')
+    readFileSync(file, 'utf8').toString().includes('const process = require(\"process\")')
     )) {
       dependencies = dependencies.filter(dep => dep !== 'process');
   }

--- a/lerna.js
+++ b/lerna.js
@@ -13,8 +13,10 @@ async function depInfo({ location, name }, log) {
   let {dependencies, devDependencies, missing, using} = await checkDeps(location, { ignorePatterns: ignore }, val => val);
 
   if (Object.values(using).flat().some(file => 
-    readFileSync(file, 'utf8').toString().includes('import process = require(\'process\')') ||
-    readFileSync(file, 'utf8').toString().includes('const process = require(\"process\")')
+    readFileSync(file, 'utf8').toString().includes('const process: NodeJS.Process = require(\'process/\')') ||
+    readFileSync(file, 'utf8').toString().includes('const process: NodeJS.Process = require(\"process/\")') ||
+    readFileSync(file, 'utf8').toString().includes('const process = require(\"process/\")') ||
+    readFileSync(file, 'utf8').toString().includes('const process = require(\'process/\')')
     )) {
       if (dependencies.includes('process')) {
         // If we know it exists and is in the dependency array, remove it so that no errors are thrown

--- a/lerna.js
+++ b/lerna.js
@@ -13,10 +13,8 @@ async function depInfo({ location, name }, log) {
   let {dependencies, devDependencies, missing, using} = await checkDeps(location, { ignorePatterns: ignore }, val => val);
 
   if (Object.values(using).flat().some(file => 
-    readFileSync(file, 'utf8').toString().includes('const process: NodeJS.Process = require(\'process/\')') ||
-    readFileSync(file, 'utf8').toString().includes('const process: NodeJS.Process = require(\"process/\")') ||
-    readFileSync(file, 'utf8').toString().includes('const process = require(\"process/\")') ||
-    readFileSync(file, 'utf8').toString().includes('const process = require(\'process/\')')
+    readFileSync(file, 'utf8').toString().includes('require(\'process/\')') ||
+    readFileSync(file, 'utf8').toString().includes('require(\"process/\")')
     )) {
       if (dependencies.includes('process')) {
         // If we know it exists and is in the dependency array, remove it so that no errors are thrown

--- a/packages/actor-http-native/lib/ActorHttpNative.ts
+++ b/packages/actor-http-native/lib/ActorHttpNative.ts
@@ -1,10 +1,11 @@
-import process = require('process');
 import type { IActionHttp, IActorHttpOutput, IActorHttpArgs } from '@comunica/bus-http';
 import { ActorHttp } from '@comunica/bus-http';
 import { KeysHttp } from '@comunica/context-entries';
 import type { IMediatorTypeTime } from '@comunica/mediatortype-time';
 import 'cross-fetch/polyfill';
 import Requester from './Requester';
+
+const process: NodeJS.Process = require('process/');
 
 /**
  * A comunica Follow Redirects Http Actor.

--- a/packages/actor-http-native/lib/ActorHttpNative.ts
+++ b/packages/actor-http-native/lib/ActorHttpNative.ts
@@ -1,3 +1,4 @@
+import process = require('process');
 import type { IActionHttp, IActorHttpOutput, IActorHttpArgs } from '@comunica/bus-http';
 import { ActorHttp } from '@comunica/bus-http';
 import { KeysHttp } from '@comunica/context-entries';

--- a/packages/actor-http-native/package.json
+++ b/packages/actor-http-native/package.json
@@ -37,7 +37,8 @@
     "@comunica/mediatortype-time": "^2.6.8",
     "cross-fetch": "^3.1.5",
     "follow-redirects": "^1.15.2",
-    "parse-link-header": "^2.0.0"
+    "parse-link-header": "^2.0.0",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -4,7 +4,7 @@ import type { Cluster } from 'cluster';
 import type { EventEmitter } from 'events';
 import * as http from 'http';
 import type { IncomingMessage, ServerResponse } from 'http';
-import process = require('process');
+
 import * as querystring from 'querystring';
 import type { Writable } from 'stream';
 import * as url from 'url';
@@ -20,6 +20,8 @@ import { QueryEngineBase, QueryEngineFactoryBase } from '..';
 import type { IDynamicQueryEngineOptions } from '..';
 import { CliArgsHandlerBase } from './cli/CliArgsHandlerBase';
 import { CliArgsHandlerHttp } from './cli/CliArgsHandlerHttp';
+
+const process: NodeJS.Process = require('process/');
 
 const quad = require('rdf-quad');
 

--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -4,6 +4,7 @@ import type { Cluster } from 'cluster';
 import type { EventEmitter } from 'events';
 import * as http from 'http';
 import type { IncomingMessage, ServerResponse } from 'http';
+import process = require('process');
 import * as querystring from 'querystring';
 import type { Writable } from 'stream';
 import * as url from 'url';

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerBase.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerBase.ts
@@ -2,12 +2,14 @@
 import { exec } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import * as OS from 'os';
-import process = require('process');
+
 import { KeysHttp, KeysInitQuery, KeysQueryOperation, KeysRdfUpdateQuads } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
 import { LoggerPretty } from '@comunica/logger-pretty';
 import type { IActionContext, ICliArgsHandler } from '@comunica/types';
 import type { Argv } from 'yargs';
+
+const process: NodeJS.Process = require('process/');
 
 /**
  * Basic CLI arguments handler that handles common options.

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerBase.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerBase.ts
@@ -2,6 +2,7 @@
 import { exec } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import * as OS from 'os';
+import process = require('process');
 import { KeysHttp, KeysInitQuery, KeysQueryOperation, KeysRdfUpdateQuads } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
 import { LoggerPretty } from '@comunica/logger-pretty';

--- a/packages/actor-init-query/package.json
+++ b/packages/actor-init-query/package.json
@@ -49,6 +49,7 @@
     "@types/yargs": "^17.0.13",
     "asynciterator": "^3.8.0",
     "negotiate": "^1.0.1",
+    "process": "^0.11.10",
     "rdf-quad": "^1.5.0",
     "rdf-string": "^1.6.1",
     "sparqlalgebrajs": "^4.0.5",

--- a/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
+++ b/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
@@ -1,3 +1,4 @@
+import process = require('process');
 import type { IActionSparqlSerialize,
   IActorQueryResultSerializeFixedMediaTypesArgs,
   IActorQueryResultSerializeOutput } from '@comunica/bus-query-result-serialize';

--- a/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
+++ b/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
@@ -1,4 +1,3 @@
-import process = require('process');
 import type { IActionSparqlSerialize,
   IActorQueryResultSerializeFixedMediaTypesArgs,
   IActorQueryResultSerializeOutput } from '@comunica/bus-query-result-serialize';
@@ -9,6 +8,8 @@ import type {
 } from '@comunica/types';
 import { Readable } from 'readable-stream';
 import type { ActionObserverHttp } from './ActionObserverHttp';
+
+const process: NodeJS.Process = require('process/');
 
 /**
  * Serializes SPARQL results for testing and debugging.

--- a/packages/actor-query-result-serialize-stats/package.json
+++ b/packages/actor-query-result-serialize-stats/package.json
@@ -37,6 +37,7 @@
     "@comunica/bus-query-result-serialize": "^2.6.8",
     "@comunica/core": "^2.6.8",
     "@comunica/types": "^2.6.8",
+    "process": "^0.11.10",
     "readable-stream": "^4.2.0"
   },
   "scripts": {

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProviderStderr.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProviderStderr.ts
@@ -1,7 +1,8 @@
-import process = require('process');
 import type { Stream } from 'bunyan';
 import type { IBunyanStreamProviderArgs } from './BunyanStreamProvider';
 import { BunyanStreamProvider } from './BunyanStreamProvider';
+
+const process: NodeJS.Process = require('process/');
 
 /**
  * A stderr bunyan stream provider.

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProviderStderr.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProviderStderr.ts
@@ -1,3 +1,4 @@
+import process = require('process');
 import type { Stream } from 'bunyan';
 import type { IBunyanStreamProviderArgs } from './BunyanStreamProvider';
 import { BunyanStreamProvider } from './BunyanStreamProvider';

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProviderStdout.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProviderStdout.ts
@@ -1,3 +1,4 @@
+import process = require('process');
 import type { Stream } from 'bunyan';
 import type { IBunyanStreamProviderArgs } from './BunyanStreamProvider';
 import { BunyanStreamProvider } from './BunyanStreamProvider';

--- a/packages/logger-bunyan/lib/stream/BunyanStreamProviderStdout.ts
+++ b/packages/logger-bunyan/lib/stream/BunyanStreamProviderStdout.ts
@@ -1,7 +1,8 @@
-import process = require('process');
 import type { Stream } from 'bunyan';
 import type { IBunyanStreamProviderArgs } from './BunyanStreamProvider';
 import { BunyanStreamProvider } from './BunyanStreamProvider';
+
+const process: NodeJS.Process = require('process/');
 
 /**
  * A stdout bunyan stream provider.

--- a/packages/logger-bunyan/package.json
+++ b/packages/logger-bunyan/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@comunica/types": "^2.6.8",
     "@types/bunyan": "^1.8.8",
-    "bunyan": "^1.8.15"
+    "bunyan": "^1.8.15",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/logger-pretty/lib/LoggerPretty.ts
+++ b/packages/logger-pretty/lib/LoggerPretty.ts
@@ -1,6 +1,7 @@
-import process = require('process');
 import { Logger } from '@comunica/types';
 import * as objectInspect from 'object-inspect';
+
+const process: NodeJS.Process = require('process/');
 
 /**
  * A logger that pretty-prints everything.

--- a/packages/logger-pretty/lib/LoggerPretty.ts
+++ b/packages/logger-pretty/lib/LoggerPretty.ts
@@ -1,3 +1,4 @@
+import process = require('process');
 import { Logger } from '@comunica/types';
 import * as objectInspect from 'object-inspect';
 

--- a/packages/logger-pretty/package.json
+++ b/packages/logger-pretty/package.json
@@ -32,7 +32,8 @@
   ],
   "dependencies": {
     "@comunica/types": "^2.6.8",
-    "object-inspect": "^1.12.2"
+    "object-inspect": "^1.12.2",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/packager/bin/package.ts
+++ b/packages/packager/bin/package.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
 import * as Path from 'path';
+import process = require('process');
 import { compileConfig } from 'componentsjs';
 import type { ParsedArgs } from 'minimist';
 import minimist = require('minimist');

--- a/packages/packager/bin/package.ts
+++ b/packages/packager/bin/package.ts
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 import * as fs from 'fs';
 import * as Path from 'path';
-import process = require('process');
+
 import { compileConfig } from 'componentsjs';
 import type { ParsedArgs } from 'minimist';
 import minimist = require('minimist');
+
+const process: NodeJS.Process = require('process/');
 
 const args: ParsedArgs = minimist(process.argv.slice(2));
 if (args._.length > 0 || args.h || args.help) {

--- a/packages/packager/package.json
+++ b/packages/packager/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@types/minimist": "^1.2.2",
     "componentsjs": "^5.3.2",
-    "minimist": "^1.2.7"
+    "minimist": "^1.2.7",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "node \"../../node_modules/typescript/bin/tsc\""

--- a/packages/runner-cli/bin/run.ts
+++ b/packages/runner-cli/bin/run.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-import process = require('process');
 import { runArgs } from '../lib/ArgsRunner';
+
+const process: NodeJS.Process = require('process/');
 
 const argv = process.argv.slice(2);
 if (argv.length === 0 || /^--?h(elp)?$/u.test(argv[0])) {

--- a/packages/runner-cli/bin/run.ts
+++ b/packages/runner-cli/bin/run.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import process = require('process');
 import { runArgs } from '../lib/ArgsRunner';
 
 const argv = process.argv.slice(2);

--- a/packages/runner-cli/lib/ArgsRunner.ts
+++ b/packages/runner-cli/lib/ArgsRunner.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-process-env,unicorn/no-process-exit */
+import process = require('process');
 import type { IActorOutputInit } from '@comunica/bus-init';
 import { ActionContext } from '@comunica/core';
 import type { ISetupProperties } from '@comunica/runner';

--- a/packages/runner-cli/lib/ArgsRunner.ts
+++ b/packages/runner-cli/lib/ArgsRunner.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-process-env,unicorn/no-process-exit */
-import process = require('process');
 import type { IActorOutputInit } from '@comunica/bus-init';
 import { ActionContext } from '@comunica/core';
 import type { ISetupProperties } from '@comunica/runner';
 import { run } from '@comunica/runner';
 import type { IActionContext } from '@comunica/types';
 import type { Readable } from 'readable-stream';
+
+const process: NodeJS.Process = require('process/');
 
 export function runArgs(configResourceUrl: string, argv: string[], stdin: NodeJS.ReadStream,
   stdout: NodeJS.WriteStream, stderr: NodeJS.WriteStream, exit: (code?: number) => void, env: NodeJS.ProcessEnv,

--- a/packages/runner-cli/package.json
+++ b/packages/runner-cli/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "@comunica/core": "^2.6.8",
     "@comunica/runner": "^2.6.8",
-    "@comunica/types": "^2.6.8"
+    "@comunica/types": "^2.6.8",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "node \"../../node_modules/typescript/bin/tsc\""

--- a/packages/runner/bin/compile-config.ts
+++ b/packages/runner/bin/compile-config.ts
@@ -1,5 +1,6 @@
-import process = require('process');
 import { compileConfig } from 'componentsjs';
+
+const process: NodeJS.Process = require('process/');
 
 // Compiles a configuration to a module (single file) that exports the instantiated instance,
 // where all dependencies are injected.

--- a/packages/runner/bin/compile-config.ts
+++ b/packages/runner/bin/compile-config.ts
@@ -1,3 +1,4 @@
+import process = require('process');
 import { compileConfig } from 'componentsjs';
 
 // Compiles a configuration to a module (single file) that exports the instantiated instance,

--- a/packages/runner/lib/Setup.ts
+++ b/packages/runner/lib/Setup.ts
@@ -1,4 +1,3 @@
-import process = require('process');
 import type { IActionInit, IActorOutputInit } from '@comunica/bus-init';
 import { ComponentsManager } from 'componentsjs';
 import type {
@@ -10,6 +9,8 @@ import type {
   LogLevel,
 } from 'componentsjs';
 import type { Runner } from './Runner';
+
+const process: NodeJS.Process = require('process/');
 
 /**
  * Helper functions to setup instances from a given comunica config file.

--- a/packages/runner/lib/Setup.ts
+++ b/packages/runner/lib/Setup.ts
@@ -1,3 +1,4 @@
+import process = require('process');
 import type { IActionInit, IActorOutputInit } from '@comunica/bus-init';
 import { ComponentsManager } from 'componentsjs';
 import type {

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@comunica/bus-init": "^2.6.8",
     "@comunica/core": "^2.6.8",
-    "componentsjs": "^5.3.2"
+    "componentsjs": "^5.3.2",
+    "process": "^0.11.10"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",


### PR DESCRIPTION
Uses the process shim rather than a global. It may be possible to remove the polyfills of process after this PR but we need to evaluate if any dependents use process globally (unless there are already tests in place to detect that in Comunica?)

