### PR TITLE
Add RDF-star and SPARQL-star support

### DIFF
--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -195,7 +195,9 @@
     "spec:prot": "yarn run spec:base -s http://www.w3.org/TR/sparql11-protocol/",
     "spec:graphstore": "yarn run spec:base -s http://www.w3.org/TR/sparql11-http-rdf-update/",
     "spec:sparql12-xsd-datetime-duration": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://raw.githubusercontent.com/kasei/sparql-12/xsd_datetime_duration/tests/xsd_functions/manifest.ttl -c ../../.rdf-test-suite-cache/ --skip \"http://www.w3.org/2009/sparql/docs/tests/data-sparql11/functions/manifest#adjust_.*\"",
-    "spec": "yarn run spec:query && yarn run spec:update && yarn run spec:sparql12-xsd-datetime-duration",
+    "spec:sparql-star-syntax": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-star/tests/sparql/syntax/manifest.ttl -c ../../.rdf-test-suite-cache/",
+    "spec:sparql-star-evaluation": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-star/tests/sparql/eval/manifest.ttl -c ../../.rdf-test-suite-cache/",
+    "spec": "yarn run spec:query && yarn run spec:update && yarn run spec:sparql12-xsd-datetime-duration && yarn run spec:sparql-star-syntax && yarn run spec:sparql-star-evaluation",
     "spec-earl": "yarn run spec:query -o earl -p spec/earl-meta.json > earl.ttl",
     "integration": "rdf-test-suite-ldf spec/sparql-engine.js https://comunica.github.io/manifest-ldf-tests/sparql/sparql-manifest.ttl -d 200000 -c ../../.rdf-test-suite-ldf-cache/"
   },

--- a/lerna.js
+++ b/lerna.js
@@ -65,7 +65,6 @@ async function depInfo({ location, name }, log) {
 
 async function depfixTask(log) {
   const packages = (await (log.packages || loadPackages())).filter(package => package.location.startsWith(path.join(__dirname, '/packages')));
-  const resolutions = Object.keys(JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf8')).resolutions ?? {});
 
   await iter.forEach(packages, { log })(async package => {
     log.info(package.name)
@@ -105,21 +104,12 @@ async function depfixTask(log) {
       }
     }
 
-    // Now fix up any resolutions to use a star ("*") import
-    const packageJson = JSON.parse(readFileSync(path.join(package.location, 'package.json'), 'utf8'));
-    for (const dep of Object.keys(packageJson.dependencies ?? {})) {
-      if (resolutions.includes(dep) && packageJson.dependencies[dep] !== '*') {
-        log.info('    converting to \'*\' import for', dep)
-        packageJson.dependencies[dep] = '*';
-      }
-    }
     writeFileSync(path.join(package.location, 'package.json'), JSON.stringify(packageJson, null, 2) + '\n');
   })
 }
 
 async function depcheckTask(log) {
   const packages = await (log.packages || loadPackages());
-  const resolutions = Object.keys(JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf8')).resolutions ?? {});
 
   return iter.forEach(packages, { log })(async package => {
     const { missingDeps, unusedDeps, allDeps } = await depInfo(package)
@@ -134,15 +124,6 @@ async function depcheckTask(log) {
 
     if (allDeps.includes(package.name))
       throw new Error(`${package.name} is a dependency of itself`);
-
-
-    // Now check all resolutions use a star ("*") import
-    const packageJson = JSON.parse(readFileSync(path.join(package.location, 'package.json'), 'utf8'));
-    for (const dep of Object.keys(packageJson.dependencies ?? {})) {
-      if (resolutions.includes(dep) && packageJson.dependencies[dep] !== '*') {
-        throw new Error(`Resolution not using \'*\' import for ${dep} in ${package.name}`);
-      }
-    }
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -45,10 +45,11 @@
     "pre-commit": "^1.2.2",
     "rdf-data-factory": "^1.1.1",
     "rdf-quad": "^1.5.0",
-    "rdf-test-suite": "^1.24.0",
+    "rdf-stores": "^1.0.0",
+    "rdf-test-suite": "^1.25.0",
     "rdf-test-suite-ldf": "^1.4.2",
     "setup-polly-jest": "^0.11.0",
-    "sparqlalgebrajs": "^4.0.5",
+    "sparqlalgebrajs": "^4.2.0",
     "stream-to-string": "^1.2.0",
     "streamify-array": "^1.0.1",
     "streamify-string": "^1.0.1",
@@ -92,6 +93,7 @@
     "ncu:major:all": "lerna-script updateTaskMajor"
   },
   "resolutions": {
-    "@rdfjs/types": "1.1.0"
+    "@rdfjs/types": "1.1.0",
+    "readable-stream": "4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "lerna": "^7.0.1",
     "lerna-script": "^1.4.0",
     "manual-git-changelog": "^1.0.2",
-    "memory-streams": "^0.1.3",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "nodemon": "^2.0.20",
     "npm-check-updates": "^16.4.1",

--- a/packages/actor-abstract-path/package.json
+++ b/packages/actor-abstract-path/package.json
@@ -41,7 +41,7 @@
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
     "rdf-string": "^1.6.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-init-query/__mocks__/http.js
+++ b/packages/actor-init-query/__mocks__/http.js
@@ -1,7 +1,7 @@
-const streams = require('memory-streams');
 const EventEmitter = require('events');
+const { PassThrough } = require("readable-stream");
 
-class ServerResponseMock extends streams.WritableStream {
+class ServerResponseMock extends PassThrough {
   constructor(){
     super();
     this.writeHead = jest.fn();

--- a/packages/actor-init-query/package.json
+++ b/packages/actor-init-query/package.json
@@ -52,7 +52,7 @@
     "process": "^0.11.10",
     "rdf-quad": "^1.5.0",
     "rdf-string": "^1.6.1",
-    "sparqlalgebrajs": "^4.0.5",
+    "sparqlalgebrajs": "^4.2.0",
     "streamify-string": "^1.0.1",
     "yargs": "^17.6.2"
   },

--- a/packages/actor-init-query/spec/sparql-engine-base.js
+++ b/packages/actor-init-query/spec/sparql-engine-base.js
@@ -1,6 +1,6 @@
 const ProxyHandlerStatic = require('@comunica/actor-http-proxy').ProxyHandlerStatic;
 const RdfTestSuite = require('rdf-test-suite');
-const N3Store = require('n3').Store;
+const RdfStore = require('rdf-stores').RdfStore;
 
 module.exports = function(engine) {
   return {
@@ -48,7 +48,9 @@ module.exports = function(engine) {
 };
 
 function source(data) {
-  const store = new N3Store();
-  store.addQuads(data);
+  const store = RdfStore.createDefault();
+  for (quad of data) {
+    store.addQuad(quad);
+  }
   return store;
 }

--- a/packages/actor-optimize-query-operation-bgp-to-join/package.json
+++ b/packages/actor-optimize-query-operation-bgp-to-join/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/bus-optimize-query-operation": "^2.7.0",
     "@comunica/core": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-optimize-query-operation-join-bgp/package.json
+++ b/packages/actor-optimize-query-operation-join-bgp/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/bus-optimize-query-operation": "^2.7.0",
     "@comunica/core": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-optimize-query-operation-join-connected/package.json
+++ b/packages/actor-optimize-query-operation-join-connected/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/bus-optimize-query-operation": "^2.7.0",
     "@comunica/core": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-ask/package.json
+++ b/packages/actor-query-operation-ask/package.json
@@ -35,7 +35,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-bgp-join/package.json
+++ b/packages/actor-query-operation-bgp-join/package.json
@@ -35,7 +35,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
+++ b/packages/actor-query-operation-construct/lib/ActorQueryOperationConstruct.ts
@@ -8,7 +8,7 @@ import type { IQueryOperationResultBindings, IActionContext, IQueryOperationResu
   MetadataQuads } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
-import { getTerms, getVariables, uniqTerms } from 'rdf-terms';
+import { getTermsNested, getVariables, uniqTerms } from 'rdf-terms';
 import { Algebra } from 'sparqlalgebrajs';
 import { BindingsToQuadsIterator } from './BindingsToQuadsIterator';
 
@@ -27,7 +27,7 @@ export class ActorQueryOperationConstruct extends ActorQueryOperationTypedMediat
    */
   public static getVariables(patterns: RDF.BaseQuad[]): RDF.Variable[] {
     return uniqTerms((<RDF.Variable[]> []).concat
-      .apply([], patterns.map(pattern => getVariables(getTerms(pattern)))));
+      .apply([], patterns.map(pattern => getVariables(getTermsNested(pattern)))));
   }
 
   public async testOperation(operation: Algebra.Construct, context: IActionContext): Promise<IActorTest> {

--- a/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
+++ b/packages/actor-query-operation-construct/lib/BindingsToQuadsIterator.ts
@@ -3,7 +3,7 @@ import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator, MultiTransformIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
-import { mapTerms } from 'rdf-terms';
+import { mapTermsNested } from 'rdf-terms';
 
 const DF = new DataFactory();
 
@@ -53,7 +53,7 @@ export class BindingsToQuadsIterator extends MultiTransformIterator<Bindings, RD
    */
   public static bindQuad(bindings: Bindings, pattern: RDF.BaseQuad): RDF.Quad | undefined {
     try {
-      return mapTerms(<RDF.Quad> pattern, term => {
+      return mapTermsNested(<RDF.Quad> pattern, term => {
         const boundTerm = BindingsToQuadsIterator.bindTerm(bindings, term);
         if (!boundTerm) {
           throw new Error('Unbound term');
@@ -88,7 +88,7 @@ export class BindingsToQuadsIterator extends MultiTransformIterator<Bindings, RD
    */
   public static localizeQuad(blankNodeCounter: number,
     pattern: RDF.BaseQuad): RDF.BaseQuad {
-    return mapTerms(pattern, term => BindingsToQuadsIterator.localizeBlankNode(blankNodeCounter, term));
+    return mapTermsNested(pattern, term => BindingsToQuadsIterator.localizeBlankNode(blankNodeCounter, term));
   }
 
   /**

--- a/packages/actor-query-operation-construct/package.json
+++ b/packages/actor-query-operation-construct/package.json
@@ -38,8 +38,8 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
-    "rdf-terms": "^1.9.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "rdf-terms": "^1.11.0",
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-construct/test/ActorQueryOperationConstruct-test.ts
+++ b/packages/actor-query-operation-construct/test/ActorQueryOperationConstruct-test.ts
@@ -84,6 +84,17 @@ describe('ActorQueryOperationConstruct', () => {
         DF.quad(DF.variable('o1'), DF.namedNode('p2'), DF.literal('o2'), DF.namedNode('g2')),
       ])).toEqual([ DF.variable('o1') ]);
     });
+
+    it('should find variables in quoted triple patterns with variables', () => {
+      return expect(ActorQueryOperationConstruct.getVariables([
+        DF.quad(
+          DF.blankNode('s1'),
+          DF.namedNode('p1'),
+          DF.quad(DF.blankNode('s1'), DF.namedNode('p1'), DF.variable('o1')),
+        ),
+        DF.quad(DF.variable('s2'), DF.namedNode('p2'), DF.literal('o2'), DF.namedNode('g2')),
+      ])).toEqual([ DF.variable('o1'), DF.variable('s2') ]);
+    });
   });
 
   describe('An ActorQueryOperationConstruct instance', () => {

--- a/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
+++ b/packages/actor-query-operation-construct/test/BindingsToQuadsIterator-test.ts
@@ -236,6 +236,34 @@ describe('BindingsToQuadsIterator', () => {
           DF.namedNode('b'),
         ));
       });
+
+      it('should return a bound quoted quad', () => {
+        return expect(BindingsToQuadsIterator.bindQuad(bindings, DF.quad(
+          DF.quad(
+            DF.variable('a'),
+            DF.namedNode('p'),
+            DF.literal('o'),
+          ),
+          DF.namedNode('p'),
+          DF.quad(
+            DF.variable('b'),
+            DF.namedNode('p'),
+            DF.literal('o'),
+          ),
+        ))).toEqual(DF.quad(
+          DF.quad(
+            DF.namedNode('a'),
+            DF.namedNode('p'),
+            DF.literal('o'),
+          ),
+          DF.namedNode('p'),
+          DF.quad(
+            DF.namedNode('b'),
+            DF.namedNode('p'),
+            DF.literal('o'),
+          ),
+        ));
+      });
     });
   });
 
@@ -385,6 +413,28 @@ describe('BindingsToQuadsIterator', () => {
         DF.blankNode('a'),
       ))).toEqual(DF.quad(
         DF.blankNode('a0'),
+        <any> DF.blankNode('a0'),
+        DF.blankNode('a0'),
+        DF.blankNode('a0'),
+      ));
+    });
+
+    it('should localize a quad with equal subject, predicate, object and graph blank nodes in quoted triples', () => {
+      return expect(BindingsToQuadsIterator.localizeQuad(0, DF.quad(
+        DF.quad(
+          DF.blankNode('a'),
+          <any> DF.blankNode('a'),
+          DF.blankNode('a'),
+        ),
+        <any> DF.blankNode('a'),
+        DF.blankNode('a'),
+        DF.blankNode('a'),
+      ))).toEqual(DF.quad(
+        DF.quad(
+          DF.blankNode('a0'),
+          <any> DF.blankNode('a0'),
+          DF.blankNode('a0'),
+        ),
         <any> DF.blankNode('a0'),
         DF.blankNode('a0'),
         DF.blankNode('a0'),

--- a/packages/actor-query-operation-describe-subject/package.json
+++ b/packages/actor-query-operation-describe-subject/package.json
@@ -38,7 +38,7 @@
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-distinct-hash/package.json
+++ b/packages/actor-query-operation-distinct-hash/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-extend/package.json
+++ b/packages/actor-query-operation-extend/package.json
@@ -36,8 +36,8 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5",
-    "sparqlee": "^2.3.0"
+    "sparqlalgebrajs": "^4.2.0",
+    "sparqlee": "^3.0.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-filter-sparqlee/package.json
+++ b/packages/actor-query-operation-filter-sparqlee/package.json
@@ -36,8 +36,8 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5",
-    "sparqlee": "^2.3.0"
+    "sparqlalgebrajs": "^4.2.0",
+    "sparqlee": "^3.0.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-from-quad/package.json
+++ b/packages/actor-query-operation-from-quad/package.json
@@ -36,7 +36,7 @@
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-group/package.json
+++ b/packages/actor-query-operation-group/package.json
@@ -40,8 +40,8 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5",
-    "sparqlee": "^2.3.0"
+    "sparqlalgebrajs": "^4.2.0",
+    "sparqlee": "^3.0.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-join/package.json
+++ b/packages/actor-query-operation-join/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-rdf-join": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-leftjoin/package.json
+++ b/packages/actor-query-operation-leftjoin/package.json
@@ -36,8 +36,8 @@
     "@comunica/bus-rdf-join": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5",
-    "sparqlee": "^2.3.0"
+    "sparqlalgebrajs": "^4.2.0",
+    "sparqlee": "^3.0.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-minus/package.json
+++ b/packages/actor-query-operation-minus/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-rdf-join": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-nop/package.json
+++ b/packages/actor-query-operation-nop/package.json
@@ -38,7 +38,7 @@
     "@comunica/metadata": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-orderby-sparqlee/lib/ActorQueryOperationOrderBySparqlee.ts
+++ b/packages/actor-query-operation-orderby-sparqlee/lib/ActorQueryOperationOrderBySparqlee.ts
@@ -72,7 +72,13 @@ export class ActorQueryOperationOrderBySparqlee extends ActorQueryOperationTyped
 
       // Sort the annoted stream
       const sortedStream = new SortIterator(transformedStream,
-        (left, right) => orderTypes(left.result, right.result, isAscending),
+        (left, right) => {
+          let compare = orderTypes(left.result, right.result);
+          if (!isAscending) {
+            compare *= -1;
+          }
+          return compare;
+        },
         options);
 
       // Remove the annotation

--- a/packages/actor-query-operation-orderby-sparqlee/package.json
+++ b/packages/actor-query-operation-orderby-sparqlee/package.json
@@ -36,8 +36,8 @@
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5",
-    "sparqlee": "^2.3.0"
+    "sparqlalgebrajs": "^4.2.0",
+    "sparqlee": "^3.0.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-alt/package.json
+++ b/packages/actor-query-operation-path-alt/package.json
@@ -37,7 +37,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-inv/package.json
+++ b/packages/actor-query-operation-path-inv/package.json
@@ -35,7 +35,7 @@
     "@comunica/actor-abstract-path": "^2.7.1",
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-link/package.json
+++ b/packages/actor-query-operation-path-link/package.json
@@ -35,7 +35,7 @@
     "@comunica/actor-abstract-path": "^2.7.1",
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-nps/package.json
+++ b/packages/actor-query-operation-path-nps/package.json
@@ -35,7 +35,7 @@
     "@comunica/actor-abstract-path": "^2.7.1",
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-one-or-more/package.json
+++ b/packages/actor-query-operation-path-one-or-more/package.json
@@ -37,7 +37,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-seq/package.json
+++ b/packages/actor-query-operation-path-seq/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/bus-rdf-join": "^2.7.1",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-zero-or-more/package.json
+++ b/packages/actor-query-operation-path-zero-or-more/package.json
@@ -38,7 +38,7 @@
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
     "rdf-string": "^1.6.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-path-zero-or-one/package.json
+++ b/packages/actor-query-operation-path-zero-or-one/package.json
@@ -38,7 +38,7 @@
     "@comunica/metadata": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-project/package.json
+++ b/packages/actor-query-operation-project/package.json
@@ -38,7 +38,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-quadpattern/package.json
+++ b/packages/actor-query-operation-quadpattern/package.json
@@ -41,8 +41,9 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
-    "rdf-terms": "^1.9.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "rdf-terms": "^1.11.0",
+    "rdf-string": "^1.6.3",
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-reduced-hash/package.json
+++ b/packages/actor-query-operation-reduced-hash/package.json
@@ -38,7 +38,7 @@
     "@comunica/types": "^2.7.0",
     "@types/lru-cache": "^7.0.0",
     "lru-cache": "^9.1.2",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-service/package.json
+++ b/packages/actor-query-operation-service/package.json
@@ -39,7 +39,7 @@
     "@comunica/metadata": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-slice/package.json
+++ b/packages/actor-query-operation-slice/package.json
@@ -36,7 +36,7 @@
     "@comunica/context-entries": "^2.7.0",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -44,9 +44,9 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
-    "fetch-sparql-endpoint": "^3.3.2",
+    "fetch-sparql-endpoint": "^3.3.3",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-union/package.json
+++ b/packages/actor-query-operation-union/package.json
@@ -38,8 +38,8 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
-    "rdf-terms": "^1.9.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "rdf-terms": "^1.11.0",
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-add-rewrite/package.json
+++ b/packages/actor-query-operation-update-add-rewrite/package.json
@@ -36,7 +36,7 @@
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-clear/package.json
+++ b/packages/actor-query-operation-update-clear/package.json
@@ -38,7 +38,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-compositeupdate/package.json
+++ b/packages/actor-query-operation-update-compositeupdate/package.json
@@ -31,7 +31,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-copy-rewrite/package.json
+++ b/packages/actor-query-operation-update-copy-rewrite/package.json
@@ -35,7 +35,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-create/package.json
+++ b/packages/actor-query-operation-update-create/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-rdf-update-quads": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-deleteinsert/package.json
+++ b/packages/actor-query-operation-update-deleteinsert/package.json
@@ -36,7 +36,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-drop/package.json
+++ b/packages/actor-query-operation-update-drop/package.json
@@ -38,7 +38,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-load/package.json
+++ b/packages/actor-query-operation-update-load/package.json
@@ -38,7 +38,7 @@
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-update-move-rewrite/package.json
+++ b/packages/actor-query-operation-update-move-rewrite/package.json
@@ -35,7 +35,7 @@
     "@comunica/bus-query-operation": "^2.7.1",
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-operation-values/package.json
+++ b/packages/actor-query-operation-values/package.json
@@ -39,7 +39,7 @@
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-parse-sparql/lib/ActorQueryParseSparql.ts
+++ b/packages/actor-query-parse-sparql/lib/ActorQueryParseSparql.ts
@@ -23,7 +23,7 @@ export class ActorQueryParseSparql extends ActorQueryParse {
   }
 
   public async run(action: IActionQueryParse): Promise<IActorQueryParseOutput> {
-    const parser = new SparqlParser({ prefixes: this.prefixes, baseIRI: action.baseIRI });
+    const parser = new SparqlParser({ prefixes: this.prefixes, baseIRI: action.baseIRI, sparqlStar: true });
     const parsedSyntax = parser.parse(action.query);
     const baseIRI = parsedSyntax.type === 'query' ? parsedSyntax.base : undefined;
     return {

--- a/packages/actor-query-parse-sparql/package.json
+++ b/packages/actor-query-parse-sparql/package.json
@@ -35,8 +35,8 @@
     "@comunica/bus-query-parse": "^2.7.0",
     "@comunica/core": "^2.7.0",
     "@types/sparqljs": "^3.1.3",
-    "sparqlalgebrajs": "^4.0.5",
-    "sparqljs": "^3.6.1"
+    "sparqlalgebrajs": "^4.2.0",
+    "sparqljs": "^3.7.1"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-query-parse-sparql/test/ActorQueryParseSparql-test.ts
+++ b/packages/actor-query-parse-sparql/test/ActorQueryParseSparql-test.ts
@@ -77,6 +77,11 @@ describe('ActorQueryParseSparql', () => {
       );
     });
 
+    it('should run for a SPARQL-star query', async() => {
+      const result = await actor.run({ query: 'SELECT * WHERE { << ?a a ?q >> a ?b }', context });
+      expect(result).toBeTruthy();
+    });
+
     it('should run for an update query', async() => {
       const result = await actor.run({
         query: 'INSERT { <http://example/egbook> <http://ex.org/p> "A" } WHERE {}',

--- a/packages/actor-query-result-serialize-simple/package.json
+++ b/packages/actor-query-result-serialize-simple/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@comunica/bus-query-result-serialize": "^2.7.0",
     "@comunica/types": "^2.7.0",
+    "@rdfjs/types": "*",
     "rdf-string": "^1.6.3",
     "readable-stream": "^4.2.0"
   },

--- a/packages/actor-query-result-serialize-simple/package.json
+++ b/packages/actor-query-result-serialize-simple/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@comunica/bus-query-result-serialize": "^2.7.0",
     "@comunica/types": "^2.7.0",
+    "rdf-string": "^1.6.3",
     "readable-stream": "^4.2.0"
   },
   "scripts": {

--- a/packages/actor-query-result-serialize-simple/test/ActorQueryResultSerializeSimple-test.ts
+++ b/packages/actor-query-result-serialize-simple/test/ActorQueryResultSerializeSimple-test.ts
@@ -41,7 +41,9 @@ describe('ActorQueryResultSerializeSimple', () => {
   describe('An ActorQueryResultSerializeSimple instance', () => {
     let actor: ActorQueryResultSerializeSimple;
     let bindingsStream: () => BindingsStream;
+    let bindingsStreamQuoted: () => BindingsStream;
     let quadStream: () => RDF.Stream & AsyncIterator<Bindings>;
+    let quadStreamQuoted: () => RDF.Stream & AsyncIterator<RDF.Quad>;
     let streamError: Readable;
 
     beforeEach(() => {
@@ -59,10 +61,22 @@ describe('ActorQueryResultSerializeSimple', () => {
           [ DF.variable('k2'), DF.namedNode('v2') ],
         ]),
       ]);
+      bindingsStreamQuoted = () => new ArrayIterator([
+        BF.bindings([
+          [ DF.variable('k1'), DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')) ],
+        ]),
+        BF.bindings([
+          [ DF.variable('k2'), DF.quad(DF.namedNode('s2'), DF.namedNode('p2'), DF.namedNode('o2')) ],
+        ]),
+      ], { autoStart: false });
       quadStream = () => new ArrayIterator([
         quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
         quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
       ]);
+      quadStreamQuoted = () => new ArrayIterator([
+        quad('<<ex:s1 ex:p1 ex:o1>>', 'http://example.org/b', 'http://example.org/c'),
+        quad('<<ex:s2 ex:p2 ex:o2>>', 'http://example.org/d', 'http://example.org/e'),
+      ], { autoStart: false });
       streamError = new Readable();
       streamError._read = () => streamError.emit('error', new Error('SparqlSimple'));
     });
@@ -151,6 +165,22 @@ describe('ActorQueryResultSerializeSimple', () => {
         );
       });
 
+      it('should run on a bindings stream with quoted triples', async() => {
+        expect(await stringifyStream((<any> (await actor.run(
+          {
+            handle: <any> { type: 'bindings', bindingsStream: bindingsStreamQuoted(), context },
+            handleMediaType: 'simple',
+            context,
+          },
+        ))).handle.data)).toEqual(
+          `?k1: <<s1 p1 o1>>
+
+?k2: <<s2 p2 o2>>
+
+`,
+        );
+      });
+
       it('should run on a quad stream', async() => {
         expect(await stringifyStream((<any> (await actor.run(
           { handle: <any> { type: 'quads', quadStream: quadStream(), context }, handleMediaType: 'simple', context },
@@ -161,6 +191,28 @@ object: http://example.org/c
 graph: 
 
 subject: http://example.org/a
+predicate: http://example.org/d
+object: http://example.org/e
+graph: 
+
+`,
+        );
+      });
+
+      it('should run on a quad stream with quoted triples', async() => {
+        expect(await stringifyStream((<any> (await actor.run(
+          {
+            handle: <any> { type: 'quads', quadStream: quadStreamQuoted(), context },
+            handleMediaType: 'simple',
+            context,
+          },
+        ))).handle.data)).toEqual(
+          `subject: <<ex:s1 ex:p1 ex:o1>>
+predicate: http://example.org/b
+object: http://example.org/c
+graph: 
+
+subject: <<ex:s2 ex:p2 ex:o2>>
 predicate: http://example.org/d
 object: http://example.org/e
 graph: 

--- a/packages/actor-query-result-serialize-sparql-csv/lib/ActorQueryResultSerializeSparqlCsv.ts
+++ b/packages/actor-query-result-serialize-sparql-csv/lib/ActorQueryResultSerializeSparqlCsv.ts
@@ -41,6 +41,13 @@ export class ActorQueryResultSerializeSparqlCsv extends ActorQueryResultSerializ
       stringValue = `${stringValue}`;
     } else if (value.termType === 'BlankNode') {
       stringValue = `_:${stringValue}`;
+    } else if (value.termType === 'Quad') {
+      let object = ActorQueryResultSerializeSparqlCsv.bindingToCsvBindings(value.object);
+      if (value.object.termType === 'Literal') {
+        // If object is a literal, it must be put in quotes, and internal quotes must be escaped
+        object = `"${object.replace(/"/ug, '""')}"`;
+      }
+      stringValue = `<< ${ActorQueryResultSerializeSparqlCsv.bindingToCsvBindings(value.subject)} ${ActorQueryResultSerializeSparqlCsv.bindingToCsvBindings(value.predicate)} ${object} >>`;
     } else {
       stringValue = `<${stringValue}>`;
     }

--- a/packages/actor-query-result-serialize-sparql-json/lib/ActorQueryResultSerializeSparqlJson.ts
+++ b/packages/actor-query-result-serialize-sparql-json/lib/ActorQueryResultSerializeSparqlJson.ts
@@ -55,6 +55,16 @@ export class ActorQueryResultSerializeSparqlJson extends ActorQueryResultSeriali
     if (value.termType === 'BlankNode') {
       return { value: value.value, type: 'bnode' };
     }
+    if (value.termType === 'Quad') {
+      return {
+        value: {
+          subject: ActorQueryResultSerializeSparqlJson.bindingToJsonBindings(value.subject),
+          predicate: ActorQueryResultSerializeSparqlJson.bindingToJsonBindings(value.predicate),
+          object: ActorQueryResultSerializeSparqlJson.bindingToJsonBindings(value.object),
+        },
+        type: 'triple',
+      };
+    }
     return { value: value.value, type: 'uri' };
   }
 

--- a/packages/actor-query-result-serialize-sparql-xml/lib/ActorQueryResultSerializeSparqlXml.ts
+++ b/packages/actor-query-result-serialize-sparql-xml/lib/ActorQueryResultSerializeSparqlXml.ts
@@ -51,6 +51,15 @@ export class ActorQueryResultSerializeSparqlXml extends ActorQueryResultSerializ
         return { name: 'literal', attributes, children: value.value };
       case 'BlankNode':
         return { name: 'bnode', children: value.value };
+      case 'Quad':
+        return {
+          name: 'triple',
+          children: [
+            { name: 'subject', children: [ this.valueToXmlValue(value.subject) ]},
+            { name: 'predicate', children: [ this.valueToXmlValue(value.predicate) ]},
+            { name: 'object', children: [ this.valueToXmlValue(value.object) ]},
+          ],
+        };
       default:
         return { name: 'uri', children: value.value };
     }

--- a/packages/actor-query-result-serialize-table/package.json
+++ b/packages/actor-query-result-serialize-table/package.json
@@ -36,7 +36,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "rdf-data-factory": "^1.1.1",
-    "rdf-terms": "^1.9.1",
+    "rdf-terms": "^1.11.0",
     "readable-stream": "^4.2.0"
   },
   "scripts": {

--- a/packages/actor-query-result-serialize-table/package.json
+++ b/packages/actor-query-result-serialize-table/package.json
@@ -36,6 +36,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "rdf-data-factory": "^1.1.1",
+    "rdf-string": "^1.6.3",
     "rdf-terms": "^1.11.0",
     "readable-stream": "^4.2.0"
   },

--- a/packages/actor-rdf-join-inner-multi-bind/package.json
+++ b/packages/actor-rdf-join-inner-multi-bind/package.json
@@ -39,7 +39,7 @@
     "@comunica/mediatortype-join-coefficients": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-join-inner-multi-sequential/package.json
+++ b/packages/actor-rdf-join-inner-multi-sequential/package.json
@@ -36,7 +36,7 @@
     "@comunica/bus-rdf-join": "^2.7.1",
     "@comunica/mediatortype-join-coefficients": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-join-inner-multi-smallest/package.json
+++ b/packages/actor-rdf-join-inner-multi-smallest/package.json
@@ -37,7 +37,7 @@
     "@comunica/bus-rdf-join-entries-sort": "^2.7.0",
     "@comunica/mediatortype-join-coefficients": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-join-optional-bind/package.json
+++ b/packages/actor-rdf-join-optional-bind/package.json
@@ -38,7 +38,7 @@
     "@comunica/context-entries": "^2.7.0",
     "@comunica/mediatortype-join-coefficients": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-join-selectivity-variable-counting/package.json
+++ b/packages/actor-rdf-join-selectivity-variable-counting/package.json
@@ -35,7 +35,7 @@
     "@comunica/bus-rdf-join-selectivity": "^2.7.0",
     "@comunica/core": "^2.7.0",
     "@comunica/mediatortype-accuracy": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
+++ b/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
@@ -37,7 +37,8 @@ export class ActorRdfParseN3 extends ActorRdfParseFixedMediaTypes {
     action.data.on('error', error => data.emit('error', error));
     const data = <Readable><any>action.data.pipe(new StreamParser({
       baseIRI: action.metadata?.baseIRI,
-      format: mediaType,
+      // Enable RDF-star-mode on all formats, except N3, where this is not supported.
+      format: mediaType.endsWith('n3') ? mediaType : `${mediaType}*`,
     }));
     return {
       data,

--- a/packages/actor-rdf-parse-n3/package.json
+++ b/packages/actor-rdf-parse-n3/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@comunica/bus-rdf-parse": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "n3": "^1.16.3"
+    "n3": "^1.17.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-parse-n3/test/ActorRdfParseN3-test.ts
+++ b/packages/actor-rdf-parse-n3/test/ActorRdfParseN3-test.ts
@@ -84,6 +84,7 @@ describe('ActorRdfParseN3', () => {
   describe('An ActorRdfParseN3 instance', () => {
     let actor: ActorRdfParseN3;
     let input: Readable;
+    let inputQuoted: Readable;
     let inputError: Readable;
 
     beforeEach(() => {
@@ -136,6 +137,10 @@ describe('ActorRdfParseN3', () => {
           <a> <b> <c>.
           <d> <e> <f>.
       `);
+        inputQuoted = stringToStream(`
+          << <a> <b> <c> >> <b> <c>.
+          <d> <e> <f>.
+      `);
         inputError = new Readable();
         inputError._read = () => inputError.emit('error', new Error('ParseN3'));
       });
@@ -169,6 +174,19 @@ describe('ActorRdfParseN3', () => {
       it('should test on Turtle', async() => {
         await expect(actor
           .test({ handle: { data: input, context }, handleMediaType: 'text/turtle', context }))
+          .resolves.toBeTruthy();
+        await expect(actor
+          .test({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: 'text/turtle',
+            context,
+          }))
+          .resolves.toBeTruthy();
+      });
+
+      it('should test on Turtle with quoted triples', async() => {
+        await expect(actor
+          .test({ handle: { data: inputQuoted, context }, handleMediaType: 'text/turtle', context }))
           .resolves.toBeTruthy();
         await expect(actor
           .test({

--- a/packages/actor-rdf-resolve-hypermedia-none/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-none/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source": "^2.7.0",
     "@comunica/bus-rdf-resolve-hypermedia": "^2.7.0",
-    "rdf-store-stream": "^1.3.1"
+    "rdf-store-stream": "^2.0.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-resolve-hypermedia-none/test/ActorRdfResolveHypermediaNone-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-none/test/ActorRdfResolveHypermediaNone-test.ts
@@ -67,7 +67,7 @@ describe('ActorRdfResolveHypermediaNone', () => {
         stream.getProperty('metadata', resolve);
       })).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'exact', value: 2 },
+        cardinality: { type: 'estimate', value: 2 },
         canContainUndefs: false,
       });
       expect(await arrayifyStream(stream!)).toEqualRdfQuadArray([

--- a/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
@@ -9,7 +9,7 @@ import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator, TransformIterator, wrap } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { termToString } from 'rdf-string';
-import { mapTerms, matchPattern } from 'rdf-terms';
+import { everyTermsNested, mapTerms, matchPattern } from 'rdf-terms';
 
 const DF = new DataFactory();
 
@@ -115,7 +115,8 @@ export class RdfSourceQpf implements IQuadSource {
       { uri: this.graphUri, term: graph },
     ];
     for (const entry of input) {
-      if (entry.uri && entry.term.termType !== 'Variable') {
+      if (entry.uri && entry.term.termType !== 'Variable' &&
+        (entry.term.termType !== 'Quad' || everyTermsNested(entry.term, value => value.termType !== 'Variable'))) {
         entries[entry.uri] = termToString(entry.term);
       }
     }

--- a/packages/actor-rdf-resolve-hypermedia-qpf/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/package.json
@@ -43,7 +43,7 @@
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
     "rdf-string": "^1.6.1",
-    "rdf-terms": "^1.9.1"
+    "rdf-terms": "^1.11.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/test/RdfSourceQpf-test.ts
@@ -222,6 +222,19 @@ describe('RdfSourceQpf', () => {
         .toEqual('S,P,O,G');
     });
 
+    it('should create a valid fragment URI with materialized quoted triple terms', () => {
+      return expect(source.createFragmentUri(metadata.searchForms.values[0],
+        DF.quad(
+          DF.namedNode('S'),
+          DF.namedNode('P'),
+          DF.namedNode('O'),
+        ),
+        DF.namedNode('P'),
+        DF.namedNode('O'),
+        DF.namedNode('G')))
+        .toEqual('<<S P O>>,P,O,G');
+    });
+
     it('should create a valid fragment URI with only a few materialized terms', () => {
       return expect(source.createFragmentUri(metadata.searchForms.values[0],
         v,
@@ -229,6 +242,19 @@ describe('RdfSourceQpf', () => {
         v,
         DF.namedNode('G')))
         .toEqual('_,P,_,G');
+    });
+
+    it('should create a valid fragment URI with quoted triple terms with variables', () => {
+      return expect(source.createFragmentUri(metadata.searchForms.values[0],
+        DF.quad(
+          DF.namedNode('S'),
+          v,
+          DF.namedNode('O'),
+        ),
+        DF.namedNode('P'),
+        DF.namedNode('O'),
+        DF.namedNode('G')))
+        .toEqual('_,P,O,G');
     });
   });
 

--- a/packages/actor-rdf-resolve-hypermedia-sparql/package.json
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/package.json
@@ -39,11 +39,11 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
-    "fetch-sparql-endpoint": "^3.3.2",
+    "fetch-sparql-endpoint": "^3.3.3",
     "lru-cache": "^9.1.2",
     "rdf-data-factory": "^1.1.1",
-    "rdf-terms": "^1.9.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "rdf-terms": "^1.11.0",
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -14,7 +14,7 @@ import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator, UnionIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
-import { mapTerms } from 'rdf-terms';
+import { mapTermsNested } from 'rdf-terms';
 import type { Algebra } from 'sparqlalgebrajs';
 import { Factory } from 'sparqlalgebrajs';
 
@@ -109,7 +109,7 @@ export class FederatedQuadSource implements IQuadSource {
    * @return The skolemized quad.
    */
   public static skolemizeQuad<Q extends RDF.BaseQuad = RDF.Quad>(quad: Q, sourceId: string): Q {
-    return mapTerms(quad, term => FederatedQuadSource.skolemizeTerm(term, sourceId));
+    return mapTermsNested(quad, term => FederatedQuadSource.skolemizeTerm(term, sourceId));
   }
 
   /**
@@ -146,7 +146,7 @@ export class FederatedQuadSource implements IQuadSource {
    * @return The deskolemized quad.
    */
   public static deskolemizeQuad<Q extends RDF.BaseQuad = RDF.Quad>(quad: Q, sourceId: string): Q {
-    return mapTerms(quad, (term: RDF.Term): RDF.Term => {
+    return mapTermsNested(quad, (term: RDF.Term): RDF.Term => {
       const newTerm = FederatedQuadSource.deskolemizeTerm(term, sourceId);
       // If the term was skolemized in a different source then dont deskolemize it
       return !newTerm ? term : newTerm;

--- a/packages/actor-rdf-resolve-quad-pattern-federated/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/package.json
@@ -43,8 +43,8 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
     "rdf-data-factory": "^1.1.1",
-    "rdf-terms": "^1.9.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "rdf-terms": "^1.11.0",
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/test/FederatedQuadSource-test.ts
@@ -235,18 +235,40 @@ describe('FederatedQuadSource', () => {
       expect(FederatedQuadSource.skolemizeQuad(
         DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o'), DF.namedNode('g')), '0',
       ))
-        .toEqualRdfQuad(DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o'), DF.namedNode('g')));
+        .toEqual(DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o'), DF.namedNode('g')));
     });
 
     it('should skolemize blank nodes', () => {
       expect(FederatedQuadSource.skolemizeQuad(
         DF.quad(DF.blankNode('s'), DF.blankNode('p'), DF.blankNode('o'), DF.blankNode('g')), '0',
       ))
-        .toEqualRdfQuad(DF.quad(
-          DF.blankNode('urn:comunica_skolem:source_0:s'),
-          DF.blankNode('urn:comunica_skolem:source_0:p'),
-          DF.blankNode('urn:comunica_skolem:source_0:o'),
-          DF.blankNode('urn:comunica_skolem:source_0:g'),
+        .toEqual(DF.quad(
+          new BlankNodeScoped('bc_0_s', DF.namedNode('urn:comunica_skolem:source_0:s')),
+          new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_0:p')),
+          new BlankNodeScoped('bc_0_o', DF.namedNode('urn:comunica_skolem:source_0:o')),
+          new BlankNodeScoped('bc_0_g', DF.namedNode('urn:comunica_skolem:source_0:g')),
+        ));
+    });
+
+    it('should skolemize blank nodes in quoted triples', () => {
+      expect(FederatedQuadSource.skolemizeQuad(
+        DF.quad(
+          DF.quad(DF.blankNode('s'), DF.blankNode('p'), DF.blankNode('o'), DF.blankNode('g')),
+          DF.blankNode('p'),
+          DF.blankNode('o'),
+          DF.blankNode('g'),
+        ), '0',
+      ))
+        .toEqual(DF.quad(
+          DF.quad(
+            new BlankNodeScoped('bc_0_s', DF.namedNode('urn:comunica_skolem:source_0:s')),
+            new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_0:p')),
+            new BlankNodeScoped('bc_0_o', DF.namedNode('urn:comunica_skolem:source_0:o')),
+            new BlankNodeScoped('bc_0_g', DF.namedNode('urn:comunica_skolem:source_0:g')),
+          ),
+          new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_0:p')),
+          new BlankNodeScoped('bc_0_o', DF.namedNode('urn:comunica_skolem:source_0:o')),
+          new BlankNodeScoped('bc_0_g', DF.namedNode('urn:comunica_skolem:source_0:g')),
         ));
     });
   });
@@ -256,32 +278,63 @@ describe('FederatedQuadSource', () => {
       expect(FederatedQuadSource.deskolemizeQuad(
         DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o'), DF.namedNode('g')), '0',
       ))
-        .toEqualRdfQuad(DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o'), DF.namedNode('g')));
+        .toEqual(DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o'), DF.namedNode('g')));
     });
 
     it('should deskolemize blank nodes with the right id', () => {
       expect(FederatedQuadSource.deskolemizeQuad(
         DF.quad(
-          DF.blankNode('urn:comunica_skolem:source_0:s'),
-          DF.blankNode('urn:comunica_skolem:source_0:p'),
-          DF.blankNode('urn:comunica_skolem:source_0:o'),
-          DF.blankNode('urn:comunica_skolem:source_0:g'),
+          new BlankNodeScoped('bc_0_s', DF.namedNode('urn:comunica_skolem:source_0:s')),
+          new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_0:p')),
+          new BlankNodeScoped('bc_0_o', DF.namedNode('urn:comunica_skolem:source_0:o')),
+          new BlankNodeScoped('bc_0_g', DF.namedNode('urn:comunica_skolem:source_0:g')),
         ), '0',
-      )).toEqualRdfQuad(DF.quad(DF.blankNode('s'), DF.blankNode('p'), DF.blankNode('o'), DF.blankNode('g')));
+      )).toEqual(DF.quad(
+        DF.blankNode('s'),
+        DF.blankNode('p'),
+        DF.blankNode('o'),
+        DF.blankNode('g'),
+      ));
+    });
+
+    it('should deskolemize blank nodes in quoted triples with the right id', () => {
+      expect(FederatedQuadSource.deskolemizeQuad(
+        DF.quad(
+          DF.quad(
+            new BlankNodeScoped('bc_0_s', DF.namedNode('urn:comunica_skolem:source_0:s')),
+            new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_0:p')),
+            new BlankNodeScoped('bc_0_o', DF.namedNode('urn:comunica_skolem:source_0:o')),
+            new BlankNodeScoped('bc_0_g', DF.namedNode('urn:comunica_skolem:source_0:g')),
+          ),
+          new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_0:p')),
+          new BlankNodeScoped('bc_0_o', DF.namedNode('urn:comunica_skolem:source_0:o')),
+          new BlankNodeScoped('bc_0_g', DF.namedNode('urn:comunica_skolem:source_0:g')),
+        ), '0',
+      )).toEqual(DF.quad(
+        DF.quad(
+          DF.blankNode('s'),
+          DF.blankNode('p'),
+          DF.blankNode('o'),
+          DF.blankNode('g'),
+        ),
+        DF.blankNode('p'),
+        DF.blankNode('o'),
+        DF.blankNode('g'),
+      ));
     });
 
     it('should deskolemize blank nodes with the right id but not ones with the wrong id', () => {
       expect(FederatedQuadSource.deskolemizeQuad(
         DF.quad(
-          DF.blankNode('urn:comunica_skolem:source_0:s'),
-          DF.blankNode('urn:comunica_skolem:source_1:p'),
-          DF.blankNode('urn:comunica_skolem:source_0:o'),
-          DF.blankNode('urn:comunica_skolem:source_0:g'),
+          new BlankNodeScoped('bc_0_s', DF.namedNode('urn:comunica_skolem:source_0:s')),
+          new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_1:p')),
+          new BlankNodeScoped('bc_0_o', DF.namedNode('urn:comunica_skolem:source_0:o')),
+          new BlankNodeScoped('bc_0_g', DF.namedNode('urn:comunica_skolem:source_0:g')),
         ), '0',
-      )).toEqualRdfQuad(
+      )).toEqual(
         DF.quad(
           DF.blankNode('s'),
-          DF.blankNode('urn:comunica_skolem:source_1:p'),
+          new BlankNodeScoped('bc_0_p', DF.namedNode('urn:comunica_skolem:source_1:p')),
           DF.blankNode('o'),
           DF.blankNode('g'),
         ),
@@ -296,7 +349,7 @@ describe('FederatedQuadSource', () => {
           DF.namedNode('urn:comunica_skolem:source_0:o'),
           DF.namedNode('urn:comunica_skolem:source_0:g'),
         ), '0',
-      )).toEqualRdfQuad(
+      )).toEqual(
         DF.quad(
           DF.blankNode('s'),
           DF.namedNode('urn:comunica_skolem:source_1:p'),

--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/package.json
@@ -52,7 +52,7 @@
     "lru-cache": "^9.1.2",
     "rdf-streaming-store": "^1.1.0",
     "readable-stream": "^4.2.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/IRdfJsSourceExtended.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/IRdfJsSourceExtended.ts
@@ -2,6 +2,18 @@ import type * as RDF from '@rdfjs/types';
 
 export interface IRdfJsSourceExtended extends RDF.Source {
   /**
+   * A record indicating supported features of this source.
+   */
+  features?: {
+    /**
+     * If true, this source supports passing quad patterns with quoted quad patterns in the `match` method.
+     * If false (or if `features` is `undefined`), such quoted quad patterns can not be passed,
+     * and must be replaced by `undefined` and filtered by the caller afterwards.
+     */
+    quotedTripleFiltering?: boolean;
+  };
+
+  /**
    * Return an estimated count of the number of quads matching the given pattern.
    *
    * The better the estimate, the better the query engine will be able to optimize the query.

--- a/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/RdfJsQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/lib/RdfJsQuadSource.ts
@@ -3,7 +3,11 @@ import { MetadataValidationState } from '@comunica/metadata';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { wrap as wrapAsyncIterator } from 'asynciterator';
+import { DataFactory } from 'rdf-data-factory';
+import { someTermsNested, filterTermsNested, someTerms, uniqTerms, matchPatternComplete } from 'rdf-terms';
 import type { IRdfJsSourceExtended } from './IRdfJsSourceExtended';
+
+const DF = new DataFactory<RDF.BaseQuad>();
 
 /**
  * A quad source that wraps over an {@link RDF.Source}.
@@ -15,19 +19,37 @@ export class RdfJsQuadSource implements IQuadSource {
     this.source = source;
   }
 
-  public static nullifyVariables(term?: RDF.Term): RDF.Term | undefined {
-    return !term || term.termType === 'Variable' ? undefined : term;
+  public static nullifyVariables(term: RDF.Term | undefined, quotedTripleFiltering: boolean): RDF.Term | undefined {
+    return !term || term.termType === 'Variable' || (!quotedTripleFiltering &&
+      term.termType === 'Quad' && someTermsNested(term, value => value.termType === 'Variable')) ?
+      undefined :
+      term;
+  }
+
+  public static hasDuplicateVariables(pattern: RDF.BaseQuad): boolean {
+    const variables = filterTermsNested(pattern, term => term.termType === 'Variable');
+    return variables.length > 1 && uniqTerms(variables).length < variables.length;
   }
 
   public match(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph: RDF.Term): AsyncIterator<RDF.Quad> {
+    // Check if the source supports quoted triple filtering
+    const quotedTripleFiltering = Boolean(this.source.features?.quotedTripleFiltering);
+
     // Create an async iterator from the matched quad stream
     const rawStream = this.source.match(
-      RdfJsQuadSource.nullifyVariables(subject),
-      RdfJsQuadSource.nullifyVariables(predicate),
-      RdfJsQuadSource.nullifyVariables(object),
-      RdfJsQuadSource.nullifyVariables(graph),
+      RdfJsQuadSource.nullifyVariables(subject, quotedTripleFiltering),
+      RdfJsQuadSource.nullifyVariables(predicate, quotedTripleFiltering),
+      RdfJsQuadSource.nullifyVariables(object, quotedTripleFiltering),
+      RdfJsQuadSource.nullifyVariables(graph, quotedTripleFiltering),
     );
-    const it = wrapAsyncIterator<RDF.Quad>(rawStream, { autoStart: false });
+    let it: AsyncIterator<RDF.Quad> = wrapAsyncIterator<RDF.Quad>(rawStream, { autoStart: false });
+
+    // Perform post-match-filtering if the source does not support quoted triple filtering,
+    // but we have a variable inside a quoted triple.
+    const pattern = DF.quad(subject, predicate, object, graph);
+    if (!quotedTripleFiltering && someTerms(pattern, term => term.termType === 'Quad')) {
+      it = it.filter(quad => matchPatternComplete(quad, pattern));
+    }
 
     // Determine metadata
     this.setMetadata(it, subject, predicate, object, graph)
@@ -43,14 +65,17 @@ export class RdfJsQuadSource implements IQuadSource {
     object: RDF.Term,
     graph: RDF.Term,
   ): Promise<void> {
+    // Check if the source supports quoted triple filtering
+    const quotedTripleFiltering = Boolean(this.source.features?.quotedTripleFiltering);
+
     let cardinality: number;
     if (this.source.countQuads) {
       // If the source provides a dedicated method for determining cardinality, use that.
       cardinality = await this.source.countQuads(
-        RdfJsQuadSource.nullifyVariables(subject),
-        RdfJsQuadSource.nullifyVariables(predicate),
-        RdfJsQuadSource.nullifyVariables(object),
-        RdfJsQuadSource.nullifyVariables(graph),
+        RdfJsQuadSource.nullifyVariables(subject, quotedTripleFiltering),
+        RdfJsQuadSource.nullifyVariables(predicate, quotedTripleFiltering),
+        RdfJsQuadSource.nullifyVariables(object, quotedTripleFiltering),
+        RdfJsQuadSource.nullifyVariables(graph, quotedTripleFiltering),
       );
     } else {
       // Otherwise, fallback to a sub-optimal alternative where we just call match again to count the quads.
@@ -59,19 +84,26 @@ export class RdfJsQuadSource implements IQuadSource {
       let i = 0;
       cardinality = await new Promise((resolve, reject) => {
         const matches = this.source.match(
-          RdfJsQuadSource.nullifyVariables(subject),
-          RdfJsQuadSource.nullifyVariables(predicate),
-          RdfJsQuadSource.nullifyVariables(object),
-          RdfJsQuadSource.nullifyVariables(graph),
+          RdfJsQuadSource.nullifyVariables(subject, quotedTripleFiltering),
+          RdfJsQuadSource.nullifyVariables(predicate, quotedTripleFiltering),
+          RdfJsQuadSource.nullifyVariables(object, quotedTripleFiltering),
+          RdfJsQuadSource.nullifyVariables(graph, quotedTripleFiltering),
         );
         matches.on('error', reject);
         matches.on('end', () => resolve(i));
         matches.on('data', () => i++);
       });
     }
+
+    // If `match` would require filtering afterwards, our count will be an over-estimate.
+    const pattern = DF.quad(subject, predicate, object, graph);
+    const wouldRequirePostFiltering = (!quotedTripleFiltering &&
+        someTerms(pattern, term => term.termType === 'Quad')) ||
+      RdfJsQuadSource.hasDuplicateVariables(pattern);
+
     it.setProperty('metadata', {
       state: new MetadataValidationState(),
-      cardinality: { type: 'exact', value: cardinality },
+      cardinality: { type: wouldRequirePostFiltering ? 'estimate' : 'exact', value: cardinality },
       canContainUndefs: false,
     });
   }

--- a/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/package.json
+++ b/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/package.json
@@ -37,7 +37,9 @@
     "@comunica/metadata": "^2.7.0",
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
-    "asynciterator": "^3.8.0"
+    "asynciterator": "^3.8.0",
+    "rdf-data-factory": "^1.1.2",
+    "rdf-terms": "^1.11.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/test/ActorRdfResolveQuadPatternRdfJsSource-test.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-rdfjs-source/test/ActorRdfResolveQuadPatternRdfJsSource-test.ts
@@ -9,6 +9,7 @@ import arrayifyStream from 'arrayify-stream';
 import { ArrayIterator } from 'asynciterator';
 import { Store } from 'n3';
 import { DataFactory } from 'rdf-data-factory';
+import { RdfStore } from 'rdf-stores';
 import { ActorRdfResolveQuadPatternRdfJsSource, RdfJsQuadSource } from '..';
 import 'jest-rdf';
 
@@ -144,6 +145,274 @@ describe('ActorRdfResolveQuadPatternRdfJsSource', () => {
         .toEqual({ cardinality: { type: 'exact', value: 2 },
           canContainUndefs: false,
           state: expect.any(MetadataValidationState) });
+    });
+
+    describe('with a real store supporting quoted triple filtering', () => {
+      let store: any;
+      beforeEach(() => {
+        store = RdfStore.createDefault();
+      });
+
+      it('should run when containing quoted triples', async() => {
+        store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+        store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('px'), DF.namedNode('o3')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+          DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+        )));
+        context = new ActionContext({
+          [KeysRdfResolveQuadPattern.source.name]: store,
+        });
+        const pattern: any = {
+          subject: DF.variable('s'),
+          predicate: DF.namedNode('p'),
+          object: DF.variable('o'),
+          graph: DF.variable('g'),
+        };
+        const { data } = await actor.run({ pattern, context });
+        expect(await arrayifyStream(data)).toEqualRdfQuadArray([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')),
+          DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')),
+          DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+            DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+          )),
+        ]);
+        expect(await new Promise(resolve => data.getProperty('metadata', resolve)))
+          .toEqual({
+            state: expect.any(MetadataValidationState),
+            cardinality: { type: 'exact', value: 3 },
+            canContainUndefs: false,
+          });
+      });
+
+      it('should run when containing quoted triples with a quoted pattern (1)', async() => {
+        store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+        store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('px'), DF.namedNode('o3')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+          DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+        )));
+        context = new ActionContext({
+          [KeysRdfResolveQuadPattern.source.name]: store,
+        });
+        const pattern: any = {
+          subject: DF.variable('s'),
+          predicate: DF.namedNode('p'),
+          object: DF.quad(
+            DF.variable('s1'), DF.variable('p1'), DF.variable('o1'),
+          ),
+          graph: DF.variable('g'),
+        };
+        const { data } = await actor.run({ pattern, context });
+        expect(await arrayifyStream(data)).toEqualRdfQuadArray([
+          DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+            DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+          )),
+        ]);
+        expect(await new Promise(resolve => data.getProperty('metadata', resolve)))
+          .toEqual({
+            state: expect.any(MetadataValidationState),
+            cardinality: { type: 'exact', value: 1 },
+            canContainUndefs: false,
+          });
+      });
+
+      it('should run when containing quoted triples with a quoted pattern (2)', async() => {
+        store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+        store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('px'), DF.namedNode('o3')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+          DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+        )));
+        context = new ActionContext({
+          [KeysRdfResolveQuadPattern.source.name]: store,
+        });
+        const pattern: any = {
+          subject: DF.variable('s'),
+          predicate: DF.variable('p'),
+          object: DF.quad(
+            DF.variable('s1'), DF.namedNode('pbx'), DF.variable('o1'),
+          ),
+          graph: DF.variable('g'),
+        };
+        const { data } = await actor.run({ pattern, context });
+        expect(await arrayifyStream(data)).toEqualRdfQuadArray([
+          DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+            DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+          )),
+        ]);
+        expect(await new Promise(resolve => data.getProperty('metadata', resolve)))
+          .toEqual({
+            state: expect.any(MetadataValidationState),
+            cardinality: { type: 'exact', value: 1 },
+            canContainUndefs: false,
+          });
+      });
+
+      it('should run when containing nested quoted triples with a nested quoted pattern', async() => {
+        store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+        store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('px'), DF.namedNode('o3')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+          DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.quad(
+            DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+          ),
+        )));
+        context = new ActionContext({
+          [KeysRdfResolveQuadPattern.source.name]: store,
+        });
+        const pattern: any = {
+          subject: DF.variable('s'),
+          predicate: DF.variable('p'),
+          object: DF.quad(
+            DF.variable('s1'), DF.namedNode('pbx'), DF.quad(
+              DF.variable('s2'), DF.variable('pcx'), DF.variable('o2'),
+            ),
+          ),
+          graph: DF.variable('g'),
+        };
+        const { data } = await actor.run({ pattern, context });
+        expect(await arrayifyStream(data)).toEqualRdfQuadArray([
+          DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+            DF.namedNode('sb3'), DF.namedNode('pbx'), DF.quad(
+              DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+            ),
+          )),
+        ]);
+        expect(await new Promise(resolve => data.getProperty('metadata', resolve)))
+          .toEqual({
+            state: expect.any(MetadataValidationState),
+            cardinality: { type: 'exact', value: 1 },
+            canContainUndefs: false,
+          });
+      });
+    });
+
+    describe('with a real store not supporting quoted triple filtering', () => {
+      let store: any;
+      beforeEach(() => {
+        store = new Store();
+      });
+
+      it('should run when containing quoted triples', async() => {
+        store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+        store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('px'), DF.namedNode('o3')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+          DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+        )));
+        context = new ActionContext({
+          [KeysRdfResolveQuadPattern.source.name]: store,
+        });
+        const pattern: any = {
+          subject: DF.variable('s'),
+          predicate: DF.namedNode('p'),
+          object: DF.variable('o'),
+          graph: DF.variable('g'),
+        };
+        const { data } = await actor.run({ pattern, context });
+        expect(await arrayifyStream(data)).toEqualRdfQuadArray([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')),
+          DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')),
+          DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+            DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+          )),
+        ]);
+        expect(await new Promise(resolve => data.getProperty('metadata', resolve)))
+          .toEqual({
+            state: expect.any(MetadataValidationState),
+            cardinality: { type: 'exact', value: 3 },
+            canContainUndefs: false,
+          });
+      });
+
+      it('should run when containing quoted triples with a quoted pattern (1)', async() => {
+        store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+        store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('px'), DF.namedNode('o3')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+          DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+        )));
+        context = new ActionContext({
+          [KeysRdfResolveQuadPattern.source.name]: store,
+        });
+        const pattern: any = {
+          subject: DF.variable('s'),
+          predicate: DF.namedNode('p'),
+          object: DF.quad(
+            DF.variable('s1'), DF.variable('p1'), DF.variable('o1'),
+          ),
+          graph: DF.variable('g'),
+        };
+        const { data } = await actor.run({ pattern, context });
+        expect(await arrayifyStream(data)).toEqualRdfQuadArray([
+          DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+            DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+          )),
+        ]);
+        expect(await new Promise(resolve => data.getProperty('metadata', resolve)))
+          .toEqual({
+            state: expect.any(MetadataValidationState),
+            cardinality: { type: 'estimate', value: 3 },
+            canContainUndefs: false,
+          });
+      });
+
+      it('should run when containing quoted triples with a quoted pattern (2)', async() => {
+        store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+        store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('px'), DF.namedNode('o3')));
+        store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.quad(
+          DF.namedNode('sa3'), DF.namedNode('pax'), DF.namedNode('oa3'),
+        )));
+        store.addQuad(DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+          DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+        )));
+        context = new ActionContext({
+          [KeysRdfResolveQuadPattern.source.name]: store,
+        });
+        const pattern: any = {
+          subject: DF.variable('s'),
+          predicate: DF.variable('p'),
+          object: DF.quad(
+            DF.variable('s1'), DF.namedNode('pbx'), DF.variable('o1'),
+          ),
+          graph: DF.variable('g'),
+        };
+        const { data } = await actor.run({ pattern, context });
+        expect(await arrayifyStream(data)).toEqualRdfQuadArray([
+          DF.quad(DF.namedNode('s4'), DF.namedNode('px'), DF.quad(
+            DF.namedNode('sb3'), DF.namedNode('pbx'), DF.namedNode('ob3'),
+          )),
+        ]);
+        expect(await new Promise(resolve => data.getProperty('metadata', resolve)))
+          .toEqual({
+            state: expect.any(MetadataValidationState),
+            cardinality: { type: 'estimate', value: 5 },
+            canContainUndefs: false,
+          });
+      });
     });
 
     it('should use countQuads for metadata if available', async() => {

--- a/packages/actor-rdf-serialize-jsonld/package.json
+++ b/packages/actor-rdf-serialize-jsonld/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/bus-rdf-serialize": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "jsonld-streaming-serializer": "^2.0.1"
+    "jsonld-streaming-serializer": "^2.1.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/actor-rdf-serialize-n3/package.json
+++ b/packages/actor-rdf-serialize-n3/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@comunica/bus-rdf-serialize": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "n3": "^1.16.3"
+    "n3": "^1.17.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/bus-optimize-query-operation/package.json
+++ b/packages/bus-optimize-query-operation/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@comunica/core": "^2.7.0",
     "@comunica/types": "^2.7.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/bus-query-operation/lib/Bindings.ts
+++ b/packages/bus-query-operation/lib/Bindings.ts
@@ -2,6 +2,7 @@ import { BindingsFactory } from '@comunica/bindings-factory';
 import type { Bindings } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import { termToString } from 'rdf-string';
+import { mapTermsNested, someTermsNested } from 'rdf-terms';
 import type { Algebra, Factory } from 'sparqlalgebrajs';
 import { Util } from 'sparqlalgebrajs';
 
@@ -25,6 +26,9 @@ export function materializeTerm(term: RDF.Term, bindings: Bindings): RDF.Term {
     if (value) {
       return value;
     }
+  }
+  if (term.termType === 'Quad' && someTermsNested(term, value => value.termType === 'Variable')) {
+    return mapTermsNested(term, subTerm => materializeTerm(subTerm, bindings));
   }
   return term;
 }

--- a/packages/bus-query-operation/package.json
+++ b/packages/bus-query-operation/package.json
@@ -39,7 +39,8 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
     "rdf-string": "^1.6.1",
-    "sparqlalgebrajs": "^4.0.5"
+    "rdf-terms": "^1.11.0",
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/bus-query-operation/test/Bindings-test.ts
+++ b/packages/bus-query-operation/test/Bindings-test.ts
@@ -116,6 +116,53 @@ describe('materializeTerm', () => {
     return expect(materializeTerm(termDefaultGraph, bindingsAC))
       .toEqual(termDefaultGraph);
   });
+
+  it('should not materialize a quoted triple without variables', () => {
+    return expect(materializeTerm(DF.quad(
+      termNamedNode,
+      termNamedNode,
+      termNamedNode,
+    ), bindingsAC))
+      .toEqual(DF.quad(
+        termNamedNode,
+        termNamedNode,
+        termNamedNode,
+      ));
+  });
+
+  it('should materialize a quoted triple with variables', () => {
+    return expect(materializeTerm(DF.quad(
+      termVariableA,
+      termNamedNode,
+      termVariableB,
+    ), bindingsAB))
+      .toEqual(DF.quad(
+        <any> valueA,
+        termNamedNode,
+        valueB,
+      ));
+  });
+
+  it('should materialize a nested quoted triple with variables', () => {
+    return expect(materializeTerm(DF.quad(
+      termVariableA,
+      termNamedNode,
+      DF.quad(
+        termVariableA,
+        termNamedNode,
+        termVariableB,
+      ),
+    ), bindingsAB))
+      .toEqual(DF.quad(
+        <any> valueA,
+        termNamedNode,
+        DF.quad(
+          <any> valueA,
+          termNamedNode,
+          valueB,
+        ),
+      ));
+  });
 });
 
 // eslint-disable-next-line mocha/max-top-level-suites

--- a/packages/bus-query-parse/package.json
+++ b/packages/bus-query-parse/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@comunica/core": "^2.7.0",
     "@rdfjs/types": "*",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/bus-rdf-resolve-quad-pattern/package.json
+++ b/packages/bus-rdf-resolve-quad-pattern/package.json
@@ -36,7 +36,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/packages/context-entries/package.json
+++ b/packages/context-entries/package.json
@@ -35,7 +35,7 @@
     "@comunica/types": "^2.7.0",
     "@rdfjs/types": "*",
     "jsonld-context-parser": "^2.2.2",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "node \"../../node_modules/typescript/bin/tsc\""

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,7 @@
     "@rdfjs/types": "*",
     "@types/yargs": "^17.0.13",
     "asynciterator": "^3.8.0",
-    "sparqlalgebrajs": "^4.0.5"
+    "sparqlalgebrajs": "^4.2.0"
   },
   "scripts": {
     "build": "npm run build:ts && npm run build:components",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8122,10 +8122,10 @@ jsonld-streaming-parser@^3.2.0:
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
-jsonld-streaming-serializer@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.0.1.tgz#b299588673df4450183e992fc34d8a8d21b50693"
-  integrity sha512-/ee/o1ZqzEaJIR70dWsMqc5ZvGV32wht4znvoGxVXtd+95vHNnQJHs9IEqm6G0tQFCNUlNSb3g62f7SK1jFNvw==
+jsonld-streaming-serializer@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz#db80d6e13d74ae5837a313123ea4d409b04df2e0"
+  integrity sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==
   dependencies:
     "@rdfjs/types" "*"
     "@types/readable-stream" "^2.3.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,20 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.1.0", "@ampproject/remapping@^2.2.0":
+"@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
   integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
   dependencies:
     "@jridgewell/gen-mapping" "^0.1.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
+"@ampproject/remapping@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
+  integrity sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
@@ -17,31 +25,38 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
+  integrity sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==
+  dependencies:
+    "@babel/highlight" "^7.22.5"
+
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.0", "@babel/compat-data@^7.20.1":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.1.tgz#f2e6ef7790d8c8dbf03d379502dcc246dcce0b30"
   integrity sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==
 
-"@babel/compat-data@^7.20.5":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.0.tgz#c241dc454e5b5917e40d37e525e2f4530c399298"
-  integrity sha512-gMuZsmsgxk/ENC3O/fRw5QY8A9/uxQbbCEypnLIiYYc/qVJtEV7ouxC3EllIIwNzMqAQee5tanFabWsUOutS7g==
+"@babel/compat-data@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.5.tgz#b1f6c86a02d85d2dd3368a2b67c09add8cd0c255"
+  integrity sha512-4Jc/YuIaYqKnDDz892kPIledykKg12Aw1PYX5i/TY28anJtacvM1Rrr8wbieB9GfEJwlzqT0hUEao0CxEebiDA==
 
 "@babel/core@^7.11.6":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.0.tgz#1341aefdcc14ccc7553fcc688dd8986a2daffc13"
-  integrity sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.22.5.tgz#d67d9747ecf26ee7ecd3ebae1ee22225fe902a89"
+  integrity sha512-SBuTAjg91A3eKOvD+bPEz3LlhHZRNu1nFOVts9lzDJTXshHTjII0BAtDS3Y2DAkdZdDKWVZGVwkDfc4Clxn1dg==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.21.0"
-    "@babel/helper-compilation-targets" "^7.20.7"
-    "@babel/helper-module-transforms" "^7.21.0"
-    "@babel/helpers" "^7.21.0"
-    "@babel/parser" "^7.21.0"
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.21.0"
-    "@babel/types" "^7.21.0"
+    "@babel/code-frame" "^7.22.5"
+    "@babel/generator" "^7.22.5"
+    "@babel/helper-compilation-targets" "^7.22.5"
+    "@babel/helper-module-transforms" "^7.22.5"
+    "@babel/helpers" "^7.22.5"
+    "@babel/parser" "^7.22.5"
+    "@babel/template" "^7.22.5"
+    "@babel/traverse" "^7.22.5"
+    "@babel/types" "^7.22.5"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -87,12 +102,12 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.21.0", "@babel/generator@^7.21.1":
-  version "7.21.1"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.1.tgz#951cc626057bc0af2c35cd23e9c64d384dea83dd"
-  integrity sha512-1lT45bAYlQhFn/BHivJs43AiW2rg3/UbLyShGfF3C0KmHvO5fSghWd5kBJy30kpRRucGzXStvnnCFniCR2kXAA==
+"@babel/generator@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.5.tgz#1e7bf768688acfb05cf30b2369ef855e82d984f7"
+  integrity sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==
   dependencies:
-    "@babel/types" "^7.21.0"
+    "@babel/types" "^7.22.5"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
@@ -122,13 +137,13 @@
     browserslist "^4.21.3"
     semver "^6.3.0"
 
-"@babel/helper-compilation-targets@^7.20.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz#a6cd33e93629f5eb473b021aac05df62c4cd09bb"
-  integrity sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==
+"@babel/helper-compilation-targets@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.5.tgz#fc7319fc54c5e2fa14b2909cf3c5fd3046813e02"
+  integrity sha512-Ji+ywpHeuqxB8WDxraCiqR0xfhYjiDE/e6k7FuIaANnoOFxAHskHChz4vA1mJC9Lbm01s1PVAGhQY4FUKSkGZw==
   dependencies:
-    "@babel/compat-data" "^7.20.5"
-    "@babel/helper-validator-option" "^7.18.6"
+    "@babel/compat-data" "^7.22.5"
+    "@babel/helper-validator-option" "^7.22.5"
     browserslist "^4.21.3"
     lru-cache "^5.1.1"
     semver "^6.3.0"
@@ -171,6 +186,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
+"@babel/helper-environment-visitor@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz#f06dd41b7c1f44e1f8da6c4055b41ab3a09a7e98"
+  integrity sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==
+
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz#41f8228ef0a6f1a036b8dfdfec7ce94f9a6bc096"
@@ -186,13 +206,13 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
-"@babel/helper-function-name@^7.21.0":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
-  integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
+"@babel/helper-function-name@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz#ede300828905bb15e582c037162f99d5183af1be"
+  integrity sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==
   dependencies:
-    "@babel/template" "^7.20.7"
-    "@babel/types" "^7.21.0"
+    "@babel/template" "^7.22.5"
+    "@babel/types" "^7.22.5"
 
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
@@ -200,6 +220,13 @@
   integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-hoist-variables@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz#c01a007dac05c085914e8fb652b339db50d823bb"
+  integrity sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==
+  dependencies:
+    "@babel/types" "^7.22.5"
 
 "@babel/helper-member-expression-to-functions@^7.18.9":
   version "7.18.9"
@@ -215,6 +242,13 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-module-imports@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz#1a8f4c9f4027d23f520bd76b364d44434a72660c"
+  integrity sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.19.6", "@babel/helper-module-transforms@^7.20.2":
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz#ac53da669501edd37e658602a21ba14c08748712"
@@ -229,19 +263,19 @@
     "@babel/traverse" "^7.20.1"
     "@babel/types" "^7.20.2"
 
-"@babel/helper-module-transforms@^7.21.0":
-  version "7.21.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz#160caafa4978ac8c00ac66636cb0fa37b024e2d2"
-  integrity sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==
+"@babel/helper-module-transforms@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.5.tgz#0f65daa0716961b6e96b164034e737f60a80d2ef"
+  integrity sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==
   dependencies:
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.20.2"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.21.2"
-    "@babel/types" "^7.21.2"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-module-imports" "^7.22.5"
+    "@babel/helper-simple-access" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
+    "@babel/template" "^7.22.5"
+    "@babel/traverse" "^7.22.5"
+    "@babel/types" "^7.22.5"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
   version "7.18.6"
@@ -254,6 +288,11 @@
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
   integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
+
+"@babel/helper-plugin-utils@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
+  integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
 
 "@babel/helper-remap-async-to-generator@^7.18.6", "@babel/helper-remap-async-to-generator@^7.18.9":
   version "7.18.9"
@@ -283,6 +322,13 @@
   dependencies:
     "@babel/types" "^7.20.2"
 
+"@babel/helper-simple-access@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz#4938357dc7d782b80ed6dbb03a0fba3d22b1d5de"
+  integrity sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.18.9":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz#fbe4c52f60518cab8140d77101f0e63a8a230684"
@@ -297,20 +343,42 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-split-export-declaration@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz#88cf11050edb95ed08d596f7a044462189127a08"
+  integrity sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==
+  dependencies:
+    "@babel/types" "^7.22.5"
+
 "@babel/helper-string-parser@^7.19.4":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
+"@babel/helper-string-parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
+  integrity sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==
 
 "@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.18.6", "@babel/helper-validator-identifier@^7.19.1":
   version "7.19.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
   integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
+"@babel/helper-validator-identifier@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
+  integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
+
 "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
+
+"@babel/helper-validator-option@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz#de52000a15a177413c8234fa3a8af4ee8102d0ac"
+  integrity sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==
 
 "@babel/helper-wrap-function@^7.18.9":
   version "7.19.0"
@@ -331,14 +399,14 @@
     "@babel/traverse" "^7.20.1"
     "@babel/types" "^7.20.0"
 
-"@babel/helpers@^7.21.0":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.21.0.tgz#9dd184fb5599862037917cdc9eecb84577dc4e7e"
-  integrity sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==
+"@babel/helpers@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.22.5.tgz#74bb4373eb390d1ceed74a15ef97767e63120820"
+  integrity sha512-pSXRmfE1vzcUIDFQcSGA5Mr+GxBV9oiRKDuDxXvWQQBCh8HoIjs/2DlDB7H8smac1IVrB9/xdXj2N3Wol9Cr+Q==
   dependencies:
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.21.0"
-    "@babel/types" "^7.21.0"
+    "@babel/template" "^7.22.5"
+    "@babel/traverse" "^7.22.5"
+    "@babel/types" "^7.22.5"
 
 "@babel/highlight@^7.18.6":
   version "7.18.6"
@@ -346,6 +414,15 @@
   integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
+"@babel/highlight@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.22.5.tgz#aa6c05c5407a67ebce408162b7ede789b4d22031"
+  integrity sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.22.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -359,10 +436,10 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.3.tgz#5358cf62e380cf69efcb87a7bb922ff88bfac6e2"
   integrity sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==
 
-"@babel/parser@^7.20.7", "@babel/parser@^7.21.0", "@babel/parser@^7.21.2":
-  version "7.21.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.2.tgz#dacafadfc6d7654c3051a66d6fe55b6cb2f2a0b3"
-  integrity sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==
+"@babel/parser@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.5.tgz#721fd042f3ce1896238cf1b341c77eb7dee7dbea"
+  integrity sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -573,11 +650,11 @@
     "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-jsx@^7.7.2":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
-  integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz#a6b68e84fb76e759fc3b93e901876ffabbe1d918"
+  integrity sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.22.5"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4", "@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
   version "7.10.4"
@@ -1000,14 +1077,14 @@
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
 
-"@babel/template@^7.20.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
-  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
+"@babel/template@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
+  integrity sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.20.7"
-    "@babel/types" "^7.20.7"
+    "@babel/code-frame" "^7.22.5"
+    "@babel/parser" "^7.22.5"
+    "@babel/types" "^7.22.5"
 
 "@babel/traverse@^7.12.5", "@babel/traverse@^7.19.0", "@babel/traverse@^7.19.1", "@babel/traverse@^7.20.1", "@babel/traverse@^7.7.2":
   version "7.20.1"
@@ -1025,19 +1102,19 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2":
-  version "7.21.2"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.21.2.tgz#ac7e1f27658750892e815e60ae90f382a46d8e75"
-  integrity sha512-ts5FFU/dSUPS13tv8XiEObDu9K+iagEKME9kAbaP7r0Y9KtZJZ+NGndDvWoRAYNpeWafbpFeki3q9QoMD6gxyw==
+"@babel/traverse@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.5.tgz#44bd276690db6f4940fdb84e1cb4abd2f729ccd1"
+  integrity sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==
   dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.21.1"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.21.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.21.2"
-    "@babel/types" "^7.21.2"
+    "@babel/code-frame" "^7.22.5"
+    "@babel/generator" "^7.22.5"
+    "@babel/helper-environment-visitor" "^7.22.5"
+    "@babel/helper-function-name" "^7.22.5"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.5"
+    "@babel/parser" "^7.22.5"
+    "@babel/types" "^7.22.5"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -1050,13 +1127,13 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.20.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2":
-  version "7.21.2"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.2.tgz#92246f6e00f91755893c2876ad653db70c8310d1"
-  integrity sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==
+"@babel/types@^7.22.5":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.5.tgz#cd93eeaab025880a3a47ec881f4b096a5b786fbe"
+  integrity sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==
   dependencies:
-    "@babel/helper-string-parser" "^7.19.4"
-    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/helper-string-parser" "^7.22.5"
+    "@babel/helper-validator-identifier" "^7.22.5"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1064,7 +1141,7 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bergos/jsonparse@^1.4.0":
+"@bergos/jsonparse@^1.4.0", "@bergos/jsonparse@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@bergos/jsonparse/-/jsonparse-1.4.1.tgz#560e7125f65d0ad6b96dfe1c0d5da3115b9f8c59"
   integrity sha512-vXIT0nzZGX/+yMD5bx2VhTzc92H55tPoehh1BW/FZHOndWGFddrH3MAfdx39FRc7irABirW6EQaGxIJYV6CGuA==
@@ -1098,9 +1175,9 @@
     eslint-visitor-keys "^3.3.0"
 
 "@eslint-community/regexpp@^4.4.0":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.4.1.tgz#087cb8d9d757bb22e9c9946c9c0c2bf8806830f1"
-  integrity sha512-BISJ6ZE4xQsuL/FmsyRaiffpq977bMlsKfGHTQrOGFErfByxIe6iZTxPf/00Zon9b9a7iUykfQwejN3s2ZW/Bw==
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.5.1.tgz#cdd35dce4fa1a89a4fd42b1599eb35b3af408884"
+  integrity sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==
 
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
@@ -1434,7 +1511,15 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.15", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.15", "@jridgewell/trace-mapping@^0.3.17":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz#25783b2086daf6ff1dcb53c9249ae480e4dd4cd6"
+  integrity sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.14", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
   integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
@@ -2076,9 +2161,9 @@
     xmlchars "^2.2.0"
 
 "@rushstack/eslint-patch@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
-  integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.3.1.tgz#edbb85ff95f3be41eaa70c6d6ad6d8ba0a9c7e46"
+  integrity sha512-RkmuBcqiNioeeBKbgzMlOdreUkJfYaSjwgx9XDgGGpjvWgyaxWvDmZVSN9CS6LjEASadhgPv2BcFp+SeouWXXA==
 
 "@sigstore/protobuf-specs@^0.1.0":
   version "0.1.0"
@@ -2114,19 +2199,19 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.3.0.tgz#0ec9264cf54a527671d990eb874e030b55b70dcc"
   integrity sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==
 
-"@sinonjs/commons@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-2.0.0.tgz#fd4ca5b063554307e8327b4564bd56d3b73924a3"
-  integrity sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==
+"@sinonjs/commons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.0.tgz#beb434fe875d965265e04722ccfc21df7f755d72"
+  integrity sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==
   dependencies:
     type-detect "4.0.8"
 
 "@sinonjs/fake-timers@^10.0.2":
-  version "10.0.2"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz#d10549ed1f423d80639c528b6c7f5a1017747d0c"
-  integrity sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-10.2.0.tgz#b3e322a34c5f26e3184e7f6115695f299c1b1194"
+  integrity sha512-OPwQlEdg40HAj5KNF8WW6q2KG4Z+cBCZb3m4ninfTZKaBmbIJodviQsDBoYMPHkOyJJMHnOJo5j2+LKDOhOACg==
   dependencies:
-    "@sinonjs/commons" "^2.0.0"
+    "@sinonjs/commons" "^3.0.0"
 
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.0"
@@ -2295,9 +2380,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^29.4.0":
-  version "29.4.0"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.4.0.tgz#a8444ad1704493e84dbf07bb05990b275b3b9206"
-  integrity sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==
+  version "29.5.2"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.2.tgz#86b4afc86e3a8f3005b297ed8a72494f89e6395b"
+  integrity sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
@@ -2371,9 +2456,9 @@
   integrity sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==
 
 "@types/node@^18.14.6":
-  version "18.14.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.6.tgz#ae1973dd2b1eeb1825695bb11ebfb746d27e3e93"
-  integrity sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==
+  version "18.16.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.18.tgz#85da09bafb66d4bc14f7c899185336d0c1736390"
+  integrity sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -2476,14 +2561,14 @@
     "@types/yargs-parser" "*"
 
 "@typescript-eslint/eslint-plugin@^5.43.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz#52c8a7a4512f10e7249ca1e2e61f81c62c34365c"
-  integrity sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.11.tgz#8d466aa21abea4c3f37129997b198d141f09e76f"
+  integrity sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==
   dependencies:
     "@eslint-community/regexpp" "^4.4.0"
-    "@typescript-eslint/scope-manager" "5.57.0"
-    "@typescript-eslint/type-utils" "5.57.0"
-    "@typescript-eslint/utils" "5.57.0"
+    "@typescript-eslint/scope-manager" "5.59.11"
+    "@typescript-eslint/type-utils" "5.59.11"
+    "@typescript-eslint/utils" "5.59.11"
     debug "^4.3.4"
     grapheme-splitter "^1.0.4"
     ignore "^5.2.0"
@@ -2492,13 +2577,13 @@
     tsutils "^3.21.0"
 
 "@typescript-eslint/parser@^5.43.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.57.0.tgz#f675bf2cd1a838949fd0de5683834417b757e4fa"
-  integrity sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.43.0.tgz#9c86581234b88f2ba406f0b99a274a91c11630fd"
+  integrity sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.57.0"
-    "@typescript-eslint/types" "5.57.0"
-    "@typescript-eslint/typescript-estree" "5.57.0"
+    "@typescript-eslint/scope-manager" "5.43.0"
+    "@typescript-eslint/types" "5.43.0"
+    "@typescript-eslint/typescript-estree" "5.43.0"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.42.1":
@@ -2509,21 +2594,29 @@
     "@typescript-eslint/types" "5.42.1"
     "@typescript-eslint/visitor-keys" "5.42.1"
 
-"@typescript-eslint/scope-manager@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.57.0.tgz#79ccd3fa7bde0758059172d44239e871e087ea36"
-  integrity sha512-NANBNOQvllPlizl9LatX8+MHi7bx7WGIWYjPHDmQe5Si/0YEYfxSljJpoTyTWFTgRy3X8gLYSE4xQ2U+aCozSw==
+"@typescript-eslint/scope-manager@5.43.0":
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz#566e46303392014d5d163704724872e1f2dd3c15"
+  integrity sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==
   dependencies:
-    "@typescript-eslint/types" "5.57.0"
-    "@typescript-eslint/visitor-keys" "5.57.0"
+    "@typescript-eslint/types" "5.43.0"
+    "@typescript-eslint/visitor-keys" "5.43.0"
 
-"@typescript-eslint/type-utils@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.57.0.tgz#98e7531c4e927855d45bd362de922a619b4319f2"
-  integrity sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==
+"@typescript-eslint/scope-manager@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.59.11.tgz#5d131a67a19189c42598af9fb2ea1165252001ce"
+  integrity sha512-dHFOsxoLFtrIcSj5h0QoBT/89hxQONwmn3FOQ0GOQcLOOXm+MIrS8zEAhs4tWl5MraxCY3ZJpaXQQdFMc2Tu+Q==
   dependencies:
-    "@typescript-eslint/typescript-estree" "5.57.0"
-    "@typescript-eslint/utils" "5.57.0"
+    "@typescript-eslint/types" "5.59.11"
+    "@typescript-eslint/visitor-keys" "5.59.11"
+
+"@typescript-eslint/type-utils@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.59.11.tgz#5eb67121808a84cb57d65a15f48f5bdda25f2346"
+  integrity sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.59.11"
+    "@typescript-eslint/utils" "5.59.11"
     debug "^4.3.4"
     tsutils "^3.21.0"
 
@@ -2532,10 +2625,15 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.42.1.tgz#0d4283c30e9b70d2aa2391c36294413de9106df2"
   integrity sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==
 
-"@typescript-eslint/types@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.57.0.tgz#727bfa2b64c73a4376264379cf1f447998eaa132"
-  integrity sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==
+"@typescript-eslint/types@5.43.0":
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.43.0.tgz#e4ddd7846fcbc074325293515fa98e844d8d2578"
+  integrity sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==
+
+"@typescript-eslint/types@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.59.11.tgz#1a9018fe3c565ba6969561f2a49f330cf1fe8db1"
+  integrity sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==
 
 "@typescript-eslint/typescript-estree@5.42.1", "@typescript-eslint/typescript-estree@^5.11.0":
   version "5.42.1"
@@ -2550,30 +2648,43 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.57.0.tgz#ebcd0ee3e1d6230e888d88cddf654252d41e2e40"
-  integrity sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==
+"@typescript-eslint/typescript-estree@5.43.0":
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz#b6883e58ba236a602c334be116bfc00b58b3b9f2"
+  integrity sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==
   dependencies:
-    "@typescript-eslint/types" "5.57.0"
-    "@typescript-eslint/visitor-keys" "5.57.0"
+    "@typescript-eslint/types" "5.43.0"
+    "@typescript-eslint/visitor-keys" "5.43.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.57.0.tgz#eab8f6563a2ac31f60f3e7024b91bf75f43ecef6"
-  integrity sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==
+"@typescript-eslint/typescript-estree@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.11.tgz#b2caaa31725e17c33970c1197bcd54e3c5f42b9f"
+  integrity sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.11"
+    "@typescript-eslint/visitor-keys" "5.59.11"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.59.11.tgz#9dbff49dc80bfdd9289f9f33548f2e8db3c59ba1"
+  integrity sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@types/json-schema" "^7.0.9"
     "@types/semver" "^7.3.12"
-    "@typescript-eslint/scope-manager" "5.57.0"
-    "@typescript-eslint/types" "5.57.0"
-    "@typescript-eslint/typescript-estree" "5.57.0"
+    "@typescript-eslint/scope-manager" "5.59.11"
+    "@typescript-eslint/types" "5.59.11"
+    "@typescript-eslint/typescript-estree" "5.59.11"
     eslint-scope "^5.1.1"
     semver "^7.3.7"
 
@@ -2599,12 +2710,20 @@
     "@typescript-eslint/types" "5.42.1"
     eslint-visitor-keys "^3.3.0"
 
-"@typescript-eslint/visitor-keys@5.57.0":
-  version "5.57.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.57.0.tgz#e2b2f4174aff1d15eef887ce3d019ecc2d7a8ac1"
-  integrity sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==
+"@typescript-eslint/visitor-keys@5.43.0":
+  version "5.43.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz#cbbdadfdfea385310a20a962afda728ea106befa"
+  integrity sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==
   dependencies:
-    "@typescript-eslint/types" "5.57.0"
+    "@typescript-eslint/types" "5.43.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.59.11":
+  version "5.59.11"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.11.tgz#dca561ddad169dc27d62396d64f45b2d2c3ecc56"
+  integrity sha512-KGYniTGG3AMTuKF9QBD7EIrvufkB6O6uX3knP73xbKLMpH+QRPcgnCxjWXSHjMRuOxFLovljqQgQpR0c7GvjoA==
+  dependencies:
+    "@typescript-eslint/types" "5.59.11"
     eslint-visitor-keys "^3.3.0"
 
 "@vue/compiler-core@3.2.42":
@@ -4396,11 +4515,6 @@ core-util-is@1.0.2:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
 
-core-util-is@~1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
-  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
 cors@^2.8.5, cors@~2.8.5:
   version "2.8.5"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
@@ -5718,6 +5832,26 @@ fetch-sparql-endpoint@^3.3.2:
     sparqlxml-parse "^2.1.1"
     stream-to-string "^1.1.0"
 
+fetch-sparql-endpoint@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.3.3.tgz#7b1fda7f980564fd62945ca880664d68c6994b93"
+  integrity sha512-5ZNesFhFMcsEiSaCyg36L5VU7YP7xMJogc5i0n00nFNFZzrfGJ4Cm8LGrzXI6eySkb7QmaRyNWJGk5btAOjniA==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/readable-stream" "^2.3.11"
+    "@types/sparqljs" "^3.1.3"
+    abort-controller "^3.0.0"
+    cross-fetch "^3.0.6"
+    is-stream "^2.0.0"
+    minimist "^1.2.0"
+    n3 "^1.6.3"
+    rdf-string "^1.6.0"
+    readable-web-to-node-stream "^3.0.2"
+    sparqljs "^3.1.2"
+    sparqljson-parse "^2.2.0"
+    sparqlxml-parse "^2.1.1"
+    stream-to-string "^1.1.0"
+
 figures@3.2.0, figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -6363,12 +6497,12 @@ got@^12.1.0:
     p-cancelable "^3.0.0"
     responselike "^3.0.0"
 
-graceful-fs@4.2.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@4.2.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@4.2.11:
+graceful-fs@4.2.11, graceful-fs@^4.2.10:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -6794,7 +6928,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7287,12 +7421,7 @@ is2@^2.0.6:
     ip-regex "^4.1.0"
     is-url "^1.2.4"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
-
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
@@ -8446,10 +8575,10 @@ lowercase-keys@^3.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
   integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
 
-lru-cache@*, lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
-  version "7.14.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
-  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
+lru-cache@*, lru-cache@^9.1.1, lru-cache@^9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-9.1.2.tgz#255fdbc14b75589d6d0e73644ca167a8db506835"
+  integrity sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -8473,10 +8602,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^9.1.1, lru-cache@^9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-9.1.2.tgz#255fdbc14b75589d6d0e73644ca167a8db506835"
-  integrity sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==
+lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
+  version "7.14.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.14.1.tgz#8da8d2f5f59827edb388e63e459ac23d6d408fea"
+  integrity sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==
 
 lunr@^2.3.9:
   version "2.3.9"
@@ -9040,6 +9169,14 @@ n3@^1.16.3:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.16.3.tgz#d339dca14c79648b1595a3252c5410b800b896f8"
   integrity sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==
+  dependencies:
+    queue-microtask "^1.1.2"
+    readable-stream "^4.0.0"
+
+n3@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-1.17.0.tgz#224d87e235e91e2d3e3fea04043ed34b6524a8ac"
+  integrity sha512-dYdkyUM4tMWHSEf9xMDPiBjOJc+rcjZHtN5cJJGcvAwOWTjE9u1i28sDFWALTwyROvsuUKuLohrz7VFaJbhiDw==
   dependencies:
     queue-microtask "^1.1.2"
     readable-stream "^4.0.0"
@@ -10147,11 +10284,6 @@ proc-log@^3.0.0:
   resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-3.0.0.tgz#fb05ef83ccd64fd7b20bbe9c8c1070fc08338dd8"
   integrity sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==
 
-process-nextick-args@~2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
-  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
-
 process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
@@ -10293,9 +10425,9 @@ pupa@^3.1.0:
     escape-goat "^4.0.0"
 
 pure-rand@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.0.tgz#701996ceefa253507923a0e864c17ab421c04a7c"
-  integrity sha512-rLSBxJjP+4DQOgcJAx6RZHT2he2pkhQdSnofG5VWyVl6GRq/K02ISOuOLcsMOrtKDIJb8JN2zm3FFzWNbezdPw==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.2.tgz#a9c2ddcae9b68d736a8163036f088a2781c8b306"
+  integrity sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==
 
 qjobs@^1.2.0:
   version "1.2.0"
@@ -10413,6 +10545,13 @@ rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1:
   dependencies:
     "@rdfjs/types" "*"
 
+rdf-data-factory@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz#d47550d2649d0d64f8cae3fcc9efae7a8a895d9a"
+  integrity sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==
+  dependencies:
+    "@rdfjs/types" "*"
+
 rdf-isomorphic@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz#cd6d433cd85bf79d903d5f0fdeea42a40eb27265"
@@ -10494,6 +10633,25 @@ rdf-store-stream@^1.1.0, rdf-store-stream@^1.3.1:
     "@rdfjs/types" "*"
     n3 "^1.11.1"
 
+rdf-store-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz#941932d4f20859a93e495586d2bd501aa0408f2f"
+  integrity sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-stores "^1.0.0"
+
+rdf-stores@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-stores/-/rdf-stores-1.0.0.tgz#1689bd669853bda857620d0db32f3b59940db208"
+  integrity sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==
+  dependencies:
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.0"
+    rdf-data-factory "^1.1.1"
+    rdf-string "^1.6.2"
+    rdf-terms "^1.9.1"
+
 rdf-streaming-store@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/rdf-streaming-store/-/rdf-streaming-store-1.1.0.tgz#a00be02eeb1616e577a095dad9afe96d9106fcfa"
@@ -10523,13 +10681,31 @@ rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-string@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.2.tgz#f709845d50968c6ea9a5273b64a5e1efd0d5877a"
-  integrity sha512-tr0aStKYRmT6ShmGsA4HikIn6O3ZkCBSLWsRbeKhlPVPZodl0QNuws6HuJdD1rUyo9+MNiDw+3wvFSUz6Iwv/g==
+rdf-string@^1.6.2, rdf-string@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.3.tgz#5c3173fad13e6328698277fb8ff151e3423282ab"
+  integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
   dependencies:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
+
+rdf-terms@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.10.0.tgz#28288657baf168f0294b67d8bc5374e6fa4d7476"
+  integrity sha512-7arMnF4ds8SySRE59VkOmx528YBi1KyZn2NEZJZmvcwh48u4z2zG8VBKQ+XAQtWbmaI4jSDcu5UmuSh6ogVMlg==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    rdf-string "^1.6.0"
+
+rdf-terms@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.11.0.tgz#0c2e3a2b43f1042959c9263af27dab08dc4b084d"
+  integrity sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    rdf-string "^1.6.0"
 
 rdf-terms@^1.7.0, rdf-terms@^1.9.1:
   version "1.9.1"
@@ -10591,10 +10767,10 @@ rdf-test-suite@^1.18.0:
     stream-to-string "^1.1.0"
     streamify-string "^1.0.1"
 
-rdf-test-suite@^1.24.0:
-  version "1.24.0"
-  resolved "https://registry.yarnpkg.com/rdf-test-suite/-/rdf-test-suite-1.24.0.tgz#c3b82079ab11a7e808cb64871b3bdbe37258c04c"
-  integrity sha512-CfzeMvAYveqBoCptLTDnEeJ6IBLCtf8mLQ7OAK+k6QY/k7R3Z8KfbOT+lekkB8EHP9cXk1LF5y9pfMO6U6swwQ==
+rdf-test-suite@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/rdf-test-suite/-/rdf-test-suite-1.25.0.tgz#26a21f9e44ad6cd907eb762c8db928c753c96351"
+  integrity sha512-rfjHWSWqUpZ02kuD33Mol6qXpTqhzqVErFsehQoXoWhmdcQODZSyPZQKKItOkvSHhTXBUIs7BfezwNwASFBetQ==
   dependencies:
     "@rdfjs/types" "*"
     "@types/json-stable-stringify" "^1.0.32"
@@ -10608,7 +10784,7 @@ rdf-test-suite@^1.24.0:
     jsonld-streaming-parser "^3.2.0"
     log-symbols "^4.0.0"
     minimist "^1.2.0"
-    n3 "^1.11.1"
+    n3 "^1.17.0"
     rdf-data-factory "^1.1.0"
     rdf-isomorphic "^1.3.0"
     rdf-literal "^1.3.0"
@@ -10619,8 +10795,8 @@ rdf-test-suite@^1.24.0:
     rdfxml-streaming-parser "^2.0.0"
     readable-web-to-node-stream "^3.0.2"
     relative-to-absolute-iri "^1.0.6"
-    sparqljson-parse "^2.0.1"
-    sparqlxml-parse "^2.0.1"
+    sparqljson-parse "^2.2.0"
+    sparqlxml-parse "^2.1.1"
     stream-to-string "^1.1.0"
     streamify-string "^1.0.1"
 
@@ -10754,39 +10930,7 @@ readable-stream-node-to-web@^1.0.1:
   resolved "https://registry.yarnpkg.com/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz#8b7614faa1465ebfa0da9b9ca6303fa27073b7cf"
   integrity sha512-OGzi2VKLa8H259kAx7BIwuRrXHGcxeHj4RdASSgEGBP9Q2wowdPvBc65upF4Q9O05qWgKqBw1+9PiLTtObl7uQ==
 
-readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
-  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@~2.3.6:
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
-  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.2.0.tgz#a7ef523d3b39e4962b0db1a1af22777b10eeca46"
-  integrity sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==
-  dependencies:
-    abort-controller "^3.0.0"
-    buffer "^6.0.3"
-    events "^3.3.0"
-    process "^0.11.10"
-
-readable-stream@^4.3.0:
+readable-stream@3, readable-stream@4.3.0, readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0, readable-stream@^3.6.0, readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.2.0, readable-stream@^4.3.0, readable-stream@~1.0.2, readable-stream@~2.3.6:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.3.0.tgz#0914d0c72db03b316c9733bb3461d64a3cc50cba"
   integrity sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==
@@ -10795,16 +10939,6 @@ readable-stream@^4.3.0:
     buffer "^6.0.3"
     events "^3.3.0"
     process "^0.11.10"
-
-readable-stream@~1.0.2:
-  version "1.0.34"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
-  integrity sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-web-to-node-stream@^3.0.2:
   version "3.0.2"
@@ -11035,9 +11169,9 @@ resolve-url@^0.2.1:
   integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
 
 resolve.exports@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.1.tgz#cee884cd4e3f355660e501fa3276b27d7ffe5a20"
-  integrity sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
+  integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.1"
@@ -11153,7 +11287,7 @@ rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -11646,7 +11780,7 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.3:
+sparqlalgebrajs@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.0.4.tgz#803e29fc780d5f54235b791645bc73a016831703"
   integrity sha512-21t8cAyc6MEF1YpwU16FvtK963NNy1zwBAImki5ay5aJQzYAbmPcIzw1pz9x89YXuLcTW5QgXOSlQHDKjxElaA==
@@ -11660,10 +11794,10 @@ sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.3:
     rdf-string "^1.6.0"
     sparqljs "^3.6.1"
 
-sparqlalgebrajs@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz#054cd4dbbe9c2e2ecc345948fd5a7cfad1d475a4"
-  integrity sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==
+sparqlalgebrajs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.2.0.tgz#b70945bdd2ab2897a0bc22adb804dd1a2b0ec98c"
+  integrity sha512-tdlJdrvgQqgx9zubcl9iiyCxMOp4qRT2fs1Sne8X35QTm1Pj2ulB+gGEHunJJnw5FW7Uhtmw7J3px0sCmgJSbw==
   dependencies:
     "@rdfjs/types" "*"
     "@types/sparqljs" "^3.1.3"
@@ -11672,12 +11806,13 @@ sparqlalgebrajs@^4.0.5:
     rdf-data-factory "^1.1.0"
     rdf-isomorphic "^1.3.0"
     rdf-string "^1.6.0"
-    sparqljs "^3.6.1"
+    rdf-terms "^1.10.0"
+    sparqljs "^3.7.1"
 
-sparqlee@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-2.3.1.tgz#aaf3bdfc4a7b2114821662538fc44c5abdaafd71"
-  integrity sha512-ODJ721Vp/7H91VN46nx7CVmzfsoE8qMMh4dDNVqhOSUhqMBf/MhlYf88E+gONM0mLFId/1F+GF+CapZTVup/Rw==
+sparqlee@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-3.0.0.tgz#3181ed386ffd16afa7b6c93487b114efcf5aaa7a"
+  integrity sha512-/SCQekZMJaTVANUelbXFfZGrmzFViLO4DieTtAI0J32kE6CobxtwQf4prfFSjRrT43vitaUuLgcuCSlpQWNycQ==
   dependencies:
     "@comunica/bindings-factory" "^2.0.1"
     "@rdfjs/types" "^1.1.0"
@@ -11687,11 +11822,11 @@ sparqlee@^2.3.0:
     bignumber.js "^9.0.1"
     hash.js "^1.1.7"
     lru-cache "^6.0.0"
-    rdf-data-factory "^1.1.0"
-    rdf-string "^1.6.0"
+    rdf-data-factory "^1.1.2"
+    rdf-string "^1.6.3"
     relative-to-absolute-iri "^1.0.6"
     spark-md5 "^3.0.1"
-    sparqlalgebrajs "^4.0.3"
+    sparqlalgebrajs "^4.2.0"
     uuid "^8.0.0"
 
 sparqljs@^3.1.2, sparqljs@^3.6.1:
@@ -11700,6 +11835,13 @@ sparqljs@^3.1.2, sparqljs@^3.6.1:
   integrity sha512-4QoI3cMywOio8mtTLa3Rl85XI7UBvQRm1CbzbHEQ7C6AN6ldBFsSS96vkhcKCQKPl0eDTmCXsi+50234+1cOpA==
   dependencies:
     rdf-data-factory "^1.1.1"
+
+sparqljs@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.1.tgz#5d121895d491d50214f2e38f2885a3a935b6c093"
+  integrity sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==
+  dependencies:
+    rdf-data-factory "^1.1.2"
 
 sparqljson-parse@^2.0.0, sparqljson-parse@^2.0.1, sparqljson-parse@^2.1.0:
   version "2.1.2"
@@ -11710,6 +11852,17 @@ sparqljson-parse@^2.0.0, sparqljson-parse@^2.0.1, sparqljson-parse@^2.1.0:
     "@types/readable-stream" "^2.3.13"
     buffer "^6.0.3"
     jsonparse "^1.3.1"
+    rdf-data-factory "^1.1.0"
+    readable-stream "^4.0.0"
+
+sparqljson-parse@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz#58c788e896f7d2c0d3079452d8812943049d4a7e"
+  integrity sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==
+  dependencies:
+    "@bergos/jsonparse" "^1.4.1"
+    "@rdfjs/types" "*"
+    "@types/readable-stream" "^2.3.13"
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
@@ -11989,24 +12142,12 @@ string.prototype.trimstart@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string_decoder@^1.1.1, string_decoder@^1.3.0:
+string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-  integrity sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -12325,9 +12466,9 @@ truncate-utf8-bytes@^1.0.0:
     utf8-byte-length "^1.0.1"
 
 ts-jest@^29.0.5:
-  version "29.0.5"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.0.5.tgz#c5557dcec8fe434fcb8b70c3e21c6b143bfce066"
-  integrity sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==
+  version "29.1.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.0.tgz#4a9db4104a49b76d2b368ea775b6c9535c603891"
+  integrity sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"
@@ -12710,11 +12851,6 @@ utf8-byte-length@^1.0.1, utf8-byte-length@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
   integrity sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==
-
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 util@^0.12.0, util@^0.12.4:
   version "0.12.5"
@@ -13273,9 +13409,9 @@ yargs@^15.0.0:
     yargs-parser "^18.1.2"
 
 yargs@^17.3.1:
-  version "17.7.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
-  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
This implements full RDF-star and SPARQL-star support according to the RDF-star CG report: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html

All spec tests (SPARQL-syntax and SPARQL-eval) pass.

Note that SPARQL-star support is enabled by default. Given the fact that quoted triples support will land in RDF-1.2, I don't see much value in hiding it behind a feature flag at this stage.

The plan is to update quoted triples support to align with the decisions of the RDF-star WG, but I doubt there will be significant changes wrt to the CG report.

This was partially based on @jeswr's work in #1122.