### PR TITLE
Update links in readme of core package

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,10 +19,10 @@ $ yarn add @comunica/core
 
 ## Exported classes
 
-* [`Actor`](https://comunica.github.io/comunica/classes/core.actor.html): An actor can act on messages of certain types and provide output of a certain type.
-* [`Bus`](https://comunica.github.io/comunica/classes/core.bus.html): A publish-subscribe bus for sending actions to actors to test whether or not they can run an action.
-* [`Mediator`](https://comunica.github.io/comunica/classes/core.mediator.html): A mediator can mediate an action over a bus of actors.
-* [`ActionObserver`](https://comunica.github.io/comunica/classes/core.actionobserver.html): An ActionObserver can passively listen to Actor.run inputs and outputs for all actors on a certain bus.
-* [`BusIndexed`](https://comunica.github.io/comunica/classes/core.busindexed.html): A bus that indexes identified actors, so that actions with a corresponding identifier can be published more efficiently.
-* [`Logger`](https://comunica.github.io/comunica/classes/core.logger.html): A logger accepts messages from different levels and emits them in a certain way.
-* [`ActionContext`](https://comunica.github.io/comunica/classes/core.actioncontext.html): Implementation of IActionContext using Immutable.js.
+* [`Actor`](https://comunica.github.io/comunica/classes/_comunica_core.Actor.html): An actor can act on messages of certain types and provide output of a certain type.
+* [`Bus`](https://comunica.github.io/comunica/classes/_comunica_core.Bus.html): A publish-subscribe bus for sending actions to actors to test whether or not they can run an action.
+* [`Mediator`](https://comunica.github.io/comunica/classes/_comunica_core.Mediator.html): A mediator can mediate an action over a bus of actors.
+* [`ActionObserver`](https://comunica.github.io/comunica/classes/_comunica_core.ActionObserver.html): An ActionObserver can passively listen to Actor.run inputs and outputs for all actors on a certain bus.
+* [`BusIndexed`](https://comunica.github.io/comunica/classes/_comunica_core.BusIndexed.html): A bus that indexes identified actors, so that actions with a corresponding identifier can be published more efficiently.
+* [`Logger`](https://comunica.github.io/comunica/classes/_comunica_types.Logger.html): A logger accepts messages from different levels and emits them in a certain way.
+* [`ActionContext`](https://comunica.github.io/comunica/classes/_comunica_core.ActionContext.html): Implementation of IActionContext using Immutable.js.


### PR DESCRIPTION
Fixes links to Actor, Mediator, Bus etc. on the [@comunica/core readme](https://github.com/comunica/comunica/tree/master/packages/core).

Closes https://github.com/comunica/comunica/issues/903