### PR TITLE
Turn on `strictFunctionTypes`

### DIFF
--- a/packages/actor-http-fetch/lib/ActorHttpFetch.ts
+++ b/packages/actor-http-fetch/lib/ActorHttpFetch.ts
@@ -41,9 +41,9 @@ export class ActorHttpFetch extends ActorHttp {
    * @param retryDelay Time in milliseconds to wait between retries
    * @returns a fetch `Response` object
    */
-  private static async getResponse(
-    fetchFn: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>,
-    requestInput: RequestInfo | URL,
+  private static async getResponse<Input extends RequestInfo | URL>(
+    fetchFn: (input: Input, init?: RequestInit | undefined) => Promise<Response>,
+    requestInput: Input,
     requestInit: RequestInit,
     retryCount: number,
     retryDelay: number,

--- a/packages/actor-query-operation-nop/lib/ActorQueryOperationNop.ts
+++ b/packages/actor-query-operation-nop/lib/ActorQueryOperationNop.ts
@@ -4,6 +4,7 @@ import { ActorQueryOperationTypedMediated } from '@comunica/bus-query-operation'
 import type { IActorTest } from '@comunica/core';
 import { MetadataValidationState } from '@comunica/metadata';
 import type { IActionContext, IQueryOperationResult } from '@comunica/types';
+import type * as RDF from '@rdfjs/types';
 import { SingletonIterator } from 'asynciterator';
 import type { Algebra } from 'sparqlalgebrajs';
 
@@ -23,7 +24,7 @@ export class ActorQueryOperationNop extends ActorQueryOperationTypedMediated<Alg
 
   public async runOperation(operation: Algebra.Nop, context: IActionContext): Promise<IQueryOperationResult> {
     return {
-      bindingsStream: new SingletonIterator(BF.bindings()),
+      bindingsStream: new SingletonIterator<RDF.Bindings>(BF.bindings()),
       metadata: () => Promise.resolve({
         state: new MetadataValidationState(),
         cardinality: { type: 'exact', value: 1 },

--- a/packages/actor-query-operation-path-zero-or-one/lib/ActorQueryOperationPathZeroOrOne.ts
+++ b/packages/actor-query-operation-path-zero-or-one/lib/ActorQueryOperationPathZeroOrOne.ts
@@ -4,9 +4,8 @@ import type { IActorQueryOperationTypedMediatedArgs } from '@comunica/bus-query-
 import { ActorQueryOperation } from '@comunica/bus-query-operation';
 import { MetadataValidationState } from '@comunica/metadata';
 import type { Bindings, IQueryOperationResult, IActionContext, BindingsStream } from '@comunica/types';
-import {
-  SingletonIterator, UnionIterator,
-} from 'asynciterator';
+import type * as RDF from '@rdfjs/types';
+import { SingletonIterator, UnionIterator } from 'asynciterator';
 import { Algebra } from 'sparqlalgebrajs';
 
 const BF = new BindingsFactory();
@@ -33,7 +32,7 @@ export class ActorQueryOperationPathZeroOrOne extends ActorAbstractPath {
       operation.subject.equals(operation.object)) {
       return {
         type: 'bindings',
-        bindingsStream: new SingletonIterator(BF.bindings()),
+        bindingsStream: new SingletonIterator<RDF.Bindings>(BF.bindings()),
         metadata: () => Promise.resolve({
           state: new MetadataValidationState(),
           cardinality: { type: 'exact', value: 1 },

--- a/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
+++ b/packages/actor-query-operation-service/lib/ActorQueryOperationService.ts
@@ -5,6 +5,7 @@ import { KeysInitQuery, KeysRdfResolveQuadPattern } from '@comunica/context-entr
 import type { IActorTest } from '@comunica/core';
 import { MetadataValidationState } from '@comunica/metadata';
 import type { IActionContext, IQueryOperationResult, IQueryOperationResultBindings } from '@comunica/types';
+import type * as RDF from '@rdfjs/types';
 import { SingletonIterator } from 'asynciterator';
 import type { Algebra } from 'sparqlalgebrajs';
 
@@ -49,7 +50,7 @@ export class ActorQueryOperationService extends ActorQueryOperationTypedMediated
       if (operation.silent) {
         // Emit a single empty binding
         output = {
-          bindingsStream: new SingletonIterator(BF.bindings()),
+          bindingsStream: new SingletonIterator<RDF.Bindings>(BF.bindings()),
           type: 'bindings',
           metadata: async() => ({
             state: new MetadataValidationState(),

--- a/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
+++ b/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
@@ -22,7 +22,8 @@ import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { wrap } from 'asynciterator';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
-import type { IUpdateTypes } from 'fetch-sparql-endpoint';
+import type { IUpdateTypes, IBindings } from 'fetch-sparql-endpoint';
+import type { Quad } from 'rdf-data-factory';
 import { DataFactory } from 'rdf-data-factory';
 import { Factory, toSparql, Util, Algebra } from 'sparqlalgebrajs';
 import { LazyCardinalityIterator } from './LazyCardinalityIterator';
@@ -154,9 +155,9 @@ export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
       this.endpointFetcher.fetchTriples(endpoint, query) :
       this.endpointFetcher.fetchBindings(endpoint, query);
 
-    const stream = wrap<any>(inputStream, { autoStart: false }).map(rawData => quads ?
-      rawData :
-      BF.bindings(Object.entries(rawData)
+    const stream = wrap<Quad | IBindings>(inputStream, { autoStart: false }).map(rawData => quads ?
+      <Quad> rawData :
+      BF.bindings(Object.entries(<IBindings> rawData)
         .map(([ key, value ]: [string, RDF.Term]) => [ DF.variable(key.slice(1)), value ])));
 
     const resultStream = new LazyCardinalityIterator(stream);

--- a/packages/actor-query-operation-update-deleteinsert/lib/ActorQueryOperationUpdateDeleteInsert.ts
+++ b/packages/actor-query-operation-update-deleteinsert/lib/ActorQueryOperationUpdateDeleteInsert.ts
@@ -39,7 +39,7 @@ export class ActorQueryOperationUpdateDeleteInsert extends ActorQueryOperationTy
     const whereBindings: BindingsStream = operation.where ?
       ActorQueryOperation.getSafeBindings(await this.mediatorQueryOperation
         .mediate({ operation: operation.where, context })).bindingsStream :
-      new ArrayIterator([ BF.bindings() ], { autoStart: false });
+      new ArrayIterator<RDF.Bindings>([ BF.bindings() ], { autoStart: false });
 
     // Construct triples using the result based on the pattern.
     let quadStreamInsert: AsyncIterator<RDF.Quad> | undefined;

--- a/packages/actor-query-result-serialize-sparql-xml/lib/XmlSerializer.ts
+++ b/packages/actor-query-result-serialize-sparql-xml/lib/XmlSerializer.ts
@@ -62,13 +62,14 @@ export class XmlSerializer {
   }
 
   private escape(text: string): string {
-    return text.replace(/["&'<>]/gu, (char: '"' | '&' | '\'' | '<' | '>') => {
+    return text.replace(/["&'<>]/gu, (char: string): string => {
       switch (char) {
         case '<': return '&lt;';
         case '>': return '&gt;';
         case '&': return '&amp;';
         case '\'': return '&apos;';
         case '"': return '&quot;';
+        default: throw new Error(`Trying to escape an unexpected character: ${char}`);
       }
     });
   }

--- a/packages/actor-rdf-join-inner-multi-empty/lib/ActorRdfJoinMultiEmpty.ts
+++ b/packages/actor-rdf-join-inner-multi-empty/lib/ActorRdfJoinMultiEmpty.ts
@@ -3,6 +3,7 @@ import { ActorRdfJoin } from '@comunica/bus-rdf-join';
 import type { IMediatorTypeJoinCoefficients } from '@comunica/mediatortype-join-coefficients';
 import { MetadataValidationState } from '@comunica/metadata';
 import type { MetadataBindings } from '@comunica/types';
+import type * as RDF from '@rdfjs/types';
 import { ArrayIterator } from 'asynciterator';
 
 /**
@@ -33,7 +34,7 @@ export class ActorRdfJoinMultiEmpty extends ActorRdfJoin {
 
     return {
       result: {
-        bindingsStream: new ArrayIterator([], { autoStart: false }),
+        bindingsStream: new ArrayIterator<RDF.Bindings>([], { autoStart: false }),
         metadata: async() => ({
           state: new MetadataValidationState(),
           cardinality: { type: 'exact', value: 0 },

--- a/packages/actor-rdf-join-inner-none/lib/ActorRdfJoinNone.ts
+++ b/packages/actor-rdf-join-inner-none/lib/ActorRdfJoinNone.ts
@@ -3,6 +3,7 @@ import type { IActionRdfJoin, IActorRdfJoinOutputInner, IActorRdfJoinArgs } from
 import { ActorRdfJoin } from '@comunica/bus-rdf-join';
 import type { IMediatorTypeJoinCoefficients } from '@comunica/mediatortype-join-coefficients';
 import { MetadataValidationState } from '@comunica/metadata';
+import type * as RDF from '@rdfjs/types';
 import { ArrayIterator } from 'asynciterator';
 
 const BF = new BindingsFactory();
@@ -30,7 +31,7 @@ export class ActorRdfJoinNone extends ActorRdfJoin {
   protected async getOutput(action: IActionRdfJoin): Promise<IActorRdfJoinOutputInner> {
     return {
       result: {
-        bindingsStream: new ArrayIterator([ BF.bindings() ], { autoStart: false }),
+        bindingsStream: new ArrayIterator<RDF.Bindings>([ BF.bindings() ], { autoStart: false }),
         metadata: () => Promise.resolve({
           state: new MetadataValidationState(),
           cardinality: { type: 'exact', value: 1 },

--- a/packages/actor-rdf-parse-jsonld/lib/DocumentLoaderMediated.ts
+++ b/packages/actor-rdf-parse-jsonld/lib/DocumentLoaderMediated.ts
@@ -21,8 +21,8 @@ export class DocumentLoaderMediated extends FetchDocumentLoader {
 
   protected static createFetcher(mediatorHttp: MediatorHttp, context: IActionContext):
   (input: RequestInfo, init: RequestInit) => Promise<Response> {
-    return async(url: string, init: RequestInit) => {
-      const response = await mediatorHttp.mediate({ input: url, init, context });
+    return async(input: RequestInfo, init: RequestInit) => {
+      const response = await mediatorHttp.mediate({ input, init, context });
       response.json = async() => JSON.parse(await stringifyStream(ActorHttp.toNodeReadable(response.body)));
       return response;
     };

--- a/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
+++ b/packages/actor-rdf-resolve-hypermedia-qpf/lib/RdfSourceQpf.ts
@@ -135,7 +135,7 @@ export class RdfSourceQpf implements IQuadSource {
       } else if (Object.keys(this.searchForm.mappings).length === 4 && !this.defaultGraph) {
         // If the sd:defaultGraph is not declared on a QPF endpoint,
         // then the default graph must be empty.
-        const quads = new ArrayIterator([], { autoStart: false });
+        const quads = new ArrayIterator<RDF.Quad>([], { autoStart: false });
         quads.setProperty('metadata', {
           requestTime: 0,
           cardinality: { type: 'exact', value: 0 },

--- a/packages/actor-rdf-resolve-hypermedia-sparql/lib/RdfSourceSparql.ts
+++ b/packages/actor-rdf-resolve-hypermedia-sparql/lib/RdfSourceSparql.ts
@@ -5,6 +5,7 @@ import type { Bindings, BindingsStream, IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { TransformIterator, wrap } from 'asynciterator';
+import type { IBindings } from 'fetch-sparql-endpoint';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { LRUCache } from 'lru-cache';
 import { DataFactory } from 'rdf-data-factory';
@@ -138,9 +139,9 @@ export class RdfSourceSparql implements IQuadSource {
    */
   public queryBindings(endpoint: string, query: string): BindingsStream {
     const rawStream = this.endpointFetcher.fetchBindings(endpoint, query);
-    return wrap<any>(rawStream, { autoStart: false, maxBufferSize: Number.POSITIVE_INFINITY })
-      .map((rawData: Record<string, RDF.Term>) => BF.bindings(Object.entries(rawData)
-        .map(([ key, value ]) => [ DF.variable(key.slice(1)), value ])));
+    return wrap<IBindings>(rawStream, { autoStart: false, maxBufferSize: Number.POSITIVE_INFINITY })
+      .map<RDF.Bindings>((rawData: Record<string, RDF.Term>) => BF.bindings(Object.entries(rawData)
+      .map(([ key, value ]) => [ DF.variable(key.slice(1)), value ])));
   }
 
   public match(subject: RDF.Term, predicate: RDF.Term, object: RDF.Term, graph: RDF.Term): AsyncIterator<RDF.Quad> {

--- a/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-federated/lib/FederatedQuadSource.ts
@@ -251,7 +251,7 @@ export class FederatedQuadSource implements IQuadSource {
         // eslint-disable-next-line no-cond-assign
         this.isSourceEmpty(source, pattern = this.algebraFactory
           .createPattern(patternS, patternP, patternO, patternG))) {
-        output = { data: new ArrayIterator([], { autoStart: false }) };
+        output = { data: new ArrayIterator<RDF.Quad>([], { autoStart: false }) };
         // Return the default metadata
         output.data.setProperty('metadata', {
           state: new MetadataValidationState(),

--- a/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/MediatedQuadSource.ts
+++ b/packages/actor-rdf-resolve-quad-pattern-hypermedia/lib/MediatedQuadSource.ts
@@ -43,8 +43,13 @@ export class MediatedQuadSource implements IQuadSource {
     predicate: RDF.Term,
     object: RDF.Term,
     graph: RDF.Term,
-    context: IActionContext,
+    context?: IActionContext,
   ): AsyncIterator<RDF.Quad> {
+    // IQuadSource["context"] should be mandatory in the next major update.
+    if (!context) {
+      throw new Error(`MediatedQuadSource requires a context.`);
+    }
+
     // Optimized match with aggregated store if enabled and started.
     let aggregatedStore: IAggregatedStore | undefined;
     if (this.aggregateStore) {

--- a/packages/bindings-factory/lib/BindingsFactory.ts
+++ b/packages/bindings-factory/lib/BindingsFactory.ts
@@ -17,7 +17,7 @@ export class BindingsFactory implements RDF.BindingsFactory {
     return new Bindings(this.dataFactory, Map(entries.map(([ key, value ]) => [ key.value, value ])));
   }
 
-  public fromBindings(bindings: Bindings): Bindings {
+  public fromBindings(bindings: RDF.Bindings): Bindings {
     return this.bindings([ ...bindings ]);
   }
 

--- a/packages/bus-query-operation/lib/ActorQueryOperation.ts
+++ b/packages/bus-query-operation/lib/ActorQueryOperation.ts
@@ -183,7 +183,7 @@ export abstract class ActorQueryOperation extends Actor<IActionQueryOperation, I
       const outputRaw = await mediatorQueryOperation.mediate({ operation, context });
       const output = ActorQueryOperation.getSafeBindings(outputRaw);
 
-      return new Promise(
+      return new Promise<boolean>(
         (resolve, reject) => {
           output.bindingsStream.on('end', () => {
             resolve(false);

--- a/packages/bus-query-operation/lib/Bindings.ts
+++ b/packages/bus-query-operation/lib/Bindings.ts
@@ -187,7 +187,7 @@ export function materializeOperation(
         const valueBindings: Record<string, RDF.Literal | RDF.NamedNode>[] = <any> op.bindings.map(binding => {
           const newBinding = { ...binding };
           let valid = true;
-          bindings.forEach((value: RDF.NamedNode, key: RDF.Variable) => {
+          bindings.forEach((value, key) => {
             const keyString = termToString(key);
             if (keyString in newBinding) {
               if (!value.equals(newBinding[keyString])) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "downlevelIteration": true,
 
     "strict": true,
-    "strictFunctionTypes": false,
     "strictPropertyInitialization": false
   },
   "include": [


### PR DESCRIPTION
My project was reporting a type failure in `BindingsFactory.d.ts`, so I dug in to investigate. It was because `fromBindings()` needs to accept any `RDF.Bindings`, not just Comunica `Bindings`. It looks like the reason that wasn't failing in Comunica itself is that `strictFunctionTypes` was off.

I've taken the liberty of turning it on and resolving the type issues it was covering up. My assumption is that it was turned off because one or more of these was proving difficult. I recommend having it on, not only because it makes for sounder code internally, but also because downstream projects can have their own issues if they don't have it turned off (which is what happened here). I'm hoping that now that the leg work is done, you'll be comfortable turning it back on.