### PR TITLE
Enable SPARQL-star support for Update queries on `@comunica/actor-query-operation-sparql-endpoint`

### DIFF
--- a/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
+++ b/packages/actor-query-operation-sparql-endpoint/lib/ActorQueryOperationSparqlEndpoint.ts
@@ -93,7 +93,7 @@ export class ActorQueryOperationSparqlEndpoint extends ActorQueryOperation {
     let variables: RDF.Variable[] | undefined;
     try {
       // Use the original query string if available
-      query = action.context.get(KeysInitQuery.queryString) ?? toSparql(action.operation);
+      query = action.context.get(KeysInitQuery.queryString) ?? toSparql(action.operation, { sparqlStar: true });
       // This will throw an error in case the result is an invalid SPARQL query
       type = this.endpointFetcher.getQueryType(query);
 

--- a/packages/actor-query-operation-sparql-endpoint/package.json
+++ b/packages/actor-query-operation-sparql-endpoint/package.json
@@ -44,7 +44,7 @@
     "@comunica/types": "^2.8.2",
     "@rdfjs/types": "*",
     "asynciterator": "^3.8.1",
-    "fetch-sparql-endpoint": "^4.0.0",
+    "fetch-sparql-endpoint": "^4.1.0",
     "rdf-data-factory": "^1.1.1",
     "sparqlalgebrajs": "^4.2.0"
   },

--- a/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
+++ b/packages/actor-query-operation-sparql-endpoint/test/ActorQueryOperationSparqlEndpoint-test.ts
@@ -408,6 +408,32 @@ describe('ActorQueryOperationSparqlEndpoint', () => {
       expect(jest.mocked(mediatorHttp.mediate).mock.calls[0][0].init.signal.aborted).toBeTruthy();
     });
 
+    it('should run for an update star query', async() => {
+      const context = new ActionContext({
+        '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'sparql', value: 'http://example.org/sparql-update' },
+      });
+      const op: any = { context,
+        operation: factory.createDeleteInsert([], [
+          factory.createPattern(
+            DF.quad(
+              DF.namedNode('http://s'),
+              DF.namedNode('http://p'),
+              DF.namedNode('http://o'),
+            ),
+            DF.namedNode('http://p'),
+            DF.namedNode('http://o'),
+          ),
+        ]) };
+      const output: IQueryOperationResultVoid = <any> await actor.run(op);
+
+      expect(mediatorHttp.mediate).not.toHaveBeenCalled();
+
+      await output.execute();
+
+      expect(jest.mocked(mediatorHttp.mediate).mock.calls[0][0].init.signal).toBeTruthy();
+      expect(jest.mocked(mediatorHttp.mediate).mock.calls[0][0].init.signal.aborted).toBeTruthy();
+    });
+
     it('should run and error for a server error', async() => {
       const thisMediator: any = {
         mediate() {


### PR DESCRIPTION
Fixes #1257 by enabling `sparqlStar` on `sparqlalgebrajs.toSparql` and using an updated version of `fetch-sparql-endpoint`