### PR TITLE
Fix `BindingsFactory`'s `fromBindings` type

### DIFF
--- a/packages/bindings-factory/lib/BindingsFactory.ts
+++ b/packages/bindings-factory/lib/BindingsFactory.ts
@@ -17,7 +17,7 @@ export class BindingsFactory implements RDF.BindingsFactory {
     return new Bindings(this.dataFactory, Map(entries.map(([ key, value ]) => [ key.value, value ])));
   }
 
-  public fromBindings(bindings: Bindings): Bindings {
+  public fromBindings(bindings: RDF.Bindings): Bindings {
     return this.bindings([ ...bindings ]);
   }
 


### PR DESCRIPTION
My project was reporting a type failure in `BindingsFactory.d.ts`, so I dug in to investigate. It was because `fromBindings()` needs to accept any `RDF.Bindings`, not just Comunica `Bindings`.

It looks like the reason that wasn't failing in Comunica itself is that `strictFunctionTypes` was off. #1233 tried to turn that back on and address various issues it was covering up. But as noted there, it wasn't quite that simple to turn on. For now, this addresses the original type issue I hit.