### PR TITLE
Switch to `@smessie/readable-web-to-node-stream@^3.0.3`

### DIFF
--- a/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
+++ b/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
@@ -6,7 +6,7 @@ import { KeysCore, KeysHttp } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import { LoggerVoid } from '@comunica/logger-void';
 import type { IActionContext } from '@comunica/types';
-import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
+import { ReadableWebToNodeStream } from '@smessie/readable-web-to-node-stream';
 import { ActorHttpFetch } from '../lib/ActorHttpFetch';
 
 const streamifyString = require('streamify-string');

--- a/packages/bus-http/lib/ActorHttp.ts
+++ b/packages/bus-http/lib/ActorHttp.ts
@@ -1,6 +1,6 @@
 import type { IAction, IActorArgs, IActorOutput, IActorTest, Mediate } from '@comunica/core';
 import { Actor } from '@comunica/core';
-import { ReadableWebToNodeStream } from 'readable-web-to-node-stream';
+import { ReadableWebToNodeStream } from '@smessie/readable-web-to-node-stream';
 
 /* istanbul ignore next */
 if (!globalThis.ReadableStream) {

--- a/packages/bus-http/package.json
+++ b/packages/bus-http/package.json
@@ -34,7 +34,7 @@
     "@comunica/core": "^2.10.0",
     "is-stream": "^2.0.1",
     "readable-stream-node-to-web": "^1.0.1",
-    "readable-web-to-node-stream": "^3.0.2",
+    "@smessie/readable-web-to-node-stream": "^3.0.3",
     "web-streams-ponyfill": "^1.4.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,6 +2067,14 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@smessie/readable-web-to-node-stream@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@smessie/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.3.tgz#5a9e192efffe8db2d407296713ab054a8bc57df6"
+  integrity sha512-8FFE7psRtRWQT31/duqbmgnSf2++QLR2YH9kj5iwsHhnoqSvHdOY3SAN5e7dhc+60p2cNk7rv3HYOiXOapTEXQ==
+  dependencies:
+    process "^0.11.10"
+    readable-stream "^4.5.1"
+
 "@socket.io/component-emitter@~3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
@@ -10624,6 +10632,17 @@ readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.3.0, readable
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.2.tgz#e6aced27ad3b9d726d8308515b9a1b98dc1b9d13"
   integrity sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
+
+readable-stream@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.5.1.tgz#3f2e4e66eab45606ac8f31597b9edb80c13b12ab"
+  integrity sha512-uQjbf34vmf/asGnOHQEw07Q4llgMACQZTWWa4MmICS0IKJoHbLwKCy71H3eR99Dw5iYejc6W+pqZZEeqRtUFAw==
   dependencies:
     abort-controller "^3.0.0"
     buffer "^6.0.3"


### PR DESCRIPTION
Hopefully closes https://github.com/comunica/comunica-feature-link-traversal/issues/121

This fork uses the latest version of the readable-stream dependency.