### PR TITLE
Feature/source context by object

### DIFF
--- a/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
@@ -37,7 +37,7 @@ export function getDataSourceValue(dataSource: IDataSource): string | RDF.Source
  */
 export function getDataSourceContext(
   dataSource: IDataSource | IDataSourceRaw,
-  context: IActionContext
+  context: IActionContext,
 ): IActionContext {
   if (isDataSourceRawType(dataSource) || !dataSource.context) {
     return context;

--- a/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
@@ -8,9 +8,9 @@ import type * as RDF from '@rdfjs/types';
  * @param dataSource A data source.
  */
 export function isDataSourceRawType(
-  dataSource: IDataSource | IDataSourceRawContext
+  dataSource: IDataSource | IDataSourceRawContext,
 ): dataSource is string | RDF.Source {
-  return typeof dataSource === "string" || "match" in dataSource;
+  return typeof dataSource === 'string' || 'match' in dataSource;
 }
 
 /**

--- a/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
@@ -7,8 +7,10 @@ import type * as RDF from '@rdfjs/types';
  * Check if the given data source is a string or RDF store.
  * @param dataSource A data source.
  */
-export function isDataSourceRawType(dataSource: IDataSource | IDataSourceRawContext): dataSource is string | RDF.Source {
-  return typeof dataSource === 'string' || 'match' in dataSource;
+export function isDataSourceRawType(
+  dataSource: IDataSource | IDataSourceRawContext
+): dataSource is string | RDF.Source {
+  return typeof dataSource === "string" || "match" in dataSource;
 }
 
 /**

--- a/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
@@ -1,4 +1,5 @@
 import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
+import { ActionContext } from '@comunica/core';
 import type { IActionContext, DataSources, IDataSource } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 
@@ -35,10 +36,11 @@ export function getDataSourceValue(dataSource: IDataSource): string | RDF.Source
  * @param {IDataSource} dataSource The source or undefined.
  */
 export function getDataSourceContext(dataSource: IDataSource, context: IActionContext): IActionContext {
-  if (typeof dataSource === 'string' || 'match' in dataSource || !dataSource.context) {
+  if (isDataSourceRawType(dataSource) || !dataSource.context) {
     return context;
   }
-  return context.merge(dataSource.context);
+
+  return context.merge(ActionContext.ensureActionContext(dataSource.context));
 }
 
 /**

--- a/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
@@ -1,13 +1,13 @@
 import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
-import type { IActionContext, DataSources, IDataSource, IDataSourceRaw } from '@comunica/types';
+import type { IActionContext, DataSources, IDataSource, IDataSourceRawContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 
 /**
  * Check if the given data source is a string or RDF store.
  * @param dataSource A data source.
  */
-export function isDataSourceRawType(dataSource: IDataSource | IDataSourceRaw): dataSource is string | RDF.Source {
+export function isDataSourceRawType(dataSource: IDataSource | IDataSourceRawContext): dataSource is string | RDF.Source {
   return typeof dataSource === 'string' || 'match' in dataSource;
 }
 
@@ -33,10 +33,10 @@ export function getDataSourceValue(dataSource: IDataSource): string | RDF.Source
 /**
  * Get the data source from the given context.
  * @param {ActionContext} context An optional context.
- * @param {IDataSource | IDataSourceRaw} dataSource The source or undefined.
+ * @param {IDataSource | IDataSourceRawContext} dataSource The source or undefined.
  */
 export function getDataSourceContext(
-  dataSource: IDataSource | IDataSourceRaw,
+  dataSource: IDataSource | IDataSourceRawContext,
   context: IActionContext,
 ): IActionContext {
   if (isDataSourceRawType(dataSource) || !dataSource.context) {

--- a/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
@@ -1,13 +1,13 @@
 import { KeysRdfResolveQuadPattern } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
-import type { IActionContext, DataSources, IDataSource } from '@comunica/types';
+import type { IActionContext, DataSources, IDataSource, IDataSourceRaw } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 
 /**
  * Check if the given data source is a string or RDF store.
  * @param dataSource A data source.
  */
-export function isDataSourceRawType(dataSource: IDataSource): dataSource is string | RDF.Source {
+export function isDataSourceRawType(dataSource: IDataSource | IDataSourceRaw): dataSource is string | RDF.Source {
   return typeof dataSource === 'string' || 'match' in dataSource;
 }
 
@@ -35,7 +35,7 @@ export function getDataSourceValue(dataSource: IDataSource): string | RDF.Source
  * @param {ActionContext} context An optional context.
  * @param {IDataSource} dataSource The source or undefined.
  */
-export function getDataSourceContext(dataSource: IDataSource, context: IActionContext): IActionContext {
+export function getDataSourceContext(dataSource: IDataSource | IDataSourceRaw, context: IActionContext): IActionContext {
   if (isDataSourceRawType(dataSource) || !dataSource.context) {
     return context;
   }

--- a/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/lib/utils.ts
@@ -33,9 +33,12 @@ export function getDataSourceValue(dataSource: IDataSource): string | RDF.Source
 /**
  * Get the data source from the given context.
  * @param {ActionContext} context An optional context.
- * @param {IDataSource} dataSource The source or undefined.
+ * @param {IDataSource | IDataSourceRaw} dataSource The source or undefined.
  */
-export function getDataSourceContext(dataSource: IDataSource | IDataSourceRaw, context: IActionContext): IActionContext {
+export function getDataSourceContext(
+  dataSource: IDataSource | IDataSourceRaw,
+  context: IActionContext
+): IActionContext {
   if (isDataSourceRawType(dataSource) || !dataSource.context) {
     return context;
   }

--- a/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
@@ -1,161 +1,161 @@
-import { ActionContext } from "@comunica/core";
-import type * as RDF from "@rdfjs/types";
+import { ActionContext } from '@comunica/core';
+import type * as RDF from '@rdfjs/types';
 import {
   getDataSourceType,
   getDataSourceValue,
   getDataSourceContext,
   isDataSourceRawType,
   getContextSourceFirst,
-} from "..";
+} from '..';
 
-describe("utils", () => {
+describe('utils', () => {
   const rdfjsSource: RDF.Source = <any>{ match: true };
 
-  describe("isDataSourceRawType", () => {
-    it("should return on a string source", () => {
-      return expect(isDataSourceRawType("abc")).toEqual(true);
+  describe('isDataSourceRawType', () => {
+    it('should return on a string source', () => {
+      return expect(isDataSourceRawType('abc')).toEqual(true);
     });
 
-    it("should return on an rdfjs source", () => {
+    it('should return on an rdfjs source', () => {
       return expect(isDataSourceRawType(rdfjsSource)).toEqual(true);
     });
 
-    it("should return on an object source", () => {
-      return expect(isDataSourceRawType({ type: "T", value: "abc" })).toEqual(
+    it('should return on an object source', () => {
+      return expect(isDataSourceRawType({ type: 'T', value: 'abc' })).toEqual(
         false
       );
     });
   });
 
-  describe("getDataSourceType", () => {
-    it("should return on a string source", () => {
-      return expect(getDataSourceType("abc")).toEqual("");
+  describe('getDataSourceType', () => {
+    it('should return on a string source', () => {
+      return expect(getDataSourceType('abc')).toEqual('');
     });
 
-    it("should return on an rdfjs source", () => {
-      return expect(getDataSourceType(rdfjsSource)).toEqual("rdfjsSource");
+    it('should return on an rdfjs source', () => {
+      return expect(getDataSourceType(rdfjsSource)).toEqual('rdfjsSource');
     });
 
-    it("should return on an object source", () => {
-      return expect(getDataSourceType({ type: "T", value: "abc" })).toEqual(
-        "T"
+    it('should return on an object source', () => {
+      return expect(getDataSourceType({ type: 'T', value: 'abc' })).toEqual(
+        'T'
       );
     });
 
-    it("should return on an object source with implicit rdfjs source", () => {
+    it('should return on an object source with implicit rdfjs source', () => {
       return expect(getDataSourceType({ value: rdfjsSource })).toEqual(
         undefined
       );
     });
 
-    it("should return on an object source with explicit rdfjs source", () => {
+    it('should return on an object source with explicit rdfjs source', () => {
       return expect(
-        getDataSourceType({ type: "rdfjsSource", value: rdfjsSource })
-      ).toEqual("rdfjsSource");
+        getDataSourceType({ type: 'rdfjsSource', value: rdfjsSource })
+      ).toEqual('rdfjsSource');
     });
   });
 
-  describe("getDataSourceValue", () => {
-    it("should return on a string source", () => {
-      return expect(getDataSourceValue("abc")).toEqual("abc");
+  describe('getDataSourceValue', () => {
+    it('should return on a string source', () => {
+      return expect(getDataSourceValue('abc')).toEqual('abc');
     });
 
-    it("should return on a rdfjs source source", () => {
+    it('should return on a rdfjs source source', () => {
       return expect(getDataSourceValue(rdfjsSource)).toEqual(rdfjsSource);
     });
 
-    it("should return on an object source", () => {
-      return expect(getDataSourceValue({ type: "T", value: "abc" })).toEqual(
-        "abc"
+    it('should return on an object source', () => {
+      return expect(getDataSourceValue({ type: 'T', value: 'abc' })).toEqual(
+        'abc'
       );
     });
 
-    it("should return on an object source with implicit rdfjs source", () => {
+    it('should return on an object source with implicit rdfjs source', () => {
       return expect(getDataSourceValue({ value: rdfjsSource })).toEqual(
         rdfjsSource
       );
     });
 
-    it("should return on an object source with explicit rdfjs source", () => {
+    it('should return on an object source with explicit rdfjs source', () => {
       return expect(
-        getDataSourceValue({ type: "rdfjsSource", value: rdfjsSource })
+        getDataSourceValue({ type: 'rdfjsSource', value: rdfjsSource })
       ).toEqual(rdfjsSource);
     });
   });
 
-  describe("getDataSourceContext", () => {
-    const context = new ActionContext({ key: "value" });
+  describe('getDataSourceContext', () => {
+    const context = new ActionContext({ key: 'value' });
 
-    it("should return on a string source", () => {
-      return expect(getDataSourceContext("abc", context)).toEqual(context);
+    it('should return on a string source', () => {
+      return expect(getDataSourceContext('abc', context)).toEqual(context);
     });
 
-    it("should return on a rdfjs source source", () => {
+    it('should return on a rdfjs source source', () => {
       return expect(getDataSourceContext(rdfjsSource, context)).toEqual(
         context
       );
     });
 
-    it("should accept object as data source context", () => {
+    it('should accept object as data source context', () => {
       return expect(
         getDataSourceContext(
-          { type: "type", value: "value", context: { "key2": "value2" } },
+          { type: 'type', value: 'value', context: { 'key2': 'value2' } },
           context
         )
-      ).toEqual(new ActionContext({key: "value", key2: "value2"}));
+      ).toEqual(new ActionContext({key: 'value', key2: 'value2'}));
     });
 
-    it("should return on an object source", () => {
-      const sourceContext = new ActionContext({ auth: "username:passwd" });
+    it('should return on an object source', () => {
+      const sourceContext = new ActionContext({ auth: 'username:passwd' });
       return expect(
         getDataSourceContext(
-          { value: "http://google.com", context: sourceContext },
+          { value: 'http://google.com', context: sourceContext },
           context
         )
       ).toEqual(context.merge(sourceContext));
     });
   });
 
-  describe("#getSingleSource", () => {
-    it("should extract single source when source is set", () => {
+  describe('#getSingleSource', () => {
+    it('should extract single source when source is set', () => {
       const source = getContextSourceFirst(
         new ActionContext({
-          "@comunica/bus-rdf-resolve-quad-pattern:source": {
-            type: "a-type",
-            value: "a-value",
+          '@comunica/bus-rdf-resolve-quad-pattern:source': {
+            type: 'a-type',
+            value: 'a-value',
           },
         })
       );
-      return expect(source).toEqual({ type: "a-type", value: "a-value" });
+      return expect(source).toEqual({ type: 'a-type', value: 'a-value' });
     });
 
-    it("should return the first source when one sources is defined in the list of sources", () => {
+    it('should return the first source when one sources is defined in the list of sources', () => {
       const source = getContextSourceFirst(
         new ActionContext({
-          "@comunica/bus-rdf-resolve-quad-pattern:sources": [
-            { type: "a-type", value: "a-value" },
+          '@comunica/bus-rdf-resolve-quad-pattern:sources': [
+            { type: 'a-type', value: 'a-value' },
           ],
         })
       );
-      return expect(source).toEqual({ type: "a-type", value: "a-value" });
+      return expect(source).toEqual({ type: 'a-type', value: 'a-value' });
     });
 
-    it("should return undefined when multiple sources are defined in the list of sources", () => {
+    it('should return undefined when multiple sources are defined in the list of sources', () => {
       const source = getContextSourceFirst(
         new ActionContext({
-          "@comunica/bus-rdf-resolve-quad-pattern:sources": [
-            { type: "a-type", value: "a-value" },
-            { type: "a-type", value: "a-value" },
+          '@comunica/bus-rdf-resolve-quad-pattern:sources': [
+            { type: 'a-type', value: 'a-value' },
+            { type: 'a-type', value: 'a-value' },
           ],
         })
       );
       return expect(source).toEqual(undefined);
     });
 
-    it("return undefined for sources that are not ended", () => {
+    it('return undefined for sources that are not ended', () => {
       const source = getContextSourceFirst(
         new ActionContext({
-          "@comunica/bus-rdf-resolve-quad-pattern:sources": [],
+          '@comunica/bus-rdf-resolve-quad-pattern:sources': [],
         })
       );
       return expect(source).toEqual(undefined);

--- a/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
@@ -96,6 +96,15 @@ describe("utils", () => {
       );
     });
 
+    it("should accept object as data source context", () => {
+      return expect(
+        getDataSourceContext(
+          { type: "type", value: "value", context: { "key2": "value2" } },
+          context
+        )
+      ).toEqual(new ActionContext({key: "value", key2: "value2"}));
+    });
+
     it("should return on an object source", () => {
       const sourceContext = new ActionContext({ auth: "username:passwd" });
       return expect(

--- a/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
@@ -99,7 +99,7 @@ describe('utils', () => {
     it('should accept object as data source context', () => {
       return expect(
         getDataSourceContext(
-          { type: 'type', value: 'value', context: { key2: 'value2' } },
+          { type: 'type', value: 'value', context: { key2: 'value2' }},
           context,
         ),
       ).toEqual(new ActionContext({ key: 'value', key2: 'value2' }));

--- a/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
@@ -22,7 +22,7 @@ describe('utils', () => {
 
     it('should return on an object source', () => {
       return expect(isDataSourceRawType({ type: 'T', value: 'abc' })).toEqual(
-        false
+        false,
       );
     });
   });
@@ -38,19 +38,19 @@ describe('utils', () => {
 
     it('should return on an object source', () => {
       return expect(getDataSourceType({ type: 'T', value: 'abc' })).toEqual(
-        'T'
+        'T',
       );
     });
 
     it('should return on an object source with implicit rdfjs source', () => {
       return expect(getDataSourceType({ value: rdfjsSource })).toEqual(
-        undefined
+        undefined,
       );
     });
 
     it('should return on an object source with explicit rdfjs source', () => {
       return expect(
-        getDataSourceType({ type: 'rdfjsSource', value: rdfjsSource })
+        getDataSourceType({ type: 'rdfjsSource', value: rdfjsSource }),
       ).toEqual('rdfjsSource');
     });
   });
@@ -66,19 +66,19 @@ describe('utils', () => {
 
     it('should return on an object source', () => {
       return expect(getDataSourceValue({ type: 'T', value: 'abc' })).toEqual(
-        'abc'
+        'abc',
       );
     });
 
     it('should return on an object source with implicit rdfjs source', () => {
       return expect(getDataSourceValue({ value: rdfjsSource })).toEqual(
-        rdfjsSource
+        rdfjsSource,
       );
     });
 
     it('should return on an object source with explicit rdfjs source', () => {
       return expect(
-        getDataSourceValue({ type: 'rdfjsSource', value: rdfjsSource })
+        getDataSourceValue({ type: 'rdfjsSource', value: rdfjsSource }),
       ).toEqual(rdfjsSource);
     });
   });
@@ -92,17 +92,17 @@ describe('utils', () => {
 
     it('should return on a rdfjs source source', () => {
       return expect(getDataSourceContext(rdfjsSource, context)).toEqual(
-        context
+        context,
       );
     });
 
     it('should accept object as data source context', () => {
       return expect(
         getDataSourceContext(
-          { type: 'type', value: 'value', context: { 'key2': 'value2' } },
-          context
-        )
-      ).toEqual(new ActionContext({key: 'value', key2: 'value2'}));
+          { type: 'type', value: 'value', context: { key2: 'value2' } },
+          context,
+        ),
+      ).toEqual(new ActionContext({ key: 'value', key2: 'value2' }));
     });
 
     it('should return on an object source', () => {
@@ -110,8 +110,8 @@ describe('utils', () => {
       return expect(
         getDataSourceContext(
           { value: 'http://google.com', context: sourceContext },
-          context
-        )
+          context,
+        ),
       ).toEqual(context.merge(sourceContext));
     });
   });
@@ -124,7 +124,7 @@ describe('utils', () => {
             type: 'a-type',
             value: 'a-value',
           },
-        })
+        }),
       );
       return expect(source).toEqual({ type: 'a-type', value: 'a-value' });
     });
@@ -135,7 +135,7 @@ describe('utils', () => {
           '@comunica/bus-rdf-resolve-quad-pattern:sources': [
             { type: 'a-type', value: 'a-value' },
           ],
-        })
+        }),
       );
       return expect(source).toEqual({ type: 'a-type', value: 'a-value' });
     });
@@ -147,7 +147,7 @@ describe('utils', () => {
             { type: 'a-type', value: 'a-value' },
             { type: 'a-type', value: 'a-value' },
           ],
-        })
+        }),
       );
       return expect(source).toEqual(undefined);
     });
@@ -156,7 +156,7 @@ describe('utils', () => {
       const source = getContextSourceFirst(
         new ActionContext({
           '@comunica/bus-rdf-resolve-quad-pattern:sources': [],
-        })
+        }),
       );
       return expect(source).toEqual(undefined);
     });

--- a/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
+++ b/packages/bus-rdf-resolve-quad-pattern/test/utils-test.ts
@@ -1,118 +1,154 @@
-import { ActionContext } from '@comunica/core';
-import type * as RDF from '@rdfjs/types';
-import { getDataSourceType, getDataSourceValue,
-  getDataSourceContext, isDataSourceRawType, getContextSourceFirst } from '..';
+import { ActionContext } from "@comunica/core";
+import type * as RDF from "@rdfjs/types";
+import {
+  getDataSourceType,
+  getDataSourceValue,
+  getDataSourceContext,
+  isDataSourceRawType,
+  getContextSourceFirst,
+} from "..";
 
-describe('utils', () => {
-  const rdfjsSource: RDF.Source = <any> { match: true };
+describe("utils", () => {
+  const rdfjsSource: RDF.Source = <any>{ match: true };
 
-  describe('isDataSourceRawType', () => {
-    it('should return on a string source', () => {
-      return expect(isDataSourceRawType('abc')).toEqual(true);
+  describe("isDataSourceRawType", () => {
+    it("should return on a string source", () => {
+      return expect(isDataSourceRawType("abc")).toEqual(true);
     });
 
-    it('should return on an rdfjs source', () => {
+    it("should return on an rdfjs source", () => {
       return expect(isDataSourceRawType(rdfjsSource)).toEqual(true);
     });
 
-    it('should return on an object source', () => {
-      return expect(isDataSourceRawType({ type: 'T', value: 'abc' })).toEqual(false);
+    it("should return on an object source", () => {
+      return expect(isDataSourceRawType({ type: "T", value: "abc" })).toEqual(
+        false
+      );
     });
   });
 
-  describe('getDataSourceType', () => {
-    it('should return on a string source', () => {
-      return expect(getDataSourceType('abc')).toEqual('');
+  describe("getDataSourceType", () => {
+    it("should return on a string source", () => {
+      return expect(getDataSourceType("abc")).toEqual("");
     });
 
-    it('should return on an rdfjs source', () => {
-      return expect(getDataSourceType(rdfjsSource)).toEqual('rdfjsSource');
+    it("should return on an rdfjs source", () => {
+      return expect(getDataSourceType(rdfjsSource)).toEqual("rdfjsSource");
     });
 
-    it('should return on an object source', () => {
-      return expect(getDataSourceType({ type: 'T', value: 'abc' })).toEqual('T');
+    it("should return on an object source", () => {
+      return expect(getDataSourceType({ type: "T", value: "abc" })).toEqual(
+        "T"
+      );
     });
 
-    it('should return on an object source with implicit rdfjs source', () => {
-      return expect(getDataSourceType({ value: rdfjsSource })).toEqual(undefined);
+    it("should return on an object source with implicit rdfjs source", () => {
+      return expect(getDataSourceType({ value: rdfjsSource })).toEqual(
+        undefined
+      );
     });
 
-    it('should return on an object source with explicit rdfjs source', () => {
-      return expect(getDataSourceType({ type: 'rdfjsSource', value: rdfjsSource })).toEqual('rdfjsSource');
+    it("should return on an object source with explicit rdfjs source", () => {
+      return expect(
+        getDataSourceType({ type: "rdfjsSource", value: rdfjsSource })
+      ).toEqual("rdfjsSource");
     });
   });
 
-  describe('getDataSourceValue', () => {
-    it('should return on a string source', () => {
-      return expect(getDataSourceValue('abc')).toEqual('abc');
+  describe("getDataSourceValue", () => {
+    it("should return on a string source", () => {
+      return expect(getDataSourceValue("abc")).toEqual("abc");
     });
 
-    it('should return on a rdfjs source source', () => {
+    it("should return on a rdfjs source source", () => {
       return expect(getDataSourceValue(rdfjsSource)).toEqual(rdfjsSource);
     });
 
-    it('should return on an object source', () => {
-      return expect(getDataSourceValue({ type: 'T', value: 'abc' })).toEqual('abc');
+    it("should return on an object source", () => {
+      return expect(getDataSourceValue({ type: "T", value: "abc" })).toEqual(
+        "abc"
+      );
     });
 
-    it('should return on an object source with implicit rdfjs source', () => {
-      return expect(getDataSourceValue({ value: rdfjsSource })).toEqual(rdfjsSource);
+    it("should return on an object source with implicit rdfjs source", () => {
+      return expect(getDataSourceValue({ value: rdfjsSource })).toEqual(
+        rdfjsSource
+      );
     });
 
-    it('should return on an object source with explicit rdfjs source', () => {
-      return expect(getDataSourceValue({ type: 'rdfjsSource', value: rdfjsSource })).toEqual(rdfjsSource);
-    });
-  });
-
-  describe('getDataSourceContext', () => {
-    const context = new ActionContext({ key: 'value' });
-
-    it('should return on a string source', () => {
-      return expect(getDataSourceContext('abc', context)).toEqual(context);
-    });
-
-    it('should return on a rdfjs source source', () => {
-      return expect(getDataSourceContext(rdfjsSource, context)).toEqual(context);
-    });
-
-    it('should return on an object source', () => {
-      const sourceContext = new ActionContext({ auth: 'username:passwd' });
-      return expect(getDataSourceContext({ value: 'http://google.com', context: sourceContext }, context))
-        .toEqual(context.merge(sourceContext));
+    it("should return on an object source with explicit rdfjs source", () => {
+      return expect(
+        getDataSourceValue({ type: "rdfjsSource", value: rdfjsSource })
+      ).toEqual(rdfjsSource);
     });
   });
 
-  describe('#getSingleSource', () => {
-    it('should extract single source when source is set', () => {
-      const source = getContextSourceFirst(new ActionContext(
-        { '@comunica/bus-rdf-resolve-quad-pattern:source': { type: 'a-type', value: 'a-value' }},
-      ));
-      return expect(source).toEqual({ type: 'a-type', value: 'a-value' });
+  describe("getDataSourceContext", () => {
+    const context = new ActionContext({ key: "value" });
+
+    it("should return on a string source", () => {
+      return expect(getDataSourceContext("abc", context)).toEqual(context);
     });
 
-    it('should return the first source when one sources is defined in the list of sources', () => {
-      const source = getContextSourceFirst(new ActionContext({
-        '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-          { type: 'a-type', value: 'a-value' },
-        ],
-      }));
-      return expect(source).toEqual({ type: 'a-type', value: 'a-value' });
+    it("should return on a rdfjs source source", () => {
+      return expect(getDataSourceContext(rdfjsSource, context)).toEqual(
+        context
+      );
     });
 
-    it('should return undefined when multiple sources are defined in the list of sources', () => {
-      const source = getContextSourceFirst(new ActionContext({
-        '@comunica/bus-rdf-resolve-quad-pattern:sources': [
-          { type: 'a-type', value: 'a-value' },
-          { type: 'a-type', value: 'a-value' },
-        ],
-      }));
+    it("should return on an object source", () => {
+      const sourceContext = new ActionContext({ auth: "username:passwd" });
+      return expect(
+        getDataSourceContext(
+          { value: "http://google.com", context: sourceContext },
+          context
+        )
+      ).toEqual(context.merge(sourceContext));
+    });
+  });
+
+  describe("#getSingleSource", () => {
+    it("should extract single source when source is set", () => {
+      const source = getContextSourceFirst(
+        new ActionContext({
+          "@comunica/bus-rdf-resolve-quad-pattern:source": {
+            type: "a-type",
+            value: "a-value",
+          },
+        })
+      );
+      return expect(source).toEqual({ type: "a-type", value: "a-value" });
+    });
+
+    it("should return the first source when one sources is defined in the list of sources", () => {
+      const source = getContextSourceFirst(
+        new ActionContext({
+          "@comunica/bus-rdf-resolve-quad-pattern:sources": [
+            { type: "a-type", value: "a-value" },
+          ],
+        })
+      );
+      return expect(source).toEqual({ type: "a-type", value: "a-value" });
+    });
+
+    it("should return undefined when multiple sources are defined in the list of sources", () => {
+      const source = getContextSourceFirst(
+        new ActionContext({
+          "@comunica/bus-rdf-resolve-quad-pattern:sources": [
+            { type: "a-type", value: "a-value" },
+            { type: "a-type", value: "a-value" },
+          ],
+        })
+      );
       return expect(source).toEqual(undefined);
     });
 
-    it('return undefined for sources that are not ended', () => {
-      const source = getContextSourceFirst(new ActionContext({
-        '@comunica/bus-rdf-resolve-quad-pattern:sources': [],
-      }));
+    it("return undefined for sources that are not ended", () => {
+      const source = getContextSourceFirst(
+        new ActionContext({
+          "@comunica/bus-rdf-resolve-quad-pattern:sources": [],
+        })
+      );
       return expect(source).toEqual(undefined);
     });
   });

--- a/packages/types/lib/IDataSource.ts
+++ b/packages/types/lib/IDataSource.ts
@@ -14,7 +14,7 @@ export interface IDataSourceExpanded {
   context?: IActionContext;
 }
 
-export interface  IDataSourceRawContext{
+export interface IDataSourceRawContext{
   type?: string;
   value: string | RDF.Source;
   context?: object;

--- a/packages/types/lib/IDataSource.ts
+++ b/packages/types/lib/IDataSource.ts
@@ -14,6 +14,12 @@ export interface IDataSourceExpanded {
   context?: IActionContext;
 }
 
+export interface IDataSourceRaw {
+  type?: string;
+  value: string | RDF.Source;
+  context?: object;
+}
+
 export type IDataSource = string | RDF.Source | IDataSourceExpanded | IDataSourceSerialized;
 
 export type DataSources = IDataSource[];

--- a/packages/types/lib/IDataSource.ts
+++ b/packages/types/lib/IDataSource.ts
@@ -14,7 +14,7 @@ export interface IDataSourceExpanded {
   context?: IActionContext;
 }
 
-export interface IDataSourceRaw {
+export interface  IDataSourceRawContext{
   type?: string;
   value: string | RDF.Source;
   context?: object;


### PR DESCRIPTION
This PR fixes #1003  

- It introduces a new type where the context can be an object. 
- Adjusted `getDataSourceContext` to convert an object context to an `IActionContext`. This prevents having to change other code. 
- Wrote a test to check if the conversion works as expected. 