### PR TITLE
Always add preprocessed context to unidentified query sources

### DIFF
--- a/packages/actor-context-preprocess-query-source-identify/lib/ActorContextPreprocessQuerySourceIdentify.ts
+++ b/packages/actor-context-preprocess-query-source-identify/lib/ActorContextPreprocessQuerySourceIdentify.ts
@@ -68,13 +68,9 @@ export class ActorContextPreprocessQuerySourceIdentify extends ActorContextPrepr
     }
     return {
       ...<Omit<IQuerySourceUnidentifiedExpanded, 'context'>>querySource,
-      ...querySource.context ?
-          {
-            context: (await this.mediatorContextPreprocess.mediate({
-              context: ActionContext.ensureActionContext(querySource.context),
-            })).context,
-          } :
-          {},
+      context: (await this.mediatorContextPreprocess.mediate({
+        context: ActionContext.ensureActionContext(querySource.context ?? {}),
+      })).context,
     };
   }
 

--- a/packages/actor-context-preprocess-query-source-identify/test/ActorContextPreprocessQuerySourceIdentify-test.ts
+++ b/packages/actor-context-preprocess-query-source-identify/test/ActorContextPreprocessQuerySourceIdentify-test.ts
@@ -76,9 +76,9 @@ describe('ActorContextPreprocessQuerySourceIdentify', () => {
         const { context: contextOut } = await actor.run({ context: contextIn });
         expect(contextOut).not.toBe(contextIn);
         expect(contextOut.get(KeysQueryOperation.querySources)).toEqual([
-          { ofUnidentified: { value: 'source1' }},
-          { ofUnidentified: { value: 'source2' }},
-          { ofUnidentified: { value: source3 }},
+          { ofUnidentified: expect.objectContaining({ value: 'source1' }) },
+          { ofUnidentified: expect.objectContaining({ value: 'source2' }) },
+          { ofUnidentified: expect.objectContaining({ value: source3 }) },
         ]);
       });
 


### PR DESCRIPTION
This should fix #1336 where query sources did not have any context entries.

Based on the comment in that issue by @rubensworks (correct me if I am wrong), context preprocessing is always expected to happen, but the code in the responsible actor was only preprocessing existing contexts. Thus, for a source without any context to begin with, no preprocessing would be done. This led to the exclusion of the traverse flag from link traversal sources.

The changes here remove the requirement to have a context added beforehand, by preprocessing either an existing context or an empty new one, and adding that to the source.

I have tested this locally by rebuilding the `solid-default` web client and running the query as it was done in the issue. The original query only produced 100 entries from Ruben's pod and none from Tim's (maybe due to the CORS errors I was getting), but the following query produced a total of 536 results across both pods:
```sparql
PREFIX terms: <http://purl.org/dc/terms/>

SELECT ?s ?o WHERE {
  ?s terms:created ?o.
}
```

If this fix is not ideal, I can try to adjust it somehow.