### PR TITLE
Fixed a bug where the order of count operations influenced the result

### DIFF
--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -832,7 +832,7 @@ SELECT ?obsId {
           ?s ?p ?o .
         }
         GROUP BY ?p
-        `, context))).map(binding => [ ...binding ].sort(([var1, _c1], [var2, _c2]) => var1.value.localeCompare(var2.value)));
+        `, context))).map(binding => [ ...binding ].sort(([ var1, _c1 ], [ var2, _c2 ]) => var1.value.localeCompare(var2.value)));
 
         expect(bindings1).toMatchObject(expectedResult);
         expect(bindings2).toMatchObject(expectedResult);

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -805,7 +805,7 @@ SELECT ?obsId {
           ?s ?p ?o .
         }
         GROUP BY ?p
-        `, context))).sort((a, b) => a - b);
+        `, context)));
 
         const expected = (await arrayifyStream(await engine.queryBindings(`
         SELECT (COUNT(DISTINCT ?o) as ?objects) (COUNT(DISTINCT ?s) AS ?subjects) ?p
@@ -814,7 +814,7 @@ SELECT ?obsId {
           ?s ?p ?o .
         }
         GROUP BY ?p
-        `, context))).sort((a, b) => a - b);
+        `, context)));
 
         expect(received).toHaveLength(expected.length);
         for (const [ index, receivedBindings ] of received.entries()) {

--- a/packages/actor-query-operation-group/lib/GroupsState.ts
+++ b/packages/actor-query-operation-group/lib/GroupsState.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import type { BindingsFactory } from '@comunica/bindings-factory';
 import type { HashFunction } from '@comunica/bus-hash-bindings';
 import type { IAsyncEvaluatorContext } from '@comunica/expression-evaluator';

--- a/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
+++ b/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
@@ -720,19 +720,17 @@ describe('ActorQueryOperationGroup', () => {
         variables: [ DF.variable('c') ],
       });
     });
-
     it('should be able to count distinct', async() => {
       const aggregate = aggregateOn('count', 'x', 'c');
       aggregate.distinct = true;
-      const i = int('1');
       const { op, actor } = constructCase({
         inputBindings: [
-          BF.bindings([[ DF.variable('x'), i ]]),
-          BF.bindings([[ DF.variable('x'), i ]]),
-          BF.bindings([[ DF.variable('x'), i ]]),
-          BF.bindings([[ DF.variable('x'), i ]]),
+          BF.bindings([[ DF.variable('x'), int('3') ]]),
+          BF.bindings([[ DF.variable('x'), int('3') ]]),
+          BF.bindings([[ DF.variable('x'), int('3') ]]),
+          BF.bindings([[ DF.variable('x'), int('3') ]]),
         ],
-        groupVariables: [],
+        groupVariables: [ ],
         inputVariables: [ 'x', 'y', 'z' ],
         inputOp: simpleXYZinput,
         aggregates: [ aggregate ],
@@ -745,7 +743,7 @@ describe('ActorQueryOperationGroup', () => {
         ]),
       ]);
       await expect(output.metadata()).resolves.toEqual({
-        cardinality: 1,
+        cardinality: 4,
         canContainUndefs: false,
         variables: [ DF.variable('c') ],
       });

--- a/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
+++ b/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
@@ -721,6 +721,36 @@ describe('ActorQueryOperationGroup', () => {
       });
     });
 
+    it('should be able to count distinct', async() => {
+      const aggregate = aggregateOn('count', 'x', 'c');
+      aggregate.distinct = true;
+      const i = int('1');
+      const { op, actor } = constructCase({
+        inputBindings: [
+          BF.bindings([[ DF.variable('x'), i ]]),
+          BF.bindings([[ DF.variable('x'), i ]]),
+          BF.bindings([[ DF.variable('x'), i ]]),
+          BF.bindings([[ DF.variable('x'), i ]]),
+        ],
+        groupVariables: [],
+        inputVariables: [ 'x', 'y', 'z' ],
+        inputOp: simpleXYZinput,
+        aggregates: [ aggregate ],
+      });
+
+      const output = <any> await actor.run(op);
+      await expect(output.bindingsStream).toEqualBindingsStream([
+        BF.bindings([
+          [ DF.variable('c'), int('1') ],
+        ]),
+      ]);
+      await expect(output.metadata()).resolves.toEqual({
+        cardinality: 1,
+        canContainUndefs: false,
+        variables: [ DF.variable('c') ],
+      });
+    });
+
     it('should be able to count with respect to empty input with group variables', async() => {
       const { op, actor } = constructCase({
         inputBindings: [],


### PR DESCRIPTION
Fixed a bug where the order of count operations influenced the result. See https://github.com/comunica/comunica/issues/1312

The problem was that we avoided counting a binding twice, even though it was for different aggregate expressions.
I solved it by hashing the binding with the expression variable and checking that this combination doesn't occur twice.

I'm not sure about the best practices when it comes to hashing, so it would be great if someone could update me on that.