### PR TITLE
Remove cross-fetch

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -85,13 +85,11 @@ module.exports = config([
   },
   {
     // Some test files import 'jest-rdf' which triggers this
-    // The http actors import 'cross-fetch/polyfill' which also triggers this
     // Some jest tests import '../../lib' which triggers this
     files: [
       '**/test/*-test.ts',
       '**/test/*-util.ts',
       'packages/jest/test/matchers/*-test.ts',
-      'packages/actor-http-*/lib/*.ts',
     ],
     rules: {
       'import/no-unassigned-import': 'off',

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/object-inspect": "^1.8.1",
     "@types/readable-stream": "^4.0.0",
     "@types/setup-polly-jest": "^0.5.2",
-    "abort-controller": "^3.0.0",
     "arrayify-stream": "^2.0.1",
     "asynciterator": "^3.9.0",
     "babel-loader": "^9.1.0",

--- a/packages/actor-dereference-http/lib/ActorDereferenceHttpBase.ts
+++ b/packages/actor-dereference-http/lib/ActorDereferenceHttpBase.ts
@@ -3,7 +3,6 @@ import { ActorDereference, emptyReadable } from '@comunica/bus-dereference';
 import type { IActorHttpOutput, MediatorHttp } from '@comunica/bus-http';
 import { ActorHttp } from '@comunica/bus-http';
 import type { IActorTest } from '@comunica/core';
-import { Headers } from 'cross-fetch';
 import { resolve as resolveRelative } from 'relative-to-absolute-iri';
 
 // Use require instead of import for default exports, to be compatible with variants of esModuleInterop in tsconfig.

--- a/packages/actor-dereference-http/package.json
+++ b/packages/actor-dereference-http/package.json
@@ -40,7 +40,6 @@
     "@comunica/bus-dereference": "^3.0.3",
     "@comunica/bus-http": "^3.0.3",
     "@comunica/core": "^3.0.3",
-    "cross-fetch": "^4.0.0",
     "relative-to-absolute-iri": "^1.0.7",
     "stream-to-string": "^1.2.0"
   },

--- a/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
+++ b/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
@@ -4,7 +4,6 @@ import { KeysCore, KeysInitQuery } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import { LoggerVoid } from '@comunica/logger-void';
 import { MediatorRace } from '@comunica/mediator-race';
-import 'cross-fetch/polyfill';
 import type { IActionContext } from '@comunica/types';
 import { ActorDereferenceHttp } from '../lib/ActorDereferenceHttp';
 

--- a/packages/actor-http-fetch/README.md
+++ b/packages/actor-http-fetch/README.md
@@ -3,13 +3,12 @@
 [![npm version](https://badge.fury.io/js/%40comunica%2Factor-http-fetch.svg)](https://www.npmjs.com/package/@comunica/actor-http-fetch)
 
 An [HTTP](https://github.com/comunica/comunica/tree/master/packages/bus-http) actor that
-uses [cross-fetch](https://www.npmjs.com/package/cross-fetch) to perform HTTP requests.
+uses [fetch](https://fetch.spec.whatwg.org/) to perform HTTP requests.
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
 
 When this actor is used, a custom fetch implementation may be provided via the context (`fetch`).
-If none is provided, the default fallback fetch implementation will be used (`node-fetch` in Node.js, and the browser's `fetch` in browser environments).
 
 [Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
 

--- a/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
+++ b/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
@@ -45,8 +45,4 @@ export class FetchInitPreprocessor implements IFetchInitPreprocessor {
     // Only enable keepalive functionality if we are not sending a body (some browsers seem to trip over this)
     return { keepalive: !init.body, ...init };
   }
-
-  public async createAbortController(): Promise<AbortController> {
-    return new AbortController();
-  }
 }

--- a/packages/actor-http-fetch/lib/FetchInitPreprocessor.ts
+++ b/packages/actor-http-fetch/lib/FetchInitPreprocessor.ts
@@ -34,12 +34,5 @@ export class FetchInitPreprocessor implements IFetchInitPreprocessor {
       duplex: halfDuplex ? 'half' : undefined,
     };
   }
-
-  public async createAbortController(): Promise<AbortController> {
-    // Fallback to abort-controller for Node 14 backward compatibility
-    /* istanbul ignore next */
-    const AbortController = globalThis.AbortController || await import('abort-controller');
-    return new AbortController();
-  }
 }
 /* eslint-enable import/no-nodejs-modules */

--- a/packages/actor-http-fetch/lib/IFetchInitPreprocessor.ts
+++ b/packages/actor-http-fetch/lib/IFetchInitPreprocessor.ts
@@ -3,5 +3,4 @@
  */
 export interface IFetchInitPreprocessor {
   handle: (init: RequestInit) => Promise<RequestInit>;
-  createAbortController: () => Promise<AbortController>;
 }

--- a/packages/actor-http-fetch/package.json
+++ b/packages/actor-http-fetch/package.json
@@ -37,9 +37,7 @@
   "dependencies": {
     "@comunica/bus-http": "^3.0.3",
     "@comunica/context-entries": "^3.0.3",
-    "@comunica/mediatortype-time": "^3.0.3",
-    "abort-controller": "^3.0.0",
-    "cross-fetch": "^4.0.0"
+    "@comunica/mediatortype-time": "^3.0.3"
   },
   "browser": {
     "./lib/FetchInitPreprocessor.js": "./lib/FetchInitPreprocessor-browser.js"

--- a/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
+++ b/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
@@ -12,12 +12,10 @@ import { ActorHttpFetch } from '../lib/ActorHttpFetch';
 const streamifyString = require('streamify-string');
 
 // Mock fetch
-jest.spyOn((<any> globalThis), 'fetch').mockImplementation((input: any, init: any) => {
-  return Promise.resolve({
-    status: input.url === 'https://www.google.com/' ? 200 : 404,
-    ...input.url === 'NOBODY' ? {} : { body: { destroy: jest.fn(), on: jest.fn() }},
-  });
-});
+jest.spyOn(globalThis, 'fetch').mockImplementation((input: any, init?: any) => Promise.resolve(<Response> <unknown>{
+  status: input.url === 'https://www.google.com/' ? 200 : 404,
+  ...input.url === 'NOBODY' ? {} : { body: { destroy: jest.fn(), on: jest.fn() }},
+}));
 
 describe('ActorHttpFetch', () => {
   let bus: any;

--- a/packages/actor-http-memento/lib/ActorHttpMemento.ts
+++ b/packages/actor-http-memento/lib/ActorHttpMemento.ts
@@ -2,7 +2,6 @@ import type { IActionHttp, IActorHttpArgs, IActorHttpOutput, MediatorHttp } from
 import { ActorHttp } from '@comunica/bus-http';
 import { KeysHttpMemento } from '@comunica/context-entries';
 import type { IActorTest } from '@comunica/core';
-import 'cross-fetch/polyfill';
 
 // Use require instead of import for default exports, to be compatible with variants of esModuleInterop in tsconfig.
 // eslint-disable-next-line ts/no-require-imports

--- a/packages/actor-http-memento/package.json
+++ b/packages/actor-http-memento/package.json
@@ -41,7 +41,6 @@
     "@comunica/context-entries": "^3.0.3",
     "@comunica/core": "^3.0.3",
     "@types/parse-link-header": "^2.0.0",
-    "cross-fetch": "^4.0.0",
     "parse-link-header": "^2.0.0"
   }
 }

--- a/packages/actor-http-memento/test/ActorHttpMemento-test.ts
+++ b/packages/actor-http-memento/test/ActorHttpMemento-test.ts
@@ -4,7 +4,6 @@ import { KeysHttpMemento } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
 import { ActorHttpMemento } from '../lib/ActorHttpMemento';
-import 'cross-fetch/polyfill';
 
 describe('ActorHttpMemento', () => {
   let bus: any;
@@ -37,9 +36,9 @@ describe('ActorHttpMemento', () => {
 
     const mediatorHttp: any = {
       mediate(action: IActionHttp) {
-        const requestUrl: string = action.input instanceof Request ?
-          action.input.url :
-          action.input;
+        const requestUrl: string = typeof action.input === 'string' ?
+          action.input :
+          action.input.url;
         const requestHeaders: Headers = action.init ? new Headers(action.init.headers) : new Headers();
 
         const headers = new Headers();

--- a/packages/actor-http-native/lib/ActorHttpNative.ts
+++ b/packages/actor-http-native/lib/ActorHttpNative.ts
@@ -2,7 +2,6 @@ import type { IActionHttp, IActorHttpOutput, IActorHttpArgs } from '@comunica/bu
 import { ActorHttp } from '@comunica/bus-http';
 import { KeysHttp } from '@comunica/context-entries';
 import type { IMediatorTypeTime } from '@comunica/mediatortype-time';
-import 'cross-fetch/polyfill';
 import Requester from './Requester';
 
 const process: NodeJS.Process = require('process/');

--- a/packages/actor-http-native/lib/Requester.ts
+++ b/packages/actor-http-native/lib/Requester.ts
@@ -6,7 +6,6 @@ import { EventEmitter } from 'node:events';
 import type { AgentOptions, ClientRequest, IncomingMessage, IncomingHttpHeaders } from 'node:http';
 import * as url from 'node:url';
 import * as zlib from 'node:zlib';
-import 'cross-fetch/polyfill';
 import { ActorHttp } from '@comunica/bus-http';
 
 const { http } = require('follow-redirects');

--- a/packages/actor-http-native/package.json
+++ b/packages/actor-http-native/package.json
@@ -40,7 +40,6 @@
     "@comunica/bus-http": "^3.0.3",
     "@comunica/context-entries": "^3.0.3",
     "@comunica/mediatortype-time": "^3.0.3",
-    "cross-fetch": "^4.0.0",
     "follow-redirects": "^1.15.2",
     "parse-link-header": "^2.0.0",
     "process": "^0.11.10"

--- a/packages/actor-http-native/test/ActorHttpNative-test.ts
+++ b/packages/actor-http-native/test/ActorHttpNative-test.ts
@@ -5,7 +5,6 @@ import { KeysCore, KeysHttp } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import { LoggerVoid } from '@comunica/logger-void';
 import type { IActionContext } from '@comunica/types';
-import { AbortController } from 'abort-controller';
 import arrayifyStream from 'arrayify-stream';
 import { ActorHttpNative } from '../lib/ActorHttpNative';
 

--- a/packages/actor-http-proxy/test/ActorHttpProxy-test.ts
+++ b/packages/actor-http-proxy/test/ActorHttpProxy-test.ts
@@ -1,7 +1,6 @@
 import { ActorHttp } from '@comunica/bus-http';
 import { KeysHttpProxy } from '@comunica/context-entries';
 import { Bus, ActionContext } from '@comunica/core';
-import 'cross-fetch/polyfill';
 import type { IActionContext } from '@comunica/types';
 import { ActorHttpProxy } from '../lib/ActorHttpProxy';
 import { ProxyHandlerStatic } from '../lib/ProxyHandlerStatic';

--- a/packages/actor-http-proxy/test/ProxyHandlerStatic-test.ts
+++ b/packages/actor-http-proxy/test/ProxyHandlerStatic-test.ts
@@ -1,4 +1,3 @@
-import 'cross-fetch/polyfill';
 import { ProxyHandlerStatic } from '../lib/ProxyHandlerStatic';
 
 describe('ProxyHandlerStatic', () => {

--- a/packages/actor-http-wayback/lib/ActorHttpWayback.ts
+++ b/packages/actor-http-wayback/lib/ActorHttpWayback.ts
@@ -6,7 +6,6 @@ import type { IActionContext, IProxyHandler, IRequest } from '@comunica/types';
 
 // Use require instead of import for default exports, to be compatible with variants of esModuleInterop in tsconfig.
 import stringifyStream = require('stream-to-string');
-import 'cross-fetch/polyfill';
 
 const WAYBACK_URL = 'http://wayback.archive-it.org/';
 

--- a/packages/actor-http-wayback/package.json
+++ b/packages/actor-http-wayback/package.json
@@ -40,7 +40,6 @@
     "@comunica/bus-http": "^3.0.3",
     "@comunica/context-entries": "^3.0.3",
     "@comunica/core": "^3.0.3",
-    "cross-fetch": "^4.0.0",
     "stream-to-string": "^1.2.0"
   }
 }

--- a/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
+++ b/packages/actor-http-wayback/test/ActorHttpWayback-test.ts
@@ -4,7 +4,6 @@ import { KeysHttpWayback, KeysHttpProxy } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IActionContext, IProxyHandler, IRequest } from '@comunica/types';
 import { ActorHttpWayback } from '../lib';
-import 'cross-fetch/polyfill';
 
 const stringToStream = require('streamify-string');
 

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
@@ -6,8 +6,6 @@ import type * as RDF from '@rdfjs/types';
 import { ArrayIterator, wrap } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 
-import 'cross-fetch/polyfill';
-
 // Needed to load Headers
 import 'jest-rdf';
 import { Algebra, Factory } from 'sparqlalgebrajs';

--- a/packages/actor-rdf-metadata-extract-allow-http-methods/test/ActorRdfMetadataExtractAllowHttpMethods-test.ts
+++ b/packages/actor-rdf-metadata-extract-allow-http-methods/test/ActorRdfMetadataExtractAllowHttpMethods-test.ts
@@ -1,7 +1,6 @@
 import type { Readable } from 'node:stream';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
-import { Headers } from 'cross-fetch';
 import { ActorRdfMetadataExtractAllowHttpMethods } from '../lib/ActorRdfMetadataExtractAllowHttpMethods';
 
 describe('ActorRdfMetadataExtractAllowHttpMethods', () => {

--- a/packages/actor-rdf-metadata-extract-patch-sparql-update/test/ActorRdfMetadataExtractPatchSparqlUpdate-test.ts
+++ b/packages/actor-rdf-metadata-extract-patch-sparql-update/test/ActorRdfMetadataExtractPatchSparqlUpdate-test.ts
@@ -1,7 +1,6 @@
 import type { Readable } from 'node:stream';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
-import { Headers } from 'cross-fetch';
 import { ActorRdfMetadataExtractPatchSparqlUpdate } from '../lib/ActorRdfMetadataExtractPatchSparqlUpdate';
 
 describe('ActorRdfMetadataExtractPatchSparqlUpdate', () => {

--- a/packages/actor-rdf-metadata-extract-put-accepted/test/ActorRdfMetadataExtractPutAccepted-test.ts
+++ b/packages/actor-rdf-metadata-extract-put-accepted/test/ActorRdfMetadataExtractPutAccepted-test.ts
@@ -1,7 +1,6 @@
 import type { Readable } from 'node:stream';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
-import { Headers } from 'cross-fetch';
 import { ActorRdfMetadataExtractPutAccepted } from '../lib/ActorRdfMetadataExtractPutAccepted';
 
 describe('ActorRdfMetadataExtractPostAccepted', () => {

--- a/packages/actor-rdf-update-hypermedia-patch-sparql-update/lib/QuadDestinationPatchSparqlUpdate.ts
+++ b/packages/actor-rdf-update-hypermedia-patch-sparql-update/lib/QuadDestinationPatchSparqlUpdate.ts
@@ -6,7 +6,6 @@ import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { ArrayIterator } from 'asynciterator';
-import { Headers } from 'cross-fetch';
 import { termToString } from 'rdf-string-ttl';
 import { Readable } from 'readable-stream';
 

--- a/packages/actor-rdf-update-hypermedia-patch-sparql-update/package.json
+++ b/packages/actor-rdf-update-hypermedia-patch-sparql-update/package.json
@@ -44,7 +44,6 @@
     "@comunica/types": "^3.0.3",
     "@rdfjs/types": "*",
     "asynciterator": "^3.9.0",
-    "cross-fetch": "^4.0.0",
     "rdf-string-ttl": "^1.3.2",
     "readable-stream": "^4.4.2"
   }

--- a/packages/actor-rdf-update-hypermedia-patch-sparql-update/test/QuadDestinationPatchSparqlUpdate-test.ts
+++ b/packages/actor-rdf-update-hypermedia-patch-sparql-update/test/QuadDestinationPatchSparqlUpdate-test.ts
@@ -4,7 +4,6 @@ import { ActionContext } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import { fromArray, wrap } from 'asynciterator';
-import { Headers } from 'cross-fetch';
 import { DataFactory } from 'rdf-data-factory';
 import { QuadDestinationPatchSparqlUpdate } from '../lib/QuadDestinationPatchSparqlUpdate';
 

--- a/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
@@ -6,7 +6,6 @@ import { validateHttpResponse } from '@comunica/bus-rdf-update-quads';
 import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
-import { Headers } from 'cross-fetch';
 
 /**
  * A quad destination that represents a resource that can be PUT.

--- a/packages/actor-rdf-update-hypermedia-put-ldp/package.json
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/package.json
@@ -44,7 +44,6 @@
     "@comunica/core": "^3.0.3",
     "@comunica/types": "^3.0.3",
     "@rdfjs/types": "*",
-    "asynciterator": "^3.9.0",
-    "cross-fetch": "^4.0.0"
+    "asynciterator": "^3.9.0"
   }
 }

--- a/packages/actor-rdf-update-hypermedia-put-ldp/test/QuadDestinationPutLdp-test.ts
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/test/QuadDestinationPutLdp-test.ts
@@ -2,7 +2,6 @@ import { ActorHttp } from '@comunica/bus-http';
 import { KeysRdfUpdateQuads } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
-import { Headers } from 'cross-fetch';
 import { DataFactory } from 'rdf-data-factory';
 import { QuadDestinationPutLdp } from '../lib/QuadDestinationPutLdp';
 

--- a/packages/actor-rdf-update-hypermedia-sparql/test/QuadDestinationSparql-test.ts
+++ b/packages/actor-rdf-update-hypermedia-sparql/test/QuadDestinationSparql-test.ts
@@ -4,7 +4,6 @@ import { ActionContext } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import { ArrayIterator } from 'asynciterator';
-import { Headers } from 'cross-fetch';
 import { DataFactory } from 'rdf-data-factory';
 import { QuadDestinationSparql } from '../lib/QuadDestinationSparql';
 

--- a/packages/bus-http/test/ActorHttp-test.ts
+++ b/packages/bus-http/test/ActorHttp-test.ts
@@ -1,5 +1,4 @@
 import { ActorHttp } from '..';
-import 'cross-fetch/polyfill';
 
 describe('ActorHttp', () => {
   describe('#headersToHash', () => {


### PR DESCRIPTION
This is a draft PR with the changes to remove `cross-fetch`, now that Node 16 is EOL and both Node and browsers support `fetch` directly. The same applies to `abort-controller`.

This was inspired `cross-fetch` and `abort-controller` being removed from `fetch-sparql-endpoint`, and I wanted to see if it is used in Comunica, which it was.

Edit: the reason I made this PR was to bring up the discussion of potentially removing that dependency.

Edit 2: also, it turns out the removal needs a bit more work... I will get to it eventually.