### PR TITLE
chore: reduce use of transform

### DIFF
--- a/packages/actor-query-operation-path-nps/lib/ActorQueryOperationPathNps.ts
+++ b/packages/actor-query-operation-path-nps/lib/ActorQueryOperationPathNps.ts
@@ -26,8 +26,7 @@ export class ActorQueryOperationPathNps extends ActorAbstractPath {
 
     // Remove the generated blank nodes from the bindings
     const bindingsStream = output.bindingsStream
-      .filter(bindings => !predicate.iris.some(iri => iri.equals(bindings.get(blank))))  
-      .map(item => item.delete(blank))
+      .map(bindings => predicate.iris.some(iri => iri.equals(bindings.get(blank))) ? null : bindings.delete(blank));
 
     return {
       type: 'bindings',

--- a/packages/actor-query-operation-path-nps/lib/ActorQueryOperationPathNps.ts
+++ b/packages/actor-query-operation-path-nps/lib/ActorQueryOperationPathNps.ts
@@ -3,7 +3,7 @@ import type { IActorQueryOperationTypedMediatedArgs } from '@comunica/bus-query-
 import {
   ActorQueryOperation,
 } from '@comunica/bus-query-operation';
-import type { Bindings, IActionContext, IQueryOperationResult } from '@comunica/types';
+import type { IActionContext, IQueryOperationResult } from '@comunica/types';
 import { Algebra } from 'sparqlalgebrajs';
 
 /**
@@ -25,15 +25,9 @@ export class ActorQueryOperationPathNps extends ActorAbstractPath {
     );
 
     // Remove the generated blank nodes from the bindings
-    const bindingsStream = output.bindingsStream.transform<Bindings>({
-      filter(bindings) {
-        return !predicate.iris.some(iri => iri.equals(bindings.get(blank)));
-      },
-      transform(item, next, push) {
-        push(item.delete(blank));
-        next();
-      },
-    });
+    const bindingsStream = output.bindingsStream
+      .filter(bindings => !predicate.iris.some(iri => iri.equals(bindings.get(blank))))  
+      .map(item => item.delete(blank))
 
     return {
       type: 'bindings',


### PR DESCRIPTION
`#map` is much more efficient when `#transform` due to https://github.com/RubenVerborgh/AsyncIterator/pull/75.