### PR TITLE
fix: components.js warning on expression evaluator

### DIFF
--- a/.componentsjs-generator-config.json
+++ b/.componentsjs-generator-config.json
@@ -12,7 +12,8 @@
     "packages/data-factory",
     "packages/jest",
     "packages/packager",
-    "packages/runner-cli"
+    "packages/runner-cli",
+    "packages/expression-evaluator"
   ],
   "ignoreComponents": [
     "Error",


### PR DESCRIPTION
This PR aims to fix a warning thrown when running `yarn install`:

> Skipped generating invalid package at ".../packages/expression-evaluator": Invalid package: Missing 'lsd:components' in ...packages/expression-evaluator/package.json
