### PR TITLE
Enforce `bindingsToString` key ordering with a unit test

### DIFF
--- a/packages/actor-hash-bindings-sha1/test/ActorHashBindingsSha1-test.ts
+++ b/packages/actor-hash-bindings-sha1/test/ActorHashBindingsSha1-test.ts
@@ -72,6 +72,13 @@ describe('ActorHashBindingsSha1', () => {
         [ DF.variable('b'), DF.namedNode('ex:b') ],
       ])));
       expect(result.hashFunction(BF.bindings([
+        [ DF.variable('b'), DF.namedNode('ex:b') ],
+        [ DF.variable('a'), DF.namedNode('ex:a') ],
+      ]))).toEqual(result.hashFunction(BF.bindings([
+        [ DF.variable('a'), DF.namedNode('ex:a') ],
+        [ DF.variable('b'), DF.namedNode('ex:b') ],
+      ])));
+      expect(result.hashFunction(BF.bindings([
         [ DF.variable('a'), DF.namedNode('ex:a') ],
         [ DF.variable('b'), DF.namedNode('ex:b') ],
       ]))).not.toEqual(result.hashFunction(BF.bindings([

--- a/packages/bindings-factory/test/bindingsToString-test.ts
+++ b/packages/bindings-factory/test/bindingsToString-test.ts
@@ -20,4 +20,16 @@ describe('bindingsToString', () => {
   "c": "ex:c"
 }`);
   });
+
+  it('should stringify non-empty bindings consistently', () => {
+    expect(bindingsToString(new BindingsFactory().bindings([
+      [ DF.variable('c'), DF.namedNode('ex:c') ],
+      [ DF.variable('a'), DF.namedNode('ex:a') ],
+      [ DF.variable('b'), DF.namedNode('ex:b') ],
+    ]))).toEqual(`{
+  "c": "ex:c",
+  "a": "ex:a",
+  "b": "ex:b"
+}`);
+  });
 });


### PR DESCRIPTION
The `bindingsToString` function produces a record where the keys are not in sorted order, but rather in the order in which they were assigned to the bindings object. Therefore, a bindings object that has identical keys and values but in different order will serialize into a different string.

This change adds a unit test to make sure that happens consistently and also makes sure it is made explicit by having a test for it - otherwise someone might assume that the function produces the same string for a bindings object with the same keys and values.

Any feedback is welcome. :slightly_smiling_face: 