### PR TITLE
Support relative and absolute paths for `COMUNICA_CONFIG`

### DIFF
--- a/packages/runner-cli/lib/ArgsRunner.ts
+++ b/packages/runner-cli/lib/ArgsRunner.ts
@@ -53,7 +53,7 @@ export function runArgsInProcess(
 ): void {
   const argv = process.argv.slice(2);
   runArgs(
-    process.env.COMUNICA_CONFIG ? `${process.cwd()}/${process.env.COMUNICA_CONFIG}` : defaultConfigPath,
+    process.env.COMUNICA_CONFIG ?? defaultConfigPath,
     argv,
     process.stdin,
     process.stdout,


### PR DESCRIPTION
This should fix #1276 and allow the use of both relative and absolute paths for `COMUNICA_CONFIG`. The prepending of current working directory seems to have been unnecessary, as the code also works without it.

Any feedback is welcome. :slightly_smiling_face: 