### PR TITLE
Allow the link queue wrapper to wrap a generic type

### DIFF
--- a/packages/bus-rdf-join/lib/ActorRdfJoin.ts
+++ b/packages/bus-rdf-join/lib/ActorRdfJoin.ts
@@ -117,6 +117,7 @@ export abstract class ActorRdfJoin
     if (bindings.length === 1) {
       return bindings[0];
     }
+
     let acc: Bindings = bindings[0];
     for (const binding of bindings.slice(1)) {
       const merged = acc.merge(binding);
@@ -278,6 +279,7 @@ export abstract class ActorRdfJoin
       parentPhysicalQueryPlanNode = action.context.get(KeysInitQuery.physicalQueryPlanNode);
       action.context = action.context.set(KeysInitQuery.physicalQueryPlanNode, action);
     }
+    
     // Log to physical plan
     const physicalQueryPlanLogger: IPhysicalQueryPlanLogger | undefined = action.context.get(KeysInitQuery
       .physicalQueryPlanLogger);
@@ -293,6 +295,7 @@ export abstract class ActorRdfJoin
         planMetadata,
       );
     }
+
     // Get action output
     const { result, physicalPlanMetadata } = await this.getOutput(action);
     const metadatas = await ActorRdfJoin.getMetadatas(action.entries);
@@ -306,6 +309,7 @@ export abstract class ActorRdfJoin
 
     // Cache metadata
     result.metadata = ActorQueryOperation.cachifyMetadata(result.metadata);
+    
     return result;
   }
 

--- a/packages/bus-rdf-join/lib/ActorRdfJoin.ts
+++ b/packages/bus-rdf-join/lib/ActorRdfJoin.ts
@@ -117,7 +117,6 @@ export abstract class ActorRdfJoin
     if (bindings.length === 1) {
       return bindings[0];
     }
-
     let acc: Bindings = bindings[0];
     for (const binding of bindings.slice(1)) {
       const merged = acc.merge(binding);
@@ -279,7 +278,6 @@ export abstract class ActorRdfJoin
       parentPhysicalQueryPlanNode = action.context.get(KeysInitQuery.physicalQueryPlanNode);
       action.context = action.context.set(KeysInitQuery.physicalQueryPlanNode, action);
     }
-
     // Log to physical plan
     const physicalQueryPlanLogger: IPhysicalQueryPlanLogger | undefined = action.context.get(KeysInitQuery
       .physicalQueryPlanLogger);
@@ -295,7 +293,6 @@ export abstract class ActorRdfJoin
         planMetadata,
       );
     }
-
     // Get action output
     const { result, physicalPlanMetadata } = await this.getOutput(action);
     const metadatas = await ActorRdfJoin.getMetadatas(action.entries);
@@ -309,7 +306,6 @@ export abstract class ActorRdfJoin
 
     // Cache metadata
     result.metadata = ActorQueryOperation.cachifyMetadata(result.metadata);
-
     return result;
   }
 

--- a/packages/bus-rdf-resolve-hypermedia-links-queue/lib/LinkQueueWrapper.ts
+++ b/packages/bus-rdf-resolve-hypermedia-links-queue/lib/LinkQueueWrapper.ts
@@ -4,10 +4,10 @@ import type { ILinkQueue } from './ILinkQueue';
 /**
  * A link queue that wraps a given link queue.
  */
-export class LinkQueueWrapper implements ILinkQueue {
-  private readonly linkQueue: ILinkQueue;
+export class LinkQueueWrapper<T extends ILinkQueue = ILinkQueue> implements ILinkQueue {
+  protected readonly linkQueue: T;
 
-  public constructor(linkQueue: ILinkQueue) {
+  public constructor(linkQueue: T) {
     this.linkQueue = linkQueue;
   }
 


### PR DESCRIPTION
PR to allow the wrapped link queue type to be generic (which defaults to the current implementation of the link queue wrapper). This will enable users to wrap other types of link queues, like a priority queue.

Sidenote: I thought the linter would fix the weird change log of ActorRdfJoin, but it didn't. If this is a problem let me know.

Credit to @joachimvh, as he suggested this implementation. 