### PR TITLE
Make ESLint rule overrides more specific and re-enable a number of rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     project: ['./tsconfig.eslint.json'],
   },
   extends: [
-      '@rubensworks'
+    '@rubensworks',
   ],
 
   // TODO: Remove this once solid-client-authn supports node 18.
@@ -16,21 +16,14 @@ module.exports = {
     // Default
     'unicorn/consistent-destructuring': 'off',
     'unicorn/no-array-callback-reference': 'off',
-    'unicorn/no-new-array': 'off',
 
     // TODO: Try to re-enable the following rules in the future
     'unicorn/prefer-at': 'off',
     'unicorn/prefer-string-replace-all': 'off',
     'import/no-commonjs': 'off',
-    'import/no-unassigned-import': 'off',
     'import/group-exports': 'off',
-    'import/no-dynamic-require': 'off',
     'import/exports-last': 'off',
-    'import/no-anonymous-default-export': 'off',
-    'import/no-default-export': 'off',
-    'import/unambiguous': 'off',
     'import/extensions': 'off',
-    'import/first': 'off',
   },
   overrides: [
     {
@@ -40,11 +33,54 @@ module.exports = {
         'packages/actor-dereference-file/**/*.ts',
         'packages/actor-http-native/**/*.ts',
         'packages/logger-bunyan/**/*.ts',
-        'packages/packager/**/*.ts'
+        'packages/packager/**/*.ts',
       ],
       rules: {
         'import/no-nodejs-modules': 'off',
-      }
-    }
+      },
+    },
+    {
+      // Only the packager makes use of dynamic require
+      files: [
+        'packages/packager/bin/package.ts',
+      ],
+      rules: {
+        'import/no-dynamic-require': 'off',
+      },
+    },
+    {
+      // The config packages use an empty index.ts
+      files: [
+        'engines/config-*/lib/index.ts',
+      ],
+      rules: {
+        'import/unambiguous': 'off',
+      },
+    },
+    {
+      // Some packages make use of 'export default'
+      files: [
+        'packages/actor-http-*/lib/*.ts',
+        'packages/jest/**/*.ts',
+      ],
+      rules: {
+        'import/no-anonymous-default-export': 'off',
+        'import/no-default-export': 'off',
+      },
+    },
+    {
+      // Some test files import 'jest-rdf' which triggers this
+      // The http actors import 'cross-fetch/polyfill' which also triggers this
+      // Some jest tests import '../../lib' which triggers this
+      files: [
+        '**/test/*-test.ts',
+        '**/test/*-util.ts',
+        'packages/jest/test/matchers/*-test.ts',
+        'packages/actor-http-*/lib/*.ts',
+      ],
+      rules: {
+        'import/no-unassigned-import': 'off',
+      },
+    },
   ],
 };

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -1,10 +1,5 @@
 /** @jest-environment setup-polly-jest/jest-environment-node */
 
-// Needed to undo automock from actor-http-native, cleaner workarounds do not appear to be working.
-if (!globalThis.window) {
-  jest.unmock('follow-redirects');
-}
-
 import { KeysHttpWayback, KeysInitQuery, KeysRdfResolveQuadPattern } from '@comunica/context-entries';
 import { BlankNodeScoped } from '@comunica/data-factory';
 import type { IActionContext, QueryBindings, QueryStringContext } from '@comunica/types';

--- a/packages/actor-dereference-http/test/MediaTypesToAcceptString-test.ts
+++ b/packages/actor-dereference-http/test/MediaTypesToAcceptString-test.ts
@@ -53,8 +53,8 @@ describe('mediaTypesToAcceptString', () => {
     const maxHeaderLength = 127;
     // Subtract 6 for ';q=0.8'
     const typeLength = Math.ceil((maxHeaderLength - 6) / 2);
-    const a = new Array(typeLength).join('a');
-    const b = new Array(typeLength).join('b');
+    const a = 'a'.repeat(typeLength - 1);
+    const b = 'b'.repeat(typeLength - 1);
     return expect(mediaTypesToAcceptString({ [a]: 1, [b]: 0.8 }, maxHeaderLength))
       .toEqual(`${a},${b};q=0.8`);
   });

--- a/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
+++ b/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
@@ -35,7 +35,7 @@ export class ActorQueryResultSerializeTable extends ActorQueryResultSerializeFix
   }
 
   public static repeat(str: string, count: number): string {
-    return new Array(count + 1).join(str);
+    return str.repeat(count);
   }
 
   public async testHandleChecked(action: IActionSparqlSerialize, context: IActionContext): Promise<boolean> {

--- a/packages/logger-bunyan/test/LoggerBunyan-test.ts
+++ b/packages/logger-bunyan/test/LoggerBunyan-test.ts
@@ -1,3 +1,6 @@
+import { LoggerBunyan } from '../lib/LoggerBunyan';
+import { BunyanStreamProviderStderr } from '../lib/stream/BunyanStreamProviderStderr';
+
 jest.mock('bunyan', () => {
   return {
     createLogger: (args: any) => ({
@@ -11,9 +14,6 @@ jest.mock('bunyan', () => {
     }),
   };
 });
-
-import { LoggerBunyan } from '../lib/LoggerBunyan';
-import { BunyanStreamProviderStderr } from '../lib/stream/BunyanStreamProviderStderr';
 
 describe('LoggerBunyan', () => {
   it('should create streams from providers during construction', () => {


### PR DESCRIPTION
Here is a small set of changes to make the ESLint rule overrides more specific, because the overrides are used to disable rules and it might make sense to disable then with the smallest possible scope. I have also added comments for what triggers the rules to make it easier to understand why the overrides exist.

There are also a couple of code changes that help make some rule overrides unnecessary:

* Replacing the use of array joins for string repetition with the repeat function from string allows re-enabling the `unicorn/no-new-array` rule.
* Making sure the imports in two files are at the top of the files allows re-enabling the `import/first` rule. This was done by moving some imports to the top of one file, and by removing an unmock workaround that did not appear to have any impact on the tests in another file.

Any feedback is welcome. I tried to keep the number of changes to a minimum without splitting them up too much, because they are all related to ESLint rules.

Re-enabling `unicorn/prefer-string-replace-all` will require changing the tsconfig to bump the target to es2021, so I will make another pull request for that later.