### PR TITLE
test: enable langString type comparison

### DIFF
--- a/packages/expression-evaluator/test/integration/util/Ordering-test.ts
+++ b/packages/expression-evaluator/test/integration/util/Ordering-test.ts
@@ -103,10 +103,9 @@ describe('terms order', () => {
   it('dateTime type comparison', () => {
     genericOrderTestLower(dateTime('2000-01-01T00:00:00Z'), dateTime('2001-01-01T00:00:00Z'));
   });
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('langString type comparison', () => {
-    // Skip for now, spec does not say anything about order of langStrings
-    genericOrderTestLower(DF.literal('a', 'de'), DF.literal('a', 'en'));
+  it('langString type comparison', () => {
+    // Spec does not say anything about order of langStrings, but we use Operator Extensibility to define it.
+    orderTestIsEqual(DF.literal('a', 'de'), DF.literal('a', 'en'));
     genericOrderTestLower(DF.literal('a', 'en'), DF.literal('b', 'en'));
   });
   it('boolean type comparison', () => {

--- a/packages/expression-evaluator/test/spec/sparql-12/sep-0002/adjust_time-01-spec-test.ts
+++ b/packages/expression-evaluator/test/spec/sparql-12/sep-0002/adjust_time-01-spec-test.ts
@@ -31,7 +31,6 @@ describe('adjust time duration', () => {
         '${timeTyped('10:00:00-07:00')}' '${dayTimeDurationTyped('PT10H')}' = '${timeTyped('03:00:00+10:00')}'
         '${timeTyped('10:00:00')}' '' = '${timeTyped('10:00:00')}'
         '${timeTyped('10:00:00-07:00')}' '' = '${timeTyped('10:00:00')}'
-        
       `,
     });
   });


### PR DESCRIPTION
I looked at the expression evaluator tests that are skipped. Seems like only one skipped test can be enabled because the other skipped tests need SparqlAlgebra to support `ADJUST`.