### PR TITLE
Skip calling endsWith on mediaType when mediaType is undefined

### DIFF
--- a/packages/actor-abstract-mediatyped/lib/ActorAbstractMediaTypedFixed.ts
+++ b/packages/actor-abstract-mediatyped/lib/ActorAbstractMediaTypedFixed.ts
@@ -19,8 +19,8 @@ export abstract class ActorAbstractMediaTypedFixed<HI, HT, HO> extends ActorAbst
     this.mediaTypeFormats = Object.freeze(this.mediaTypeFormats);
   }
 
-  public async testHandle(action: HI, mediaType: string, context: IActionContext): Promise<HT> {
-    if (!(mediaType in this.mediaTypePriorities)) {
+  public async testHandle(action: HI, mediaType: string | undefined, context: IActionContext): Promise<HT> {
+    if (!mediaType || !(mediaType in this.mediaTypePriorities)) {
       throw new Error(`Unrecognized media type: ${mediaType}`);
     }
     return await this.testHandleChecked(action, context);

--- a/packages/actor-abstract-mediatyped/test/ActorAbstractMediaTypedFixed-test.ts
+++ b/packages/actor-abstract-mediatyped/test/ActorAbstractMediaTypedFixed-test.ts
@@ -43,12 +43,16 @@ describe('ActorAbstractMediaTypedFixed', () => {
       return expect(actor.mediaTypePriorities).toEqual({ a: 0.25 });
     });
 
-    it('should testParse for a valid media type', () => {
+    it('should testHandle for a valid media type', () => {
       return expect(actor.testHandle(null, 'a')).resolves.toBeTruthy();
     });
 
-    it('should not testParse for an invalid media type', () => {
+    it('should not testHandle for an invalid media type', () => {
       return expect(actor.testHandle(null, 'b')).rejects.toBeTruthy();
+    });
+
+    it('should not testHandle for an undefined media type', () => {
+      return expect(actor.testHandle(null)).rejects.toBeTruthy();
     });
 
     it('should always testMediaType', () => {

--- a/packages/actor-rdf-parse-jsonld/lib/ActorRdfParseJsonLd.ts
+++ b/packages/actor-rdf-parse-jsonld/lib/ActorRdfParseJsonLd.ts
@@ -32,11 +32,12 @@ export class ActorRdfParseJsonLd extends ActorRdfParseFixedMediaTypes {
     super(args);
   }
 
-  public async testHandle(action: IActionRdfParse, mediaType: string, context: IActionContext): Promise<IActorTest> {
+  public async testHandle(action: IActionRdfParse, mediaType: string | undefined, context: IActionContext):
+  Promise<IActorTest> {
     if (context.has(KeysRdfParseHtmlScript.processingHtmlScript) && mediaType !== 'application/ld+json') {
       throw new Error(`JSON-LD in script tags can only have media type 'application/ld+json'`);
     }
-    if (!(mediaType in this.mediaTypePriorities) && !mediaType?.endsWith('+json')) {
+    if (!mediaType || !(mediaType in this.mediaTypePriorities || mediaType.endsWith('+json'))) {
       throw new Error(`Unrecognized media type: ${mediaType}`);
     }
     return await this.testHandleChecked(action);

--- a/packages/actor-rdf-parse-jsonld/lib/ActorRdfParseJsonLd.ts
+++ b/packages/actor-rdf-parse-jsonld/lib/ActorRdfParseJsonLd.ts
@@ -36,7 +36,7 @@ export class ActorRdfParseJsonLd extends ActorRdfParseFixedMediaTypes {
     if (context.has(KeysRdfParseHtmlScript.processingHtmlScript) && mediaType !== 'application/ld+json') {
       throw new Error(`JSON-LD in script tags can only have media type 'application/ld+json'`);
     }
-    if (!(mediaType in this.mediaTypePriorities) && !mediaType.endsWith('+json')) {
+    if (!(mediaType in this.mediaTypePriorities) && !mediaType?.endsWith('+json')) {
       throw new Error(`Unrecognized media type: ${mediaType}`);
     }
     return await this.testHandleChecked(action);

--- a/packages/actor-rdf-parse-jsonld/test/ActorRdfParseJsonLd-test.ts
+++ b/packages/actor-rdf-parse-jsonld/test/ActorRdfParseJsonLd-test.ts
@@ -232,27 +232,27 @@ describe('ActorRdfParseJsonLd', () => {
       it('should not test on N-Triples', async() => {
         await expect(actor
           .test({ handle: { data: input, context }, handleMediaType: 'application/n-triples', context }))
-          .rejects.toBeTruthy();
+          .rejects.toThrow(new Error('Unrecognized media type: application/n-triples'));
         await expect(actor
           .test({
             handle: { data: input, metadata: { baseIRI: '' }, context },
             handleMediaType: 'application/n-triples',
             context,
           }))
-          .rejects.toBeTruthy();
+          .rejects.toThrow(new Error('Unrecognized media type: application/n-triples'));
       });
 
       it('should not test on undefined', async() => {
         await expect(actor
           .test({ handle: { data: input, context }, handleMediaType: undefined, context }))
-          .rejects.toBeTruthy();
+          .rejects.toThrow(new Error('Unrecognized media type: undefined'));
         await expect(actor
           .test({
             handle: { data: input, metadata: { baseIRI: '' }, context },
             handleMediaType: undefined,
             context,
           }))
-          .rejects.toBeTruthy();
+          .rejects.toThrow(new Error('Unrecognized media type: undefined'));
       });
 
       it('should run', () => {

--- a/packages/actor-rdf-parse-jsonld/test/ActorRdfParseJsonLd-test.ts
+++ b/packages/actor-rdf-parse-jsonld/test/ActorRdfParseJsonLd-test.ts
@@ -242,6 +242,19 @@ describe('ActorRdfParseJsonLd', () => {
           .rejects.toBeTruthy();
       });
 
+      it('should not test on undefined', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: undefined, context }))
+          .rejects.toBeTruthy();
+        await expect(actor
+          .test({
+            handle: { data: input, metadata: { baseIRI: '' }, context },
+            handleMediaType: undefined,
+            context,
+          }))
+          .rejects.toBeTruthy();
+      });
+
       it('should run', () => {
         return actor.run({
           handle: { data: input, metadata: { baseIRI: '' }, context },


### PR DESCRIPTION
This fixes a small error about trying to call the endsWith on mediaType string when the string is undefined. The other parse actors also report undefined as unsupported media type, so this change also aligns the actor with those.