### PR TITLE
Update actions/cache to v3, use --frozen-lockfile instead of --pure-lockfile, cancel old workflow when new one is queued

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: "CI"
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             **/node_modules
@@ -77,7 +77,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-lint-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
@@ -99,7 +99,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-browser-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
@@ -126,7 +126,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-docker-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
@@ -153,7 +153,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Load cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-docs-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           firefox-version: 'latest'
       - name: Install dependencies
-        run: yarn install --pure-lockfile
+        run: yarn install --frozen-lockfile
       - name: Build project
         run: yarn run build
       - name: Run depcheck
@@ -82,7 +82,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-lint-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --pure-lockfile
+        run: yarn install --frozen-lockfile
       - name: Run linter
         run: yarn run lint
 
@@ -104,7 +104,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-browser-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --pure-lockfile
+        run: yarn install --frozen-lockfile
       - name: Build for browser
         run: npx lerna run browser --concurrency 1
       - name: Deploy browser build
@@ -131,7 +131,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-docker-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --pure-lockfile
+        run: yarn install --frozen-lockfile
       - name: Install Lerna Docker
         run: sh -c "`curl -fsSl https://raw.githubusercontent.com/rubensworks/lerna-docker/master/install.sh`"
       - name: Build Docker images
@@ -158,7 +158,7 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-docs-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --pure-lockfile
+        run: yarn install --frozen-lockfile
       - name: Build docs
         run: yarn run doc
       - name: Deploy TSDoc to GitHub Pages


### PR DESCRIPTION
Here is a small set of changes that I was thinking might make sense, but that will need some discussion I feel. There are three changes:

1. Update `actions/cache` to v3, because v2 used Node 12 and that has been deprecated. The new one seems to work the same way as the previous one.
2. Use `--frozen-lockfile` instead of `--pure-lockfile`, because the pure option only skips generating a lockfile, whereas the frozen one ensures that the lockfile and package.json are synced by failing if any lockfile changes would result from the installation according to [the documentation](https://classic.yarnpkg.com/lang/en/docs/cli/install/).
3. Always run linter first, then tests, and then everything else. I feel like this would make sense, because linting should be the cheapest and fastest to do, and since linter errors will need to be fixed anyway, it makes sense to catch them first. Making sure the tests pass before building Dockerfiles or running browser tests feels intuitive, as well. Running TypeDoc takes half an hour, so I also feel like it would be better to do it only after the tests have passed.

Any feedback would be welcome, especially with regards to changing the order of the workflow. The changes make sense to me, but I am not sure if everyone would agree. I will make this a draft for now.