### PR TITLE
Migrate from readable-web-to-node-stream to readable-from-web

### DIFF
--- a/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
+++ b/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
@@ -1,12 +1,11 @@
 import { Agent as HttpAgent } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
-import { Readable } from 'node:stream';
 import { ActorHttp } from '@comunica/bus-http';
 import { KeysCore, KeysHttp } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import { LoggerVoid } from '@comunica/logger-void';
 import type { IActionContext } from '@comunica/types';
-import { ReadableWebToNodeStream } from '@smessie/readable-web-to-node-stream';
+import { Readable } from 'readable-stream';
 import { ActorHttpFetch } from '../lib/ActorHttpFetch';
 
 const streamifyString = require('streamify-string');
@@ -314,7 +313,7 @@ describe('ActorHttpFetch', () => {
       expect(spy).toHaveBeenCalledWith(
         { url: 'https://www.google.com/' },
         {
-          body: expect.any(ReadableWebToNodeStream),
+          body: expect.any(Readable),
           agent: expect.anything(),
           headers: expect.anything(),
           keepalive: undefined,
@@ -394,7 +393,7 @@ describe('ActorHttpFetch', () => {
     it('should work with a large timeout including body if the body is consumed', async() => {
       jest.spyOn(globalThis, 'clearTimeout');
       const customFetch = jest.fn(async(_, _init) => {
-        const body = Readable.from('foo');
+        const body = streamifyString('foo');
         return {
           body,
         };
@@ -417,7 +416,7 @@ describe('ActorHttpFetch', () => {
     it('should work with a large timeout including body if the body is cancelled', async() => {
       jest.spyOn(globalThis, 'clearTimeout');
       const customFetch = jest.fn(async(_, _init) => {
-        const body = Readable.from('foo');
+        const body = streamifyString('foo');
         return {
           body,
         };

--- a/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
+++ b/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
@@ -461,6 +461,10 @@ describe('ActorHttpInterceptWayback', () => {
                   async read() {
                     return { done: true };
                   },
+                  async cancel() {
+                    /* Noop */
+                  },
+                  closed: new Promise(() => { /* Noop */ }),
                 };
               },
             };

--- a/packages/bus-http/lib/ActorHttp.ts
+++ b/packages/bus-http/lib/ActorHttp.ts
@@ -1,6 +1,6 @@
 import type { IAction, IActorArgs, IActorOutput, IActorTest, Mediate } from '@comunica/core';
 import { Actor } from '@comunica/core';
-import { ReadableWebToNodeStream } from '@smessie/readable-web-to-node-stream';
+import { readableFromWeb } from 'readable-from-web';
 
 /* istanbul ignore next */
 if (!globalThis.ReadableStream) {
@@ -39,7 +39,7 @@ export abstract class ActorHttp extends Actor<IActionHttp, IActorTest, IActorHtt
   public static toNodeReadable(body: ReadableStream | null): NodeJS.ReadableStream {
     return isStream(body) || body === null ?
       <NodeJS.ReadableStream> <any> body :
-      <NodeJS.ReadableStream> <any> new ReadableWebToNodeStream(body);
+      <NodeJS.ReadableStream> <any> readableFromWeb(body);
   }
 
   /**

--- a/packages/bus-http/package.json
+++ b/packages/bus-http/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "@comunica/core": "^3.0.3",
-    "@smessie/readable-web-to-node-stream": "^3.0.3",
     "is-stream": "^2.0.1",
+    "readable-from-web": "^1.0.0",
     "readable-stream-node-to-web": "^1.0.1",
     "web-streams-ponyfill": "^1.4.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12198,6 +12198,14 @@ read@^2.0.0:
   dependencies:
     mute-stream "~1.0.0"
 
+readable-from-web@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/readable-from-web/-/readable-from-web-1.0.0.tgz#5713e5b14447aee9476840926da17ffe43d6472e"
+  integrity sha512-tei03fQhxqLEklpIvocFUR9hO42hiyYvdhwoNHAjJztPAQ8QS1NqF2AhLwzGxIGidPBJ4MCqB48wn7OAFCfhsQ==
+  dependencies:
+    "@types/readable-stream" "^4.0.0"
+    readable-stream "^4.0.0"
+
 readable-stream-node-to-web@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/readable-stream-node-to-web/-/readable-stream-node-to-web-1.0.1.tgz#8b7614faa1465ebfa0da9b9ca6303fa27073b7cf"
@@ -13459,7 +13467,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13476,6 +13484,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -13542,7 +13559,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13555,6 +13572,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -14741,7 +14765,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14754,6 +14778,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Here is a small set of changes to migrate from `@smessie/readable-web-to-node-stream` to `readable-from-web`.

I had to adjust the tests a little, as well, including one `ActorHttpWayback` test that was missing the `closed` promise and the `cancel` function from its mock implementation of WHATWG ReadableStream.

The `@smessie/readable-web-to-node-stream` package is still in yarn.lock because it is required by 2.x versions of Comunica, which are required by `rdf-parse`, which are required by `componentsjs`.

Is there something that is not obvious, but that should also be checked or adjusted with this change? :thinking: 