### PR TITLE
`Bindings` `merge()` and `mergeWith()` accept RDF.Bindings

### DIFF
--- a/packages/bindings-factory/lib/Bindings.ts
+++ b/packages/bindings-factory/lib/Bindings.ts
@@ -91,7 +91,7 @@ export class Bindings implements RDF.Bindings {
       .map((value, key) => fn(value, this.dataFactory.variable!(key)))));
   }
 
-  public merge(other: Bindings): Bindings | undefined {
+  public merge(other: RDF.Bindings): Bindings | undefined {
     // Determine the union of keys
     const keys = new Set([
       ...this.iteratorToIterable(this.entries.keys()),
@@ -115,7 +115,7 @@ export class Bindings implements RDF.Bindings {
 
   public mergeWith(
     merger: (self: RDF.Term, other: RDF.Term, key: RDF.Variable) => RDF.Term,
-    other: Bindings,
+    other: RDF.Bindings,
   ): Bindings {
     // Determine the union of keys
     const keys = new Set([


### PR DESCRIPTION
These work correctly with any `RDF.Bindings`, not only Comunica's implementation of `Bindings`.

Not only is this currently stopping these methods from working with other implementations of `Bindings`, they're stopping Comunica's `Bindings` from being interchangeable with other `Bindings` in general, at the type level. Consider the following code:

```ts
import type * as RDF from '@rdfjs/types';
import { Bindings } from "@comunica/bindings-factory";

function doSomethingWithBindings(bindings: RDF.Bindings) {}
declare const comunicaBindings: Bindings;
doSomethingWithBindings(comunicaBindings)
```

This causes a TypeScript error, because `comunicaBindings` cannot be passed to `doSomethingWithBindings()`, because the types are incompatible, because `comunicaBindings.merge()` takes a Comunica `Bindings`, while `RDF.Bindings`' `merge()` takes an `RDF.Bindings`. Essentially, TypeScript is concerned that `doSomethingWithBindings` might call `bindings.merge(otherBindings)`, where `otherBindings` is some other implementation of `Bindings`, and if `bindings.merge` expects a Comunica implementation specifically, that could go poorly. TypeScript doesn't know that the Comunica's implementation doesn't rely on anything Comunica-specific. With this PR, it now does.