### PR TITLE
Fix DELETE/INSERT update operation order

### DIFF
--- a/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
@@ -46,6 +46,10 @@ export class QuadDestinationPutLdp implements IQuadDestination {
     throw new Error(`Put-based LDP destinations don't support deletions`);
   }
 
+  public update(_quadsToInsert: AsyncIterator<RDF.Quad>, _quadsToDelete: AsyncIterator<RDF.Quad>): Promise<void> {
+    throw new Error(`Put-based LDP destinations don't support deletions`);
+  }
+
   public async wrapRdfUpdateRequest(type: 'INSERT' | 'DELETE', quads: AsyncIterator<RDF.Quad>): Promise<void> {
     // Determine media type for serialization
     const { mediaTypes } = await this.mediatorRdfSerializeMediatypes.mediate(

--- a/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
@@ -46,7 +46,7 @@ export class QuadDestinationPutLdp implements IQuadDestination {
     throw new Error(`Put-based LDP destinations don't support deletions`);
   }
 
-  public update(_quadsToInsert: AsyncIterator<RDF.Quad>, _quadsToDelete: AsyncIterator<RDF.Quad>): Promise<void> {
+  public async update(_quadsToInsert: AsyncIterator<RDF.Quad>, _quadsToDelete: AsyncIterator<RDF.Quad>): Promise<void> {
     throw new Error(`Put-based LDP destinations don't support deletions`);
   }
 

--- a/packages/actor-rdf-update-hypermedia-put-ldp/test/QuadDestinationPutLdp-test.ts
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/test/QuadDestinationPutLdp-test.ts
@@ -143,6 +143,13 @@ describe('QuadDestinationPutLdp', () => {
     });
   });
 
+  describe('update', () => {
+    it('should always throw', async() => {
+      await expect(destination.update(<any> 'QUADS', <any> 'QUADS'))
+        .rejects.toThrow(`Put-based LDP destinations don't support deletions`);
+    });
+  });
+
   describe('deleteGraphs', () => {
     it('should always throw', async() => {
       await expect(destination.deleteGraphs('ALL', true, true))

--- a/packages/actor-rdf-update-hypermedia-sparql/test/QuadDestinationSparql-test.ts
+++ b/packages/actor-rdf-update-hypermedia-sparql/test/QuadDestinationSparql-test.ts
@@ -119,6 +119,39 @@ describe('QuadDestinationSparql', () => {
     });
   });
 
+  describe('update', () => {
+    it('should handle a valid update', async() => {
+      await destination.update(
+        new ArrayIterator([
+          DF.quad(DF.namedNode('ex:s1'), DF.namedNode('ex:p1'), DF.namedNode('ex:o1')),
+          DF.quad(DF.namedNode('ex:s2'), DF.namedNode('ex:p2'), DF.namedNode('ex:o2'), DF.namedNode('ex:g2')),
+        ]),
+        new ArrayIterator([
+          DF.quad(DF.namedNode('ex:sd1'), DF.namedNode('ex:pd1'), DF.namedNode('ex:od1')),
+          DF.quad(DF.namedNode('ex:sd2'), DF.namedNode('ex:pd2'), DF.namedNode('ex:od2'), DF.namedNode('ex:gd2')),
+        ]),
+      );
+
+      expect(mediatorHttp.mediate).toHaveBeenCalledWith({
+        context,
+        init: {
+          headers: { 'content-type': 'application/sparql-update' },
+          method: 'POST',
+          body: `DELETE DATA {
+  <ex:sd1> <ex:pd1> <ex:od1> .
+  GRAPH <ex:gd2> { <ex:sd2> <ex:pd2> <ex:od2> . }
+} ;
+INSERT DATA {
+  <ex:s1> <ex:p1> <ex:o1> .
+  GRAPH <ex:g2> { <ex:s2> <ex:p2> <ex:o2> . }
+}`,
+          signal: expect.anything(),
+        },
+        input: 'abc',
+      });
+    });
+  });
+
   describe('deleteGraphs', () => {
     it('should delete the default graph', async() => {
       await destination.deleteGraphs(DF.defaultGraph(), true, true);

--- a/packages/actor-rdf-update-quads-rdfjs-store/lib/RdfJsQuadDestination.ts
+++ b/packages/actor-rdf-update-quads-rdfjs-store/lib/RdfJsQuadDestination.ts
@@ -32,6 +32,10 @@ export class RdfJsQuadDestination implements IQuadDestination {
     return this.promisifyEventEmitter(this.store.import(quads));
   }
 
+  public update(quadStreamInsert: AsyncIterator<RDF.Quad>, quadStreamDelete: AsyncIterator<RDF.Quad>): Promise<void> {
+    return this.delete(quadStreamDelete).then(() => this.insert(quadStreamInsert));
+  }
+
   public async deleteGraphs(
     graphs: RDF.DefaultGraph | 'NAMED' | 'ALL' | RDF.NamedNode[],
     _requireExistence: boolean,

--- a/packages/actor-rdf-update-quads-rdfjs-store/test/ActorRdfUpdateQuadsRdfJsStore-test.ts
+++ b/packages/actor-rdf-update-quads-rdfjs-store/test/ActorRdfUpdateQuadsRdfJsStore-test.ts
@@ -117,6 +117,29 @@ describe('ActorRdfUpdateQuadsRdfJsStore', () => {
     });
 
     describe('for insert and delete', () => {
+      it('should run with insert stream', async() => {
+        context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
+        const quadStreamInsert = new ArrayIterator([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+        ]);
+        const { execute } = await actor.run({ quadStreamInsert, context });
+        await expect(execute()).resolves.toBeUndefined();
+        await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+        ]);
+      });
+
+      it('should run with delete stream', async() => {
+        context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
+        const quadStreamDelete = new ArrayIterator([
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+        ]);
+        const { execute } = await actor.run({ quadStreamDelete, context });
+        await expect(execute()).resolves.toBeUndefined();
+        await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([]);
+      });
+
       it('should run with insert and delete streams', async() => {
         context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
         const quadStreamInsert = new ArrayIterator([
@@ -129,6 +152,23 @@ describe('ActorRdfUpdateQuadsRdfJsStore', () => {
         await expect(execute()).resolves.toBeUndefined();
         await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([
           DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+        ]);
+      });
+
+      it('should run with insert and delete streams and not delete inserted quads', async() => {
+        context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
+        const quadStreamInsert = new ArrayIterator([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+        ]);
+        const quadStreamDelete = new ArrayIterator([
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+        ]);
+        const { execute } = await actor.run({ quadStreamInsert, quadStreamDelete, context });
+        await expect(execute()).resolves.toBeUndefined();
+        await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
         ]);
       });
     });

--- a/packages/bus-rdf-update-quads/lib/ActorRdfUpdateQuadsDestination.ts
+++ b/packages/bus-rdf-update-quads/lib/ActorRdfUpdateQuadsDestination.ts
@@ -52,8 +52,8 @@ export abstract class ActorRdfUpdateQuadsDestination extends ActorRdfUpdateQuads
     action: IActionRdfUpdateQuads,
   ): Promise<IActorRdfUpdateQuadsOutput> {
     const execute = (): Promise<void> => Promise.all([
-      action.quadStreamInsert ? destination.insert(action.quadStreamInsert) : Promise.resolve(),
       action.quadStreamDelete ? destination.delete(action.quadStreamDelete) : Promise.resolve(),
+      action.quadStreamInsert ? destination.insert(action.quadStreamInsert) : Promise.resolve(),
       action.deleteGraphs ?
         destination.deleteGraphs(
           action.deleteGraphs.graphs,

--- a/packages/bus-rdf-update-quads/lib/ActorRdfUpdateQuadsDestination.ts
+++ b/packages/bus-rdf-update-quads/lib/ActorRdfUpdateQuadsDestination.ts
@@ -52,8 +52,15 @@ export abstract class ActorRdfUpdateQuadsDestination extends ActorRdfUpdateQuads
     action: IActionRdfUpdateQuads,
   ): Promise<IActorRdfUpdateQuadsOutput> {
     const execute = (): Promise<void> => Promise.all([
-      action.quadStreamDelete ? destination.delete(action.quadStreamDelete) : Promise.resolve(),
-      action.quadStreamInsert ? destination.insert(action.quadStreamInsert) : Promise.resolve(),
+      action.quadStreamInsert && !action.quadStreamDelete ?
+        destination.insert(action.quadStreamInsert) :
+        Promise.resolve(),
+      !action.quadStreamInsert && action.quadStreamDelete ?
+        destination.delete(action.quadStreamDelete) :
+        Promise.resolve(),
+      action.quadStreamInsert && action.quadStreamDelete ?
+        destination.update(action.quadStreamInsert, action.quadStreamDelete) :
+        Promise.resolve(),
       action.deleteGraphs ?
         destination.deleteGraphs(
           action.deleteGraphs.graphs,

--- a/packages/bus-rdf-update-quads/lib/IQuadDestination.ts
+++ b/packages/bus-rdf-update-quads/lib/IQuadDestination.ts
@@ -22,6 +22,12 @@ export interface IQuadDestination {
    */
   delete: (quads: AsyncIterator<RDF.Quad>) => Promise<void>;
   /**
+   * Updates destination with quad stream to insert and quad stream to delete.
+   * @param quadStreamInsert The quads to insert.
+   * @param quadStreamDelete The quads to delete.
+   */
+  update: (quadStreamInsert: AsyncIterator<RDF.Quad>, quadStreamDelete: AsyncIterator<RDF.Quad>) => Promise<void>;
+  /**
    * Graphs that should be deleted.
    * @param graphs The graph(s) in which all triples must be removed.
    * @param requireExistence If true, and any of the graphs does not exist, an error must be emitted.

--- a/packages/bus-rdf-update-quads/test/ActorRdfUpdateQuadsDestination-test.ts
+++ b/packages/bus-rdf-update-quads/test/ActorRdfUpdateQuadsDestination-test.ts
@@ -131,6 +131,28 @@ describe('ActorRdfUpdateQuadsDestination', () => {
 
       expect(store.getQuads(null, null, null, null)).toEqual([ skolemized ]);
     });
+
+    it('should not delete quads that are being inserted', async() => {
+      const q1 = quad(namedNode('http://example.org/1'), namedNode('http://example.org#type'), namedNode('http://example.org#thing'));
+      const q2 = quad(namedNode('http://example.org/2'), namedNode('http://example.org#type'), namedNode('http://example.org#thing'));
+
+      const store = new Store();
+      store.addQuads([q1, q2]);
+      const context: IActionContext = new ActionContext({
+        [KeysRdfUpdateQuads.destination.name]: store,
+        [KeysQuerySourceIdentify.sourceIds.name]: new Map([[ store, '3' ]]),
+      });
+
+      const output: IActorRdfUpdateQuadsOutput = await actor.run({
+        quadStreamInsert: new ArrayIterator([q1], { autoStart: false }),
+        quadStreamDelete: new ArrayIterator([q1, q2], { autoStart: false }),
+        context,
+      });
+
+      await output.execute();
+
+      expect(store.getQuads(null, null, null, null)).toEqual([ q1 ]);
+    });
   });
 });
 

--- a/packages/bus-rdf-update-quads/test/ActorRdfUpdateQuadsDestination-test.ts
+++ b/packages/bus-rdf-update-quads/test/ActorRdfUpdateQuadsDestination-test.ts
@@ -137,15 +137,15 @@ describe('ActorRdfUpdateQuadsDestination', () => {
       const q2 = quad(namedNode('http://example.org/2'), namedNode('http://example.org#type'), namedNode('http://example.org#thing'));
 
       const store = new Store();
-      store.addQuads([q1, q2]);
+      store.addQuads([ q1, q2 ]);
       const context: IActionContext = new ActionContext({
         [KeysRdfUpdateQuads.destination.name]: store,
         [KeysQuerySourceIdentify.sourceIds.name]: new Map([[ store, '3' ]]),
       });
 
       const output: IActorRdfUpdateQuadsOutput = await actor.run({
-        quadStreamInsert: new ArrayIterator([q1], { autoStart: false }),
-        quadStreamDelete: new ArrayIterator([q1, q2], { autoStart: false }),
+        quadStreamInsert: new ArrayIterator([ q1 ], { autoStart: false }),
+        quadStreamDelete: new ArrayIterator([ q1, q2 ], { autoStart: false }),
         context,
       });
 


### PR DESCRIPTION
Resolves #1301.

I swapped the order of operations of insert and delete streams to first delete quads and then insert. After that, updating a quad that has already been in the data source works as expected, i.e. it is not deleted.