### PR TITLE
Fix DELETE/INSERT update operation order [next/major]

### DIFF
--- a/packages/actor-rdf-update-hypermedia-patch-sparql-update/lib/QuadDestinationPatchSparqlUpdate.ts
+++ b/packages/actor-rdf-update-hypermedia-patch-sparql-update/lib/QuadDestinationPatchSparqlUpdate.ts
@@ -5,6 +5,7 @@ import { validateHttpResponse } from '@comunica/bus-rdf-update-quads';
 import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
+import { ArrayIterator, EmptyIterator } from 'asynciterator';
 import { Headers } from 'cross-fetch';
 import { termToString } from 'rdf-string-ttl';
 import { Readable } from 'readable-stream';
@@ -28,17 +29,30 @@ export class QuadDestinationPatchSparqlUpdate implements IQuadDestination {
     this.mediatorHttp = mediatorHttp;
   }
 
-  public insert(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.wrapSparqlUpdateRequest('INSERT', quads);
+  public async update(
+    quadStreams: { insert?: AsyncIterator<RDF.Quad>; delete?: AsyncIterator<RDF.Quad> },
+  ): Promise<void> {
+    // Create combined query stream with quads to insert and delete
+    const queryStream = this.createCombinedQuadsQuery(quadStreams.insert, quadStreams.delete);
+    await this.wrapSparqlUpdateRequest(queryStream);
   }
 
-  public async delete(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.wrapSparqlUpdateRequest('DELETE', quads);
+  private createCombinedQuadsQuery(
+    quadsToInsert?: AsyncIterator<RDF.Quad>,
+    quadsToDelete?: AsyncIterator<RDF.Quad>,
+  ): AsyncIterator<string> {
+    return new EmptyIterator<string>()
+      .append(this.createQuadsQuery('DELETE', quadsToDelete))
+      .append(quadsToDelete && quadsToInsert ? [ ' ;\n' ] : [])
+      .append(this.createQuadsQuery('INSERT', quadsToInsert));
   }
 
-  public async wrapSparqlUpdateRequest(type: 'INSERT' | 'DELETE', quads: AsyncIterator<RDF.Quad>): Promise<void> {
+  private createQuadsQuery(type: 'INSERT' | 'DELETE', quads?: AsyncIterator<RDF.Quad>): AsyncIterator<string> {
+    if (!quads) {
+      return new ArrayIterator<string>([], { autoStart: false });
+    }
     // Wrap triples in DATA block
-    const dataWrapped = quads
+    return quads
       .map((quad: RDF.Quad) => {
         let stringQuad = `${termToString(quad.subject)} ${termToString(quad.predicate)} ${termToString(quad.object)} .`;
         if (quad.graph.termType === 'DefaultGraph') {
@@ -50,10 +64,13 @@ export class QuadDestinationPatchSparqlUpdate implements IQuadDestination {
       })
       .prepend([ `${type} DATA {\n` ])
       .append([ '}' ]);
+  }
+
+  private async wrapSparqlUpdateRequest(queryStream: AsyncIterator<string>): Promise<void> {
     const readable = new Readable();
     readable._read = () => true;
-    dataWrapped.on('data', (quad: RDF.Quad) => readable.push(quad));
-    dataWrapped.on('end', () => readable.push(null));
+    queryStream.on('data', (quad: RDF.Quad) => readable.push(quad));
+    queryStream.on('end', () => readable.push(null));
 
     // Send data in PUT request
     const headers: Headers = new Headers({ 'content-type': 'application/sparql-update' });

--- a/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/lib/QuadDestinationPutLdp.ts
@@ -38,12 +38,15 @@ export class QuadDestinationPutLdp implements IQuadDestination {
     this.mediatorRdfSerialize = mediatorRdfSerialize;
   }
 
-  public insert(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.wrapRdfUpdateRequest('INSERT', quads);
-  }
-
-  public async delete(_quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    throw new Error(`Put-based LDP destinations don't support deletions`);
+  public async update(
+    quadStreams: { insert?: AsyncIterator<RDF.Quad>; delete?: AsyncIterator<RDF.Quad> },
+  ): Promise<void> {
+    if (quadStreams.delete) {
+      throw new Error(`Put-based LDP destinations don't support deletions`);
+    }
+    if (quadStreams.insert) {
+      await this.wrapRdfUpdateRequest('INSERT', quadStreams.insert);
+    }
   }
 
   public async wrapRdfUpdateRequest(type: 'INSERT' | 'DELETE', quads: AsyncIterator<RDF.Quad>): Promise<void> {

--- a/packages/actor-rdf-update-hypermedia-put-ldp/test/QuadDestinationPutLdp-test.ts
+++ b/packages/actor-rdf-update-hypermedia-put-ldp/test/QuadDestinationPutLdp-test.ts
@@ -56,7 +56,7 @@ describe('QuadDestinationPutLdp', () => {
 
   describe('insert', () => {
     it('should handle a valid insert', async() => {
-      await destination.insert(<any> 'QUADS');
+      await destination.update({ insert: <any> 'QUADS' });
 
       expect(mediatorRdfSerializeMediatypes.mediate).toHaveBeenCalledWith({
         context,
@@ -93,7 +93,7 @@ describe('QuadDestinationPutLdp', () => {
         mediatorRdfSerialize,
       );
 
-      await destination.insert(<any> 'QUADS');
+      await destination.update({ insert: <any> 'QUADS' });
 
       expect(mediatorRdfSerializeMediatypes.mediate).toHaveBeenCalledWith({
         context,
@@ -121,7 +121,7 @@ describe('QuadDestinationPutLdp', () => {
 
     it('should throw on a server error', async() => {
       mediatorHttp.mediate = () => ({ status: 400 });
-      await expect(destination.insert(<any> 'QUADS')).rejects
+      await expect(destination.update({ insert: <any> 'QUADS' })).rejects
         .toThrow('Could not update abc (HTTP status 400):\nempty response');
     });
 
@@ -131,14 +131,21 @@ describe('QuadDestinationPutLdp', () => {
         status: 200,
         body: { cancel },
       });
-      await destination.insert(<any> 'QUADS');
+      await destination.update({ insert: <any> 'QUADS' });
       expect(cancel).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('delete', () => {
     it('should always throw', async() => {
-      await expect(destination.delete(<any> 'QUADS'))
+      await expect(destination.update({ delete: <any> 'QUADS' }))
+        .rejects.toThrow(`Put-based LDP destinations don't support deletions`);
+    });
+  });
+
+  describe('update', () => {
+    it('should always throw', async() => {
+      await expect(destination.update({ delete: <any> 'QUADS', insert: <any> 'QUADS' }))
         .rejects.toThrow(`Put-based LDP destinations don't support deletions`);
     });
   });

--- a/packages/actor-rdf-update-hypermedia-sparql/lib/QuadDestinationSparql.ts
+++ b/packages/actor-rdf-update-hypermedia-sparql/lib/QuadDestinationSparql.ts
@@ -3,6 +3,7 @@ import type { IQuadDestination } from '@comunica/bus-rdf-update-quads';
 import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
+import { ArrayIterator, EmptyIterator } from 'asynciterator';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { termToString } from 'rdf-string-ttl';
 
@@ -35,17 +36,29 @@ export class QuadDestinationSparql implements IQuadDestination {
     });
   }
 
-  public insert(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.wrapSparqlUpdateRequest('INSERT', quads);
+  public async update(
+    quadStreams: { insert?: AsyncIterator<RDF.Quad>; delete?: AsyncIterator<RDF.Quad> },
+  ): Promise<void> {
+    // Create combined query stream with quads to insert and delete
+    const queryStream = this.createCombinedQuadsQuery(quadStreams.insert, quadStreams.delete);
+    await this.wrapSparqlUpdateRequest(queryStream);
   }
 
-  public async delete(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.wrapSparqlUpdateRequest('DELETE', quads);
+  private createCombinedQuadsQuery(
+    quadsToInsert?: AsyncIterator<RDF.Quad>,
+    quadsToDelete?: AsyncIterator<RDF.Quad>,
+  ): AsyncIterator<string> {
+    return new EmptyIterator<string>()
+      .append(this.createQuadsQuery('DELETE', quadsToDelete))
+      .append(quadsToDelete && quadsToInsert ? [ ' ;\n' ] : [])
+      .append(this.createQuadsQuery('INSERT', quadsToInsert));
   }
 
-  public async wrapSparqlUpdateRequest(type: 'INSERT' | 'DELETE', quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    // Wrap triples in DATA block
-    const dataWrapped = quads
+  private createQuadsQuery(type: 'INSERT' | 'DELETE', quads?: AsyncIterator<RDF.Quad>): AsyncIterator<string> {
+    if (!quads) {
+      return new ArrayIterator<string>([], { autoStart: false });
+    }
+    return quads
       .map((quad: RDF.Quad) => {
         let stringQuad = `${termToString(quad.subject)} ${termToString(quad.predicate)} ${termToString(quad.object)} .`;
         if (quad.graph.termType === 'DefaultGraph') {
@@ -57,9 +70,11 @@ export class QuadDestinationSparql implements IQuadDestination {
       })
       .prepend([ `${type} DATA {\n` ])
       .append([ '}' ]);
+  }
 
+  private async wrapSparqlUpdateRequest(queryStream: AsyncIterator<string>): Promise<void> {
     // Serialize query stream to string
-    const query = await stringifyStream(dataWrapped);
+    const query = await stringifyStream(queryStream);
 
     // Send update query to endpoint
     await this.endpointFetcher.fetchUpdate(this.url, query);

--- a/packages/actor-rdf-update-quads-rdfjs-store/lib/RdfJsQuadDestination.ts
+++ b/packages/actor-rdf-update-quads-rdfjs-store/lib/RdfJsQuadDestination.ts
@@ -24,12 +24,15 @@ export class RdfJsQuadDestination implements IQuadDestination {
     });
   }
 
-  public delete(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.promisifyEventEmitter(this.store.remove(quads));
-  }
-
-  public insert(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.promisifyEventEmitter(this.store.import(quads));
+  public async update(
+    quadStreams: { insert?: AsyncIterator<RDF.Quad>; delete?: AsyncIterator<RDF.Quad> },
+  ): Promise<void> {
+    if (quadStreams.delete) {
+      await this.promisifyEventEmitter(this.store.remove(quadStreams.delete));
+    }
+    if (quadStreams.insert) {
+      await this.promisifyEventEmitter(this.store.import(quadStreams.insert));
+    }
   }
 
   public async deleteGraphs(

--- a/packages/actor-rdf-update-quads-rdfjs-store/test/ActorRdfUpdateQuadsRdfJsStore-test.ts
+++ b/packages/actor-rdf-update-quads-rdfjs-store/test/ActorRdfUpdateQuadsRdfJsStore-test.ts
@@ -117,6 +117,29 @@ describe('ActorRdfUpdateQuadsRdfJsStore', () => {
     });
 
     describe('for insert and delete', () => {
+      it('should run with insert stream', async() => {
+        context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
+        const quadStreamInsert = new ArrayIterator([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+        ]);
+        const { execute } = await actor.run({ quadStreamInsert, context });
+        await expect(execute()).resolves.toBeUndefined();
+        await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+        ]);
+      });
+
+      it('should run with delete stream', async() => {
+        context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
+        const quadStreamDelete = new ArrayIterator([
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+        ]);
+        const { execute } = await actor.run({ quadStreamDelete, context });
+        await expect(execute()).resolves.toBeUndefined();
+        await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([]);
+      });
+
       it('should run with insert and delete streams', async() => {
         context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
         const quadStreamInsert = new ArrayIterator([
@@ -129,6 +152,23 @@ describe('ActorRdfUpdateQuadsRdfJsStore', () => {
         await expect(execute()).resolves.toBeUndefined();
         await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([
           DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+        ]);
+      });
+
+      it('should run with insert and delete streams and not delete inserted quads', async() => {
+        context = new ActionContext({ '@comunica/bus-rdf-update-quads:destination': store });
+        const quadStreamInsert = new ArrayIterator([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+        ]);
+        const quadStreamDelete = new ArrayIterator([
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
+        ]);
+        const { execute } = await actor.run({ quadStreamInsert, quadStreamDelete, context });
+        await expect(execute()).resolves.toBeUndefined();
+        await expect(arrayifyStream(store.match())).resolves.toBeRdfIsomorphic([
+          DF.quad(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+          DF.quad(DF.namedNode('sd1'), DF.namedNode('pd1'), DF.namedNode('od1')),
         ]);
       });
     });

--- a/packages/bus-rdf-update-quads/lib/ActorRdfUpdateQuadsDestination.ts
+++ b/packages/bus-rdf-update-quads/lib/ActorRdfUpdateQuadsDestination.ts
@@ -51,22 +51,19 @@ export abstract class ActorRdfUpdateQuadsDestination extends ActorRdfUpdateQuads
     destination: IQuadDestination,
     action: IActionRdfUpdateQuads,
   ): Promise<IActorRdfUpdateQuadsOutput> {
-    const execute = (): Promise<void> => Promise.all([
-      action.quadStreamInsert ? destination.insert(action.quadStreamInsert) : Promise.resolve(),
-      action.quadStreamDelete ? destination.delete(action.quadStreamDelete) : Promise.resolve(),
-      action.deleteGraphs ?
+    const execute = async(): Promise<void> => {
+      await destination.update({ insert: action.quadStreamInsert, delete: action.quadStreamDelete });
+      await (action.deleteGraphs ?
         destination.deleteGraphs(
           action.deleteGraphs.graphs,
           action.deleteGraphs.requireExistence,
           action.deleteGraphs.dropGraphs,
         ) :
-        Promise.resolve(),
-      action.createGraphs ?
+        Promise.resolve());
+      await (action.createGraphs ?
         destination.createGraphs(action.createGraphs.graphs, action.createGraphs.requireNonExistence) :
-        Promise.resolve(),
-    ]).then(() => {
-      // Return void
-    });
+        Promise.resolve());
+    };
     return { execute };
   }
 

--- a/packages/bus-rdf-update-quads/lib/IQuadDestination.ts
+++ b/packages/bus-rdf-update-quads/lib/IQuadDestination.ts
@@ -10,17 +10,10 @@ import stringifyStream = require('stream-to-string');
  */
 export interface IQuadDestination {
   /**
-   * Insert the given quad stream into the destination.
-   * @param quads The quads to insert.
-   * @return {AsyncIterator<RDF.Quad>} The inserted quad stream.
+   * Updates destination with quad stream to insert and quad stream to delete.
+   * @param quadStreams The quads to insert and delete.
    */
-  insert: (quads: AsyncIterator<RDF.Quad>) => Promise<void>;
-  /**
-   * Delete the given quad stream from the destination.
-   * @param quads The quads to delete.
-   * @return {AsyncIterator<RDF.Quad>} The deleted quad stream.
-   */
-  delete: (quads: AsyncIterator<RDF.Quad>) => Promise<void>;
+  update: (quadStreams: { insert?: AsyncIterator<RDF.Quad>; delete?: AsyncIterator<RDF.Quad> }) => Promise<void>;
   /**
    * Graphs that should be deleted.
    * @param graphs The graph(s) in which all triples must be removed.

--- a/packages/bus-rdf-update-quads/test/ActorRdfUpdateQuadsDestination-test.ts
+++ b/packages/bus-rdf-update-quads/test/ActorRdfUpdateQuadsDestination-test.ts
@@ -34,8 +34,7 @@ describe('ActorRdfUpdateQuadsDestination', () => {
   describe('An ActorRdfUpdateQuadsDestination instance', () => {
     const actor = new (<any> ActorRdfUpdateQuadsDestination)({ name: 'actor', bus });
     actor.getDestination = () => ({
-      insert: () => Promise.resolve(),
-      delete: () => Promise.resolve(),
+      update: () => Promise.resolve(),
     });
 
     describe('getContextDestinationUrl', () => {
@@ -151,11 +150,14 @@ class RdfJsQuadDestination {
     });
   }
 
-  public delete(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.promisifyEventEmitter(this.store.remove(<any> quads));
-  }
-
-  public insert(quads: AsyncIterator<RDF.Quad>): Promise<void> {
-    return this.promisifyEventEmitter(this.store.import(<any> quads));
+  public async update(
+    quadStreams: { insert?: AsyncIterator<RDF.Quad>; delete?: AsyncIterator<RDF.Quad> },
+  ): Promise<void> {
+    if (quadStreams.delete) {
+      await this.promisifyEventEmitter(this.store.remove(<any> quadStreams.delete));
+    }
+    if (quadStreams.insert) {
+      await this.promisifyEventEmitter(this.store.import(<any> quadStreams.insert));
+    }
   }
 }


### PR DESCRIPTION
Resolves #1301 properly.

This is a follow up work to #1326 and #1328.

It includes a proper fix to prevent race condition when inserting and deleting quads to/from destination. Delete and update operations are now being run in sequence and batched into single SPARQL queries when applicable for extra performance gain.

This PR introduces breaking changes in `IQuadsDestination` interface.