### PR TITLE
Update URL's in the readme

### DIFF
--- a/packages/actor-abstract-mediatyped/README.md
+++ b/packages/actor-abstract-mediatyped/README.md
@@ -17,6 +17,6 @@ $ yarn add @comunica/actor-abstract-mediatyped
 
 ## Usage
 
-This package exposes [`ActorAbstractMediaTyped`](https://comunica.github.io/comunica/classes/actor_abstract_mediatyped.actorabstractmediatyped.html)
-and [`ActorAbstractMediaTypedFixed`](https://comunica.github.io/comunica/classes/actor_abstract_mediatyped.actorabstractmediatypedfixed.html)
+This package exposes [`ActorAbstractMediaTyped`](https://comunica.github.io/comunica/classes/_comunica_actor_abstract_mediatyped.ActorAbstractMediaTyped.html)
+and [`ActorAbstractMediaTypedFixed`](https://comunica.github.io/comunica/classes/_comunica_actor_abstract_mediatyped.ActorAbstractMediaTypedFixed.html)
 that provide utility methods for actors that handle media types.

--- a/packages/actor-abstract-path/README.md
+++ b/packages/actor-abstract-path/README.md
@@ -18,5 +18,5 @@ $ yarn add @comunica/actor-abstract-path
 
 ## Usage
 
-This package exposes [`ActorAbstractPath`](https://comunica.github.io/comunica/classes/actor_abstract_path.actorabstractpath.html)
+This package exposes [`ActorAbstractPath`](https://comunica.github.io/comunica/classes/_comunica_actor_abstract_path.ActorAbstractPath.html)
 that provides utility methods for actors that implement property path operations.

--- a/packages/actor-rdf-metadata-extract-hydra-controls/README.md
+++ b/packages/actor-rdf-metadata-extract-hydra-controls/README.md
@@ -20,7 +20,7 @@ $ yarn add @comunica/actor-rdf-metadata-extract-hydra-controls
 
 This actor adds the following entries to the metadata object.
 
-* `searchForms`: All available Hydra search forms, using the [`ISearchForms`](https://comunica.github.io/comunica/interfaces/actor_rdf_metadata_extract_hydra_controls.isearchforms.html) interface.
+* `searchForms`: All available Hydra search forms, using the [`ISearchForms`](https://comunica.github.io/comunica/interfaces/_comunica_actor_rdf_metadata_extract_hydra_controls.ISearchForms.html) interface.
 * `first`: Value of `http://www.w3.org/ns/hydra/core#first`.
 * `next`: Value of `http://www.w3.org/ns/hydra/core#next`.
 * `previous`: Value of `http://www.w3.org/ns/hydra/core#previous`.

--- a/packages/actor-rdf-resolve-hypermedia-links-queue-fifo/README.md
+++ b/packages/actor-rdf-resolve-hypermedia-links-queue-fifo/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/%40comunica%2Factor-rdf-resolve-hypermedia-links-queue-fifo.svg)](https://www.npmjs.com/package/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo)
 
 An [RDF Resolve Hypermedia Links Queue](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-resolve-hypermedia-links-queue) actor
-that provides a [`ILinkQueue`](https://comunica.github.io/comunica/interfaces/bus_rdf_resolve_hypermedia_links_queue.ilinkqueue.html)
+that provides a [`ILinkQueue`](https://comunica.github.io/comunica/interfaces/_comunica_bus_rdf_resolve_hypermedia_links_queue.ILinkQueue.html)
 following the first in, first out strategy.
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),

--- a/packages/bus-context-preprocess/README.md
+++ b/packages/bus-context-preprocess/README.md
@@ -22,4 +22,4 @@ $ yarn add @comunica/bus-context-preprocess
 
 ## Creating actors on this bus
 
-Actors extending [`ActorContextPreprocess`](https://comunica.github.io/comunica/classes/bus_context_preprocess.actorcontextpreprocess.html) are automatically subscribed to this bus.
+Actors extending [`ActorContextPreprocess`](https://comunica.github.io/comunica/classes/_comunica_bus_context_preprocess.ActorContextPreprocess.html) are automatically subscribed to this bus.

--- a/packages/bus-dereference-rdf/README.md
+++ b/packages/bus-dereference-rdf/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-dereference-rdf
 
 ## Creating actors on this bus
 
-Actors extending [`ActorDereferenceRdf`](https://comunica.github.io/comunica/classes/bus_dereference_rdf.actordereferencerdf.html) are automatically subscribed to this bus.
+Actors extending [`ActorDereferenceRdf`](https://comunica.github.io/comunica/classes/_comunica_bus_dereference_rdf.ActorDereferenceRdf.html) are automatically subscribed to this bus.
 

--- a/packages/bus-dereference/README.md
+++ b/packages/bus-dereference/README.md
@@ -22,4 +22,4 @@ $ yarn add @comunica/bus-dereference
 
 ## Creating actors on this bus
 
-Actors extending [`ActorDereference`](https://comunica.github.io/comunica/classes/bus_dereference.actordereference.html) are automatically subscribed to this bus.
+Actors extending [`ActorDereference`](https://comunica.github.io/comunica/classes/_comunica_bus_dereference.ActorDereference.html) are automatically subscribed to this bus.

--- a/packages/bus-hash-bindings/README.md
+++ b/packages/bus-hash-bindings/README.md
@@ -24,4 +24,4 @@ $ yarn add @comunica/bus-hash-bindings
 
 ## Creating actors on this bus
 
-Actors extending [`ActorHashBindings`](https://comunica.github.io/comunica/classes/bus_hash_bindings.actorhashbindings.html) are automatically subscribed to this bus.
+Actors extending [`ActorHashBindings`](https://comunica.github.io/comunica/classes/_comunica_bus_hash_bindings.ActorHashBindings.html) are automatically subscribed to this bus.

--- a/packages/bus-http/README.md
+++ b/packages/bus-http/README.md
@@ -22,4 +22,4 @@ $ yarn add @comunica/bus-http
 
 ## Creating actors on this bus
 
-Actors extending [`ActorHttp`](https://comunica.github.io/comunica/classes/bus_http.actorhttp.html) are automatically subscribed to this bus.
+Actors extending [`ActorHttp`](https://comunica.github.io/comunica/classes/_comunica_bus_http.ActorHttp.html) are automatically subscribed to this bus.

--- a/packages/bus-init/README.md
+++ b/packages/bus-init/README.md
@@ -23,5 +23,5 @@ $ yarn add @comunica/bus-init
 
 ## Creating actors on this bus
 
-Actors extending [`ActorInit`](https://comunica.github.io/comunica/classes/bus_init.actorinit.html) are automatically subscribed to this bus.
+Actors extending [`ActorInit`](https://comunica.github.io/comunica/classes/_comunica_bus_init.ActorInit.html) are automatically subscribed to this bus.
 

--- a/packages/bus-optimize-query-operation/README.md
+++ b/packages/bus-optimize-query-operation/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-optimize-query-operation
 
 ## Creating actors on this bus
 
-Actors extending [`ActorOptimizeQueryOperation`](https://comunica.github.io/comunica/classes/bus_optimize_query_operation.actoroptimizequeryoperation.html) are automatically subscribed to this bus.
+Actors extending [`ActorOptimizeQueryOperation`](https://comunica.github.io/comunica/classes/_comunica_bus_optimize_query_operation.ActorOptimizeQueryOperation.html) are automatically subscribed to this bus.
 

--- a/packages/bus-query-operation/README.md
+++ b/packages/bus-query-operation/README.md
@@ -22,7 +22,7 @@ $ yarn add @comunica/bus-query-operation
 
 ## Creating actors on this bus
 
-Actors extending [`ActorQueryOperation`](https://comunica.github.io/comunica/classes/bus_query_operation.actorqueryoperation.html) or [`ActorQueryOperationTyped`](https://comunica.github.io/comunica/classes/bus_query_operation.actorqueryoperationtyped.html) are automatically subscribed to this bus.
+Actors extending [`ActorQueryOperation`](https://comunica.github.io/comunica/classes/_comunica_bus_query_operation.ActorQueryOperation.html) or [`ActorQueryOperationTyped`](https://comunica.github.io/comunica/classes/_comunica_bus_query_operation.ActorQueryOperationTyped.html) are automatically subscribed to this bus.
 
 It is recommended to extend from `ActorQueryOperationTyped` if your actor supports a single query operation,
 as the bus will be able to handle this actor more efficiently.

--- a/packages/bus-query-parse/README.md
+++ b/packages/bus-query-parse/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-query-parse
 
 ## Creating actors on this bus
 
-Actors extending [`ActorQueryParse`](https://comunica.github.io/comunica/classes/bus_query_parse.actorqueryparse.html) are automatically subscribed to this bus.
+Actors extending [`ActorQueryParse`](https://comunica.github.io/comunica/classes/_comunica_bus_query_parse.ActorQueryParse.html) are automatically subscribed to this bus.
 

--- a/packages/bus-query-result-serialize/README.md
+++ b/packages/bus-query-result-serialize/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-query-result-serialize
 
 ## Creating actors on this bus
 
-Actors extending [`ActorQueryResultSerialize`](https://comunica.github.io/comunica/classes/bus_query_result_serialize.actorqueryresultserialize.html) are automatically subscribed to this bus.
+Actors extending [`ActorQueryResultSerialize`](https://comunica.github.io/comunica/classes/_comunica_bus_query_result_serialize.ActorQueryResultSerialize.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-join-entries-sort/README.md
+++ b/packages/bus-rdf-join-entries-sort/README.md
@@ -24,4 +24,4 @@ $ yarn add @comunica/bus-rdf-join-entries-sort
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfJoinEntriesSort`](https://comunica.github.io/comunica/classes/bus_rdf_join_entries_sort.actorrdfjoinentriessort.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfJoinEntriesSort`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_join_entries_sort.ActorRdfJoinEntriesSort.html) are automatically subscribed to this bus.

--- a/packages/bus-rdf-join-selectivity/README.md
+++ b/packages/bus-rdf-join-selectivity/README.md
@@ -24,4 +24,4 @@ $ yarn add @comunica/bus-rdf-join-selectivity
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfJoinSelectivity`](https://comunica.github.io/comunica/classes/bus_rdf_join.actorrdfjoinselectivity.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfJoinSelectivity`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_join.ActorRdfJoinSelectivity.html) are automatically subscribed to this bus.

--- a/packages/bus-rdf-join/README.md
+++ b/packages/bus-rdf-join/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-join
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfJoin`](https://comunica.github.io/comunica/classes/bus_rdf_join.actorrdfjoin.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfJoin`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_join.ActorRdfJoin.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-metadata-accumulate/README.md
+++ b/packages/bus-rdf-metadata-accumulate/README.md
@@ -22,4 +22,4 @@ $ yarn add @comunica/bus-rdf-metadata-accumulate
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfMetadataAccumulate`](https://comunica.github.io/comunica/classes/bus_rdf_metadata_accumulate.ActorRdfMetadataAccumulate.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfMetadataAccumulate`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_metadata_accumulate.ActorRdfMetadataAccumulate.html) are automatically subscribed to this bus.

--- a/packages/bus-rdf-metadata-extract/README.md
+++ b/packages/bus-rdf-metadata-extract/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-metadata-extract
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfMetadataExtract`](https://comunica.github.io/comunica/classes/bus_rdf_metadata_extract.ActorRdfMetadataExtract.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfMetadataExtract`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_metadata_extract.ActorRdfMetadataExtract.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-metadata/README.md
+++ b/packages/bus-rdf-metadata/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-metadata
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfMetadata`](https://comunica.github.io/comunica/classes/bus_rdf_metadata.actorrdfmetadata.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfMetadata`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_metadata.ActorRdfMetadata.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-parse-html/README.md
+++ b/packages/bus-rdf-parse-html/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-parse-html
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfParseHtml`](https://comunica.github.io/comunica/classes/bus_rdf_parse_html.actorrdfparsehtml.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfParseHtml`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_parse_html.ActorRdfParseHtml.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-parse/README.md
+++ b/packages/bus-rdf-parse/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-parse
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfParse`](https://comunica.github.io/comunica/classes/bus_rdf_parse.actorrdfparse.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfParse`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_parse.ActorRdfParse.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-resolve-hypermedia-links-queue/README.md
+++ b/packages/bus-rdf-resolve-hypermedia-links-queue/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/%40comunica%2Fbus-rdf-resolve-hypermedia-links-queue.svg)](https://www.npmjs.com/package/@comunica/bus-rdf-resolve-hypermedia-links-queue)
 
-A bus for creating [`ILinkQueue`](https://comunica.github.io/comunica/interfaces/bus_rdf_resolve_hypermedia_links_queue.ilinkqueue.html) instances,
+A bus for creating [`ILinkQueue`](https://comunica.github.io/comunica/interfaces/_comunica_bus_rdf_resolve_hypermedia_links_queue.ILinkQueue.html) instances,
 which enable different strategies for queueing links.
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica).
@@ -22,4 +22,4 @@ $ yarn add @comunica/bus-rdf-resolve-hypermedia-links-queue
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfResolveHypermediaLinksQueue`](https://comunica.github.io/comunica/classes/bus_rdf_resolve_hypermedia_links_queue.actorrdfresolvehypermedialinksqueue.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfResolveHypermediaLinksQueue`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_resolve_hypermedia_links_queue.ActorRdfResolveHypermediaLinksQueue.html) are automatically subscribed to this bus.

--- a/packages/bus-rdf-resolve-hypermedia-links/README.md
+++ b/packages/bus-rdf-resolve-hypermedia-links/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-resolve-hypermedia-links
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfresolveHypermediaLinks`](https://comunica.github.io/comunica/classes/bus_rdf_resolve_hypermedia_links.actorrdfresolvehypermedialinks.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfresolveHypermediaLinks`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_resolve_hypermedia_links.ActorRdfresolveHypermediaLinks.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-resolve-hypermedia/README.md
+++ b/packages/bus-rdf-resolve-hypermedia/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-resolve-hypermedia
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfResolveHypermedia`](https://comunica.github.io/comunica/classes/bus_rdf_resolve_hypermedia.actorrdfresolvehypermedia.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfResolveHypermedia`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_resolve_hypermedia.ActorRdfResolveHypermedia.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-resolve-quad-pattern/README.md
+++ b/packages/bus-rdf-resolve-quad-pattern/README.md
@@ -22,8 +22,8 @@ $ yarn add @comunica/bus-rdf-resolve-quad-pattern
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfResolveQuadPattern`](https://comunica.github.io/comunica/classes/bus_rdf_resolve_quad_pattern.ActorRdfResolveQuadPattern.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfResolveQuadPattern`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_resolve_quad_pattern.ActorRdfResolveQuadPattern.html) are automatically subscribed to this bus.
 
-[`ActorRdfResolveQuadPatternSource`](https://comunica.github.io/comunica/classes/bus_rdf_resolve_quad_pattern.ActorRdfResolveQuadPatternSource.html) is an extension of `ActorRdfResolveQuadPattern`
-that delegates quad pattern stream creation to an [`IQuadSource`](https://comunica.github.io/comunica/interfaces/bus_rdf_resolve_quad_pattern.IQuadSource.html).
+[`ActorRdfResolveQuadPatternSource`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_resolve_quad_pattern.ActorRdfResolveQuadPatternSource.html) is an extension of `ActorRdfResolveQuadPattern`
+that delegates quad pattern stream creation to an [`IQuadSource`](https://comunica.github.io/comunica/interfaces/_comunica_bus_rdf_resolve_quad_pattern.IQuadSource.html).
 

--- a/packages/bus-rdf-serialize/README.md
+++ b/packages/bus-rdf-serialize/README.md
@@ -22,5 +22,5 @@ $ yarn add @comunica/bus-rdf-serialize
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfSerialize`](https://comunica.github.io/comunica/classes/bus_rdf_serialize.actorrdfserialize.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfSerialize`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_serialize.ActorRdfSerialize.html) are automatically subscribed to this bus.
 

--- a/packages/bus-rdf-update-hypermedia/README.md
+++ b/packages/bus-rdf-update-hypermedia/README.md
@@ -22,4 +22,4 @@ $ yarn add @comunica/bus-rdf-update-hypermedia
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfUpdateHypermedia`](https://comunica.github.io/comunica/classes/bus_rdf_update_hypermedia.actorrdfupdatehypermedia.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfUpdateHypermedia`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_update_hypermedia.ActorRdfUpdateHypermedia.html) are automatically subscribed to this bus.

--- a/packages/bus-rdf-update-quads/README.md
+++ b/packages/bus-rdf-update-quads/README.md
@@ -24,7 +24,7 @@ $ yarn add @comunica/bus-rdf-update-quads
 
 ## Creating actors on this bus
 
-Actors extending [`ActorRdfUpdateQuads`](https://comunica.github.io/comunica/classes/bus_rdf_update_quads.actorrdfupdatequads.html) are automatically subscribed to this bus.
+Actors extending [`ActorRdfUpdateQuads`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_update_quads.ActorRdfUpdateQuads.html) are automatically subscribed to this bus.
 
-[`ActorRdfUpdateQuadsDestination`](https://comunica.github.io/comunica/classes/bus_rdf_update_quads.actorrdfupdatequadsdestination.html) is an extension of `ActorRdfUpdateQuads`
-that delegates insert and delete streams to an [`IQuadDestination`](https://comunica.github.io/comunica/classes/bus_rdf_update_quads.iquaddestination.html).
+[`ActorRdfUpdateQuadsDestination`](https://comunica.github.io/comunica/classes/_comunica_bus_rdf_update_quads.ActorRdfUpdateQuadsDestination.html) is an extension of `ActorRdfUpdateQuads`
+that delegates insert and delete streams to an [`IQuadDestination`](https://comunica.github.io/comunica/interfaces/_comunica_bus_rdf_update_quads.IQuadDestination.html).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,10 +19,10 @@ $ yarn add @comunica/core
 
 ## Exported classes
 
-* [`Actor`](https://comunica.github.io/comunica/classes/core.actor.html): An actor can act on messages of certain types and provide output of a certain type.
-* [`Bus`](https://comunica.github.io/comunica/classes/core.bus.html): A publish-subscribe bus for sending actions to actors to test whether or not they can run an action.
-* [`Mediator`](https://comunica.github.io/comunica/classes/core.mediator.html): A mediator can mediate an action over a bus of actors.
-* [`ActionObserver`](https://comunica.github.io/comunica/classes/core.actionobserver.html): An ActionObserver can passively listen to Actor.run inputs and outputs for all actors on a certain bus.
-* [`BusIndexed`](https://comunica.github.io/comunica/classes/core.busindexed.html): A bus that indexes identified actors, so that actions with a corresponding identifier can be published more efficiently.
-* [`Logger`](https://comunica.github.io/comunica/classes/core.logger.html): A logger accepts messages from different levels and emits them in a certain way.
-* [`ActionContext`](https://comunica.github.io/comunica/classes/core.actioncontext.html): Implementation of IActionContext using Immutable.js.
+* [`Actor`](https://comunica.github.io/comunica/classes/_comunica_core.Actor.html): An actor can act on messages of certain types and provide output of a certain type.
+* [`Bus`](https://comunica.github.io/comunica/classes/_comunica_core.Bus.html): A publish-subscribe bus for sending actions to actors to test whether or not they can run an action.
+* [`Mediator`](https://comunica.github.io/comunica/classes/_comunica_core.Mediator.html): A mediator can mediate an action over a bus of actors.
+* [`ActionObserver`](https://comunica.github.io/comunica/classes/_comunica_core.ActionObserver.html): An ActionObserver can passively listen to Actor.run inputs and outputs for all actors on a certain bus.
+* [`BusIndexed`](https://comunica.github.io/comunica/classes/_comunica_core.BusIndexed.html): A bus that indexes identified actors, so that actions with a corresponding identifier can be published more efficiently.
+* [`Logger`](https://comunica.github.io/comunica/classes/_comunica_types.Logger.html): A logger accepts messages from different levels and emits them in a certain way.
+* [`ActionContext`](https://comunica.github.io/comunica/classes/_comunica_core.ActionContext.html): Implementation of IActionContext using Immutable.js.

--- a/packages/data-factory/README.md
+++ b/packages/data-factory/README.md
@@ -17,5 +17,5 @@ $ yarn add @comunica/data-factory
 
 ## Exposed classes
 
-* [`BlankNodeScoped`](https://comunica.github.io/comunica/classes/data_factory.blanknodescoped.html): A blank node that is scoped to a certain source, and exposes a skolemized named node.
-* [`BlankNodeBindingsScoped`](https://comunica.github.io/comunica/classes/data_factory.blanknodebindingsscoped.html): A blank node that is scoped to a certain set of bindings.
+* [`BlankNodeScoped`](https://comunica.github.io/comunica/classes/_comunica_data_factory.BlankNodeScoped.html): A blank node that is scoped to a certain source, and exposes a skolemized named node.
+* [`BlankNodeBindingsScoped`](https://comunica.github.io/comunica/classes/_comunica_data_factory.BlankNodeBindingsScoped.html): A blank node that is scoped to a certain set of bindings.

--- a/packages/expression-evaluator/README.md
+++ b/packages/expression-evaluator/README.md
@@ -20,13 +20,13 @@ $ yarn add @comunica/expression-evaluator
 ## Exposed classes
 
 * [`AsyncEvaluator`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.AsyncEvaluator.html): An evaluator for SPARQL expressions working with Promises.
-* [`IAsyncEvaluatorContext`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.IAsyncEvaluatorContext.html): Context used to configure the `AsyncEvaluator`. See [Config](https://comunica.dev/docs/modify/advanced/expression-evaluator/#config). 
+* [`IAsyncEvaluatorContext`](https://comunica.github.io/comunica/interfaces/_comunica_expression_evaluator.IAsyncEvaluatorContext.html): Context used to configure the `AsyncEvaluator`. See [Config](https://comunica.dev/docs/modify/advanced/expression-evaluator/#config). 
 * [`SyncEvaluator`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.SyncEvaluator.html): An evaluator for SPARQL expressions working without Promises.
-* [`ISyncEvaluatorContext`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.ISyncEvaluatorContext.html): Context used to configure the `SyncEvaluator`. See [Config](https://comunica.dev/docs/modify/advanced/expression-evaluator/#config).
+* [`ISyncEvaluatorContext`](https://comunica.github.io/comunica/interfaces/_comunica_expression_evaluator.ISyncEvaluatorContext.html): Context used to configure the `SyncEvaluator`. See [Config](https://comunica.dev/docs/modify/advanced/expression-evaluator/#config).
 * [`AggregateEvaluator`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.AggregateEvaluator.html): An evaluator for SPARQL aggregate expressions working without promises. See [Aggregates](https://comunica.dev/docs/modify/advanced/expression-evaluator/#aggregates).
 * [`ExpressionError`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.ExpressionError.html): An error class for SPARQL expression errors as defined in the [error section](https://comunica.dev/docs/modify/advanced/expression-evaluator/#errors).
-* [`isExpressionError`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.isExpressionError.html): A way to check if an error is of type `ExpressionError`.
-* [`orderTypes`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.orderTypes.html): A function to order types according to the [SPARQL ORDER BY specification](https://www.w3.org/TR/sparql11-query/#modOrderBy).
+* [`isExpressionError`](https://comunica.github.io/comunica/functions/_comunica_expression_evaluator.isExpressionError.html): A way to check if an error is of type `ExpressionError`.
+* [`orderTypes`](https://comunica.github.io/comunica/functions/_comunica_expression_evaluator.orderTypes.html): A function to order types according to the [SPARQL ORDER BY specification](https://www.w3.org/TR/sparql11-query/#modOrderBy).
 * [`AsyncAggregateEvaluator`](https://comunica.github.io/comunica/classes/_comunica_expression_evaluator.AsyncAggregateEvaluator.html): An evaluator for SPARQL aggregate expressions working with promises. See [Aggregates](https://comunica.dev/docs/modify/advanced/expression-evaluator/#aggregates).
 
 


### PR DESCRIPTION
Fixes links to Actor, Mediator, Bus etc. on the [@comunica/core readme](https://github.com/comunica/comunica/tree/master/packages/core).

Solves https://github.com/comunica/comunica/issues/903

This PR is an updated version of this one:
https://github.com/comunica/comunica/pull/1290
