### PR TITLE
backpressure: fix serialisation backpressure issues

### DIFF
--- a/packages/actor-query-result-serialize-json/lib/ActorQueryResultSerializeJson.ts
+++ b/packages/actor-query-result-serialize-json/lib/ActorQueryResultSerializeJson.ts
@@ -41,6 +41,10 @@ export class ActorQueryResultSerializeJson extends ActorQueryResultSerializeFixe
   public async runHandle(action: IActionSparqlSerialize, _mediaType: string, _context: IActionContext):
   Promise<IActorQueryResultSerializeOutput> {
     const data = new Readable();
+    data._read = () => {
+      // Do nothing
+    };
+
     if (action.type === 'bindings' || action.type === 'quads') {
       let stream = action.type === 'bindings' ?
         wrap((<IQueryOperationResultBindings> action).bindingsStream)
@@ -57,15 +61,12 @@ export class ActorQueryResultSerializeJson extends ActorQueryResultSerializeFixe
       }).prepend([ '[' ]).append([ '\n]\n' ]);
 
       data.wrap(<any> stream);
-    } else if (action.type === 'boolean') {
-      try {
-        data.push(`${JSON.stringify(await (<IQueryOperationResultBoolean> action).execute())}\n`);
-        data.push(null);
-      } catch (error: unknown) {
-        setTimeout(() => data.emit('error', error));
-      }
-    } else {
-      throw new Error(`Unknown action type [${action.type}] for ${this.name}.`);
+    }
+    try {
+      data.push(`${JSON.stringify(await (<IQueryOperationResultBoolean> action).execute())}\n`);
+      data.push(null);
+    } catch (error: unknown) {
+      setTimeout(() => data.emit('error', error));
     }
 
     return { data };

--- a/packages/actor-query-result-serialize-json/package.json
+++ b/packages/actor-query-result-serialize-json/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@comunica/bus-query-result-serialize": "^3.1.0",
     "@comunica/types": "^3.1.0",
+    "asynciterator": "^3.9.0",
     "rdf-string": "^1.6.1",
     "readable-stream": "^4.4.2"
   }

--- a/packages/actor-query-result-serialize-json/test/ActorQueryResultSerializeJson-test.ts
+++ b/packages/actor-query-result-serialize-json/test/ActorQueryResultSerializeJson-test.ts
@@ -303,7 +303,7 @@ describe('ActorQueryResultSerializeJson', () => {
             handleMediaType: 'application/json',
             context,
           },
-        )).rejects.toThrowError('Unknown action type [invalid] for actor.');
+        )).rejects.toThrow('Unknown action type [invalid] for actor.');
       });
     });
   });

--- a/packages/actor-query-result-serialize-json/test/ActorQueryResultSerializeJson-test.ts
+++ b/packages/actor-query-result-serialize-json/test/ActorQueryResultSerializeJson-test.ts
@@ -295,16 +295,6 @@ describe('ActorQueryResultSerializeJson', () => {
           },
         ))).handle.data)).rejects.toBeTruthy();
       });
-
-      it('should throw an error when an invalid type is provided', async() => {
-        await expect(actor.run(
-          {
-            handle: <any> { type: 'invalid', context },
-            handleMediaType: 'application/json',
-            context,
-          },
-        )).rejects.toThrow('Unknown action type [invalid] for actor.');
-      });
     });
   });
 });

--- a/packages/actor-query-result-serialize-json/test/ActorQueryResultSerializeJson-test.ts
+++ b/packages/actor-query-result-serialize-json/test/ActorQueryResultSerializeJson-test.ts
@@ -226,7 +226,7 @@ describe('ActorQueryResultSerializeJson', () => {
             context,
           },
         ))).handle.data)).resolves
-          .toBe(`[]
+          .toBe(`[\n]
 `);
       });
 
@@ -238,7 +238,7 @@ describe('ActorQueryResultSerializeJson', () => {
             context,
           },
         ))).handle.data)).resolves
-          .toBe(`[]
+          .toBe(`[\n]
 `);
       });
 
@@ -294,6 +294,16 @@ describe('ActorQueryResultSerializeJson', () => {
             context,
           },
         ))).handle.data)).rejects.toBeTruthy();
+      });
+
+      it('should throw an error when an invalid type is provided', async() => {
+        await expect(actor.run(
+          {
+            handle: <any> { type: 'invalid', context },
+            handleMediaType: 'application/json',
+            context,
+          },
+        )).rejects.toThrowError('Unknown action type [invalid] for actor.');
       });
     });
   });

--- a/packages/actor-query-result-serialize-simple/package.json
+++ b/packages/actor-query-result-serialize-simple/package.json
@@ -40,6 +40,7 @@
     "@comunica/bus-query-result-serialize": "^3.1.0",
     "@comunica/types": "^3.1.0",
     "@rdfjs/types": "*",
+    "asynciterator": "^3.9.0",
     "rdf-string": "^1.6.3",
     "readable-stream": "^4.4.2"
   }

--- a/packages/actor-query-result-serialize-sparql-csv/lib/ActorQueryResultSerializeSparqlCsv.ts
+++ b/packages/actor-query-result-serialize-sparql-csv/lib/ActorQueryResultSerializeSparqlCsv.ts
@@ -76,26 +76,14 @@ export class ActorQueryResultSerializeSparqlCsv extends ActorQueryResultSerializ
     const bindingsAction = <IQueryOperationResultBindings> action;
 
     const data = new Readable();
-    data._read = () => {
-      // Do nothing
-    };
 
-    // Write head
     const metadata = await bindingsAction.metadata();
     data.push(`${metadata.variables.map(variable => variable.value).join(',')}\r\n`);
 
-    // Write bindings
-    bindingsAction.bindingsStream.on('error', (error: Error) => {
-      data.emit('error', error);
-    });
-    bindingsAction.bindingsStream.on('data', (bindings: Bindings) => {
-      data.push(`${metadata.variables
+    // Write head
+    data.wrap(<any> bindingsAction.bindingsStream.map((bindings: Bindings) => `${metadata.variables
         .map(key => ActorQueryResultSerializeSparqlCsv.bindingToCsvBindings(bindings.get(key)))
-        .join(',')}\r\n`);
-    });
-    bindingsAction.bindingsStream.on('end', () => {
-      data.push(null);
-    });
+        .join(',')}\r\n`));
 
     return { data };
   }

--- a/packages/actor-query-result-serialize-sparql-csv/lib/ActorQueryResultSerializeSparqlCsv.ts
+++ b/packages/actor-query-result-serialize-sparql-csv/lib/ActorQueryResultSerializeSparqlCsv.ts
@@ -78,9 +78,11 @@ export class ActorQueryResultSerializeSparqlCsv extends ActorQueryResultSerializ
     const data = new Readable();
 
     const metadata = await bindingsAction.metadata();
-    data.push(`${metadata.variables.map(variable => variable.value).join(',')}\r\n`);
 
     // Write head
+    data.push(`${metadata.variables.map(variable => variable.value).join(',')}\r\n`);
+
+    // Write body
     data.wrap(<any> bindingsAction.bindingsStream.map((bindings: Bindings) => `${metadata.variables
         .map(key => ActorQueryResultSerializeSparqlCsv.bindingToCsvBindings(bindings.get(key)))
         .join(',')}\r\n`));

--- a/packages/actor-query-result-serialize-sparql-json/lib/ActorQueryResultSerializeSparqlJson.ts
+++ b/packages/actor-query-result-serialize-sparql-json/lib/ActorQueryResultSerializeSparqlJson.ts
@@ -5,12 +5,12 @@ import type {
 } from '@comunica/bus-query-result-serialize';
 import { ActorQueryResultSerializeFixedMediaTypes } from '@comunica/bus-query-result-serialize';
 import type {
-  Bindings,
   IActionContext,
   IQueryOperationResultBindings,
   IQueryOperationResultBoolean,
 } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
+import { wrap } from 'asynciterator';
 import { Readable } from 'readable-stream';
 import type { ActionObserverHttp } from './ActionObserverHttp';
 
@@ -47,8 +47,7 @@ export class ActorQueryResultSerializeSparqlJson extends ActorQueryResultSeriali
     if (value.termType === 'Literal') {
       const literal: RDF.Literal = value;
       const jsonValue: any = { value: literal.value, type: 'literal' };
-      const { language } = literal;
-      const { datatype } = literal;
+      const { language, datatype } = literal;
       if (language) {
         jsonValue['xml:lang'] = language;
       } else if (datatype && datatype.value !== 'http://www.w3.org/2001/XMLSchema#string') {
@@ -82,10 +81,6 @@ export class ActorQueryResultSerializeSparqlJson extends ActorQueryResultSeriali
   public async runHandle(action: IActionSparqlSerialize, _mediaType: string | undefined, _context: IActionContext):
   Promise<IActorQueryResultSerializeOutput> {
     const data = new Readable();
-    data._read = () => {
-      // Do nothing
-    };
-
     // Write head
     const head: any = {};
     if (action.type === 'bindings') {
@@ -95,55 +90,24 @@ export class ActorQueryResultSerializeSparqlJson extends ActorQueryResultSeriali
       }
     }
     data.push(`{"head": ${JSON.stringify(head)},\n`);
-    let empty = true;
 
     if (action.type === 'bindings') {
-      const resultStream: NodeJS.EventEmitter = (<IQueryOperationResultBindings> action).bindingsStream;
+      const resultStream = (<IQueryOperationResultBindings> action).bindingsStream;
+      data.push('"results": { "bindings": [\n');
 
+      let first = true;
       // Write bindings
-      resultStream.on('error', (error: Error) => {
-        data.emit('error', error);
-      });
-      resultStream.on('data', (bindings: Bindings) => {
-        if (empty) {
-          data.push('"results": { "bindings": [\n');
-        } else {
-          data.push(',\n');
-        }
-
+      data.wrap(
         // JSON SPARQL results spec does not allow unbound variables and blank node bindings
-        const bindingsJson = Object.fromEntries([ ...bindings ]
-          .map(([ key, value ]) => [ key.value, ActorQueryResultSerializeSparqlJson.bindingToJsonBindings(value) ]));
-        data.push(JSON.stringify(bindingsJson));
-        empty = false;
-      });
-
-      // Close streams
-      resultStream.on('end', () => {
-        // Push bindings header if empty
-        if (empty) {
-          data.push('"results": { "bindings": [\n');
-        }
-
-        // End bindings array
-        data.push('\n]}');
-
-        // Push metadata footer
-        if (this.emitMetadata) {
-          data.push(`,\n"metadata": { "httpRequests": ${this.httpObserver.requests} }`);
-        }
-
-        // End stream
-        data.push('}\n');
-        data.push(null);
-      });
+        <any> wrap(resultStream).map((bindings) => {
+          const res = `${first ? '' : ',\n'}${JSON.stringify(Object.fromEntries([ ...bindings ]
+          .map(([ key, value ]) => [ key.value, ActorQueryResultSerializeSparqlJson.bindingToJsonBindings(value) ])))}`;
+          first = false;
+          return res;
+        }).append([ `\n]}${this.emitMetadata ? `,\n"metadata": { "httpRequests": ${this.httpObserver.requests} }` : ''}}\n` ]),
+      );
     } else {
-      try {
-        data.push(`"boolean":${await (<IQueryOperationResultBoolean> action).execute()}\n}\n`);
-        data.push(null);
-      } catch (error: unknown) {
-        data.once('newListener', () => data.emit('error', error));
-      }
+      data.wrap(<any> wrap((<IQueryOperationResultBoolean> action).execute().then(value => [ `"boolean":${value}\n}\n` ])));
     }
 
     return { data };

--- a/packages/actor-query-result-serialize-sparql-json/package.json
+++ b/packages/actor-query-result-serialize-sparql-json/package.json
@@ -43,6 +43,7 @@
     "@comunica/core": "^3.1.0",
     "@comunica/types": "^3.1.0",
     "@rdfjs/types": "*",
+    "asynciterator": "^3.9.0",
     "readable-stream": "^4.4.2"
   }
 }

--- a/packages/actor-query-result-serialize-sparql-tsv/lib/ActorQueryResultSerializeSparqlTsv.ts
+++ b/packages/actor-query-result-serialize-sparql-tsv/lib/ActorQueryResultSerializeSparqlTsv.ts
@@ -57,32 +57,13 @@ export class ActorQueryResultSerializeSparqlTsv extends ActorQueryResultSerializ
     const bindingsAction = <IQueryOperationResultBindings> action;
 
     const data = new Readable();
-    const read = data._read = (size) => {
-      while (size > 0) {
-        const bindings = bindingsAction.bindingsStream.read();
-        if (bindings === null) {
-          bindingsAction.bindingsStream.once('readable', () => read(size));
-          return;
-        }
-        size--;
-        data.push(`${metadata.variables
-          .map((key: RDF.Variable) => ActorQueryResultSerializeSparqlTsv
-            .bindingToTsvBindings(bindings.get(key)))
-          .join('\t')}\n`);
-      }
-    };
-
     // Write head
     const metadata = await bindingsAction.metadata();
     data.push(`${metadata.variables.map((variable: RDF.Variable) => variable.value).join('\t')}\n`);
-
-    // Write bindings
-    bindingsAction.bindingsStream.on('error', (error: Error) => {
-      data.emit('error', error);
-    });
-    bindingsAction.bindingsStream.on('end', () => {
-      data.push(null);
-    });
+    data.wrap(<any> bindingsAction.bindingsStream.map((bindings: RDF.Bindings) => `${metadata.variables
+      .map((key: RDF.Variable) => ActorQueryResultSerializeSparqlTsv
+        .bindingToTsvBindings(bindings.get(key)))
+      .join('\t')}\n`));
 
     return { data };
   }

--- a/packages/actor-query-result-serialize-sparql-tsv/lib/ActorQueryResultSerializeSparqlTsv.ts
+++ b/packages/actor-query-result-serialize-sparql-tsv/lib/ActorQueryResultSerializeSparqlTsv.ts
@@ -60,6 +60,8 @@ export class ActorQueryResultSerializeSparqlTsv extends ActorQueryResultSerializ
     // Write head
     const metadata = await bindingsAction.metadata();
     data.push(`${metadata.variables.map((variable: RDF.Variable) => variable.value).join('\t')}\n`);
+
+    // Write Bindings
     data.wrap(<any> bindingsAction.bindingsStream.map((bindings: RDF.Bindings) => `${metadata.variables
       .map((key: RDF.Variable) => ActorQueryResultSerializeSparqlTsv
         .bindingToTsvBindings(bindings.get(key)))

--- a/packages/actor-query-result-serialize-sparql-xml/lib/ActorQueryResultSerializeSparqlXml.ts
+++ b/packages/actor-query-result-serialize-sparql-xml/lib/ActorQueryResultSerializeSparqlXml.ts
@@ -79,7 +79,9 @@ export class ActorQueryResultSerializeSparqlXml extends ActorQueryResultSerializ
   public async runHandle(action: IActionSparqlSerialize, _mediaType: string, _context: IActionContext):
   Promise<IActorQueryResultSerializeOutput> {
     const data = new Readable();
-    data._read = () => {};
+    data._read = () => {
+      // Do nothing
+    };
 
     const serializer = new XmlSerializer();
     const metadata = await (<IQueryOperationResultBindings> action).metadata();

--- a/packages/actor-query-result-serialize-sparql-xml/lib/XmlSerializer.ts
+++ b/packages/actor-query-result-serialize-sparql-xml/lib/XmlSerializer.ts
@@ -2,38 +2,32 @@
  * A very simple XML serializer
  */
 export class XmlSerializer {
-  private readonly push: (data: string) => void;
-
   private readonly stack: string[] = [];
 
-  public constructor(push: (data: string) => void) {
-    this.push = push;
-    this.push(`<?xml version="1.0" encoding="UTF-8"?>\n`);
-  }
+  public static header = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+
+  public constructor() {}
 
   /**
    *
    * @param name should be a valid XML tag name
    * @param attributes keys should be valid attribute names
    */
-  public open(name: string, attributes?: Record<string, string>): void {
-    this.push(`${this.identation() + this.formatTag(name, attributes, 'open')}\n`);
+  public open(name: string, attributes?: Record<string, string>): string {
+    const res = `${this.identation() + this.formatTag(name, attributes, 'open')}\n`;
     this.stack.push(name);
+    return res;
   }
 
-  public close(): void {
+  public close(): string {
     const name = this.stack.pop();
     if (name === undefined) {
       throw new Error('There is no tag left to close');
     }
-    this.push(`${this.identation() + this.formatTag(name, {}, 'close')}\n`);
+    return `${this.identation() + this.formatTag(name, {}, 'close')}\n`;
   }
 
-  public add(node: IXmlNode): void {
-    this.push(this.serializeNode(node));
-  }
-
-  private serializeNode(node: IXmlNode): string {
+  public serializeNode(node: IXmlNode): string {
     if (node.children === undefined) {
       return `${this.identation() + this.formatTag(node.name, node.attributes, 'self-closing')}\n`;
     }

--- a/packages/actor-query-result-serialize-sparql-xml/package.json
+++ b/packages/actor-query-result-serialize-sparql-xml/package.json
@@ -40,6 +40,7 @@
     "@comunica/bus-query-result-serialize": "^3.1.0",
     "@comunica/types": "^3.1.0",
     "@rdfjs/types": "*",
+    "asynciterator": "^3.9.0",
     "readable-stream": "^4.4.2"
   }
 }

--- a/packages/actor-query-result-serialize-sparql-xml/test/XmlSerializer-test.ts
+++ b/packages/actor-query-result-serialize-sparql-xml/test/XmlSerializer-test.ts
@@ -6,12 +6,13 @@ describe('XmlSerializer', () => {
 
   beforeEach(() => {
     data = [];
-    serializer = new XmlSerializer(chunk => data.push(chunk));
+    serializer = new XmlSerializer();
   });
 
   it('should support opening and closing tags', () => {
-    serializer.open('foo', { bar: 'baz' });
-    serializer.close();
+    data.push(XmlSerializer.header);
+    data.push(serializer.open('foo', { bar: 'baz' }));
+    data.push(serializer.close());
     expect(data.join('')).toBe(`<?xml version="1.0" encoding="UTF-8"?>
 <foo bar="baz">
 </foo>
@@ -19,14 +20,15 @@ describe('XmlSerializer', () => {
   });
 
   it('should support tree', () => {
-    serializer.add({
+    data.push(XmlSerializer.header);
+    data.push(serializer.serializeNode({
       name: 'foo',
       attributes: { bar: 'baz' },
       children: [
         { name: 'bar', attributes: { bar: 'baz' }, children: 'test' },
         { name: 'baz', attributes: { bar: 'baz' }},
       ],
-    });
+    }));
     expect(data.join('')).toBe(`<?xml version="1.0" encoding="UTF-8"?>
 <foo bar="baz">
   <bar bar="baz">test</bar>
@@ -36,22 +38,25 @@ describe('XmlSerializer', () => {
   });
 
   it('should escape text', () => {
-    serializer.add({ name: 'bar', children: '\'&<>"' });
+    data.push(XmlSerializer.header);
+    data.push(serializer.serializeNode({ name: 'bar', children: '\'&<>"' }));
     expect(data.join('')).toBe(`<?xml version="1.0" encoding="UTF-8"?>
 <bar>&apos;&amp;&lt;&gt;&quot;</bar>
 `);
   });
 
   it('should escape attributes', () => {
-    serializer.add({ name: 'bar', attributes: { baz: '\'&<>"' }});
+    data.push(XmlSerializer.header);
+    data.push(serializer.serializeNode({ name: 'bar', attributes: { baz: '\'&<>"' }}));
     expect(data.join('')).toBe(`<?xml version="1.0" encoding="UTF-8"?>
 <bar baz="&apos;&amp;&lt;&gt;&quot;"/>
 `);
   });
 
   it('should check extra close calls', () => {
-    serializer.open('foo');
-    serializer.close();
+    data.push(XmlSerializer.header);
+    data.push(serializer.open('foo'));
+    data.push(serializer.close());
     expect(() => serializer.close()).toThrow(Error);
   });
 });

--- a/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
+++ b/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
@@ -49,6 +49,7 @@ export class ActorQueryResultSerializeStats extends ActorQueryResultSerializeFix
   /**
    * @deprecated Use {@link createStat} instead.
    */
+  /* istanbul ignore next */
   public pushStat(data: Readable, startTime: number, result: number): void {
     /* istanbul ignore next */
     data.push(this.createStat(startTime, result));
@@ -63,6 +64,7 @@ export class ActorQueryResultSerializeStats extends ActorQueryResultSerializeFix
   /**
    * @deprecated Use {@link createFooter} instead.
    */
+  /* istanbul ignore next */
   public pushFooter(data: Readable, startTime: number): void {
     /* istanbul ignore next */
     data.push(this.createFooter(startTime));

--- a/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
+++ b/packages/actor-query-result-serialize-stats/lib/ActorQueryResultSerializeStats.ts
@@ -46,30 +46,10 @@ export class ActorQueryResultSerializeStats extends ActorQueryResultSerializeFix
     data.push(`${header}\n`);
   }
 
-  /**
-   * @deprecated Use {@link createStat} instead.
-   */
-  /* istanbul ignore next */
-  public pushStat(data: Readable, startTime: number, result: number): void {
-    /* istanbul ignore next */
-    data.push(this.createStat(startTime, result));
-  }
-
   public createStat(startTime: number, result: number): string {
     const row: string = [ result, this.delay(startTime), this.httpObserver.requests,
     ].join(',');
     return `${row}\n`;
-  }
-
-  /**
-   * @deprecated Use {@link createFooter} instead.
-   */
-  /* istanbul ignore next */
-  public pushFooter(data: Readable, startTime: number): void {
-    /* istanbul ignore next */
-    data.push(this.createFooter(startTime));
-    /* istanbul ignore next */
-    data.push(null);
   }
 
   public createFooter(startTime: number): string {

--- a/packages/actor-query-result-serialize-stats/package.json
+++ b/packages/actor-query-result-serialize-stats/package.json
@@ -42,6 +42,7 @@
     "@comunica/bus-query-result-serialize": "^3.1.0",
     "@comunica/core": "^3.1.0",
     "@comunica/types": "^3.1.0",
+    "asynciterator": "^3.9.0",
     "process": "^0.11.10",
     "readable-stream": "^4.4.2"
   }

--- a/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
+++ b/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
@@ -64,8 +64,11 @@ export class ActorQueryResultSerializeTable extends ActorQueryResultSerializeFix
     data.push(`${header}\n${ActorQueryResultSerializeTable.repeat('-', header.length)}\n`);
   }
 
+  /**
+   * @deprecated Use {@link createRow} instead.
+   */
   public pushRow(data: Readable, labels: RDF.Variable[], bindings: Bindings): void {
-    // instanbul ignore next
+    /* istanbul ignore next */
     data.push(this.createRow(labels, bindings));
   }
 

--- a/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
+++ b/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
@@ -64,15 +64,6 @@ export class ActorQueryResultSerializeTable extends ActorQueryResultSerializeFix
     data.push(`${header}\n${ActorQueryResultSerializeTable.repeat('-', header.length)}\n`);
   }
 
-  /* istanbul ignore next */
-  /**
-   * @deprecated Use {@link createRow} instead.
-   */
-  public pushRow(data: Readable, labels: RDF.Variable[], bindings: Bindings): void {
-    /* istanbul ignore next */
-    data.push(this.createRow(labels, bindings));
-  }
-
   public createRow(labels: RDF.Variable[], bindings: Bindings): string {
     return `${labels
       .map(label => bindings.has(label) ? this.termToString(bindings.get(label)!) : '')

--- a/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
+++ b/packages/actor-query-result-serialize-table/lib/ActorQueryResultSerializeTable.ts
@@ -64,6 +64,7 @@ export class ActorQueryResultSerializeTable extends ActorQueryResultSerializeFix
     data.push(`${header}\n${ActorQueryResultSerializeTable.repeat('-', header.length)}\n`);
   }
 
+  /* istanbul ignore next */
   /**
    * @deprecated Use {@link createRow} instead.
    */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,7 +2382,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
@@ -13359,7 +13359,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13376,15 +13376,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -13455,7 +13446,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13468,13 +13459,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -14650,7 +14634,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14663,15 +14647,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR resolves backpressure issues in the serialisers (partly resolving #759).

It also makes it easy to migrate to having serialisers return `AsyncIterator`s rather than `Readable`s as we are now largely just wrapping `Readable`s around `AsyncIterator`s. If there is demand for consuming the serialised information as `AsyncIterator`s then one option would be to extend the output interface to be

```ts
export interface IActorQueryResultSerializeOutput extends IActorOutput {
  /**
   * A readable string stream in a certain SPARQL serialization that was serialized.
   */
  data: NodeJS.ReadableStream;
  
  iterator: AsyncIterator<string>;
}
```

and implement it such that the `data` key is a getter which only creates a readable stream wrapping the asynciterator when the `data` key is retrieved.

cc @rubensworks @jacoscaz 