### PR TITLE
fix: provide baseIRI for shaclc

### DIFF
--- a/packages/actor-rdf-parse-shaclc/lib/ActorRdfParseShaclc.ts
+++ b/packages/actor-rdf-parse-shaclc/lib/ActorRdfParseShaclc.ts
@@ -34,7 +34,9 @@ export class ActorRdfParseShaclc extends ActorRdfParseFixedMediaTypes {
   public async runHandle(action: IActionRdfParse, mediaType: string, context: IActionContext):
   Promise<IActorRdfParseOutput> {
     const prefixIterator = new PrefixWrappingIterator(
-      streamToString(action.data).then(str => parse(str, { extendedSyntax: mediaType === 'text/shaclc-ext' })),
+      streamToString(action.data).then(str => parse(str, {
+        extendedSyntax: mediaType === 'text/shaclc-ext', baseIRI: action.metadata?.baseIRI,
+      })),
     );
 
     const readable = new Readable({ objectMode: true });

--- a/packages/actor-rdf-parse-shaclc/package.json
+++ b/packages/actor-rdf-parse-shaclc/package.json
@@ -37,7 +37,7 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
     "readable-stream": "^4.2.0",
-    "shaclc-parse": "^1.3.0",
+    "shaclc-parse": "^1.4.0",
     "stream-to-string": "^1.2.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12673,10 +12673,10 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaclc-parse@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.3.0.tgz#5981e53a5ebda0b37fdac88dbb16a605375ec981"
-  integrity sha512-DOaN9xEMFVRhqmMHhGH5g68/0h93fuJu9oERNgQxDDSYkHVo9SCduVldqHhKFpqUgxwWEoDh1BpN6aHXVU2u1A==
+shaclc-parse@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.4.0.tgz#1a82643daf0f7309ca8722d9bee4ee40f2726925"
+  integrity sha512-zyxjIYQH2ghg/wtMvOp+4Nr6aK8j9bqFiVT3w47K8WHPYN+S3Zgnh2ybT+dGgMwo9KjiOoywxhjC7d8Z6GCmfA==
   dependencies:
     "@rdfjs/types" "^1.1.0"
     n3 "^1.16.3"


### PR DESCRIPTION
Without this patch `urn:x-base:default` is used as the base for relative IRIs in shaclc documents.

I would appreciate it if a release containing this patch could be made fairly quickly.