### PR TITLE
chore: migrate parse-link-header to http-link-header

### DIFF
--- a/lerna-custom-script.js
+++ b/lerna-custom-script.js
@@ -18,7 +18,7 @@ function filterTypeUsedTypeDependencies({ dependencies, using }) {
   const newDependencies = [];
   for (const dependency of dependencies) {
     if (dependency.startsWith('@types/') && Object.keys(using).includes(dependency.slice(7))) {
-      break;
+      continue;
     }
     newDependencies.push(dependency);
   }

--- a/packages/actor-http-memento/lib/ActorHttpMemento.ts
+++ b/packages/actor-http-memento/lib/ActorHttpMemento.ts
@@ -3,10 +3,7 @@ import { ActorHttp } from '@comunica/bus-http';
 import { KeysHttpMemento } from '@comunica/context-entries';
 import type { IActorTest } from '@comunica/core';
 import 'cross-fetch/polyfill';
-
-// Use require instead of import for default exports, to be compatible with variants of esModuleInterop in tsconfig.
-// eslint-disable-next-line ts/no-require-imports
-import parseLink = require('parse-link-header');
+import { parse } from 'http-link-header';
 
 /**
  * A comunica Memento Http Actor.
@@ -47,11 +44,12 @@ export class ActorHttpMemento extends ActorHttp {
     // Did we ask for a time-negotiated response, but haven't received one?
     if (headers.has('accept-datetime') && result.headers && !result.headers.has('memento-datetime')) {
       // The links might have a timegate that can help us
-      const links = result.headers.has('link') && parseLink(result.headers.get('link'));
-      if (links && links.timegate) {
+      const header = result.headers.get('link');
+      const timegate = header && parse(header)?.get('rel', 'timegate');
+      if (timegate && timegate.length > 0) {
         await result.body?.cancel();
         // Respond with a time-negotiated response from the timegate instead
-        const followLink: IActionHttp = { context: action.context, input: links.timegate.url, init };
+        const followLink: IActionHttp = { context: action.context, input: timegate[0].uri, init };
         return this.mediatorHttp.mediate(followLink);
       }
     }

--- a/packages/actor-http-memento/package.json
+++ b/packages/actor-http-memento/package.json
@@ -40,10 +40,8 @@
     "@comunica/bus-http": "^3.2.0",
     "@comunica/context-entries": "^3.2.0",
     "@comunica/core": "^3.2.0",
+    "@types/http-link-header": "^1.0.7",
     "cross-fetch": "^4.0.0",
     "http-link-header": "^1.1.3"
-  },
-  "devDependencies": {
-    "@types/http-link-header": "^1.0.7"
   }
 }

--- a/packages/actor-http-memento/package.json
+++ b/packages/actor-http-memento/package.json
@@ -42,6 +42,9 @@
     "@comunica/core": "^3.2.0",
     "@types/parse-link-header": "^2.0.0",
     "cross-fetch": "^4.0.0",
-    "parse-link-header": "^2.0.0"
+    "http-link-header": "^1.1.3"
+  },
+  "devDependencies": {
+    "@types/http-link-header": "^1.0.7"
   }
 }

--- a/packages/actor-http-memento/package.json
+++ b/packages/actor-http-memento/package.json
@@ -40,7 +40,6 @@
     "@comunica/bus-http": "^3.2.0",
     "@comunica/context-entries": "^3.2.0",
     "@comunica/core": "^3.2.0",
-    "@types/parse-link-header": "^2.0.0",
     "cross-fetch": "^4.0.0",
     "http-link-header": "^1.1.3"
   },

--- a/packages/actor-http-native/package.json
+++ b/packages/actor-http-native/package.json
@@ -40,15 +40,13 @@
     "@comunica/bus-http": "^3.2.0",
     "@comunica/context-entries": "^3.2.0",
     "@comunica/mediatortype-time": "^3.2.0",
+    "@types/http-link-header": "^1.0.7",
     "cross-fetch": "^4.0.0",
     "follow-redirects": "^1.15.2",
-    "parse-link-header": "^2.0.0",
+    "http-link-header": "^1.1.3",
     "process": "^0.11.10"
   },
   "browser": {
     "./lib/Requester.js": "./lib/Requester-browser.js"
-  },
-  "devDependencies": {
-    "@types/parse-link-header": "^2.0.3"
   }
 }

--- a/packages/actor-http-native/package.json
+++ b/packages/actor-http-native/package.json
@@ -47,5 +47,8 @@
   },
   "browser": {
     "./lib/Requester.js": "./lib/Requester-browser.js"
+  },
+  "devDependencies": {
+    "@types/parse-link-header": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,7 +2409,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
@@ -2941,11 +2941,6 @@
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
-
-"@types/parse-link-header@^2.0.0":
-  version "2.0.3"
-  resolved "https://registry.npmjs.org/@types/parse-link-header/-/parse-link-header-2.0.3.tgz"
-  integrity sha512-ffLAxD6Xqcf2gSbtEJehj8yJ5R/2OZqD4liodQvQQ+hhO4kg1mk9ToEZQPMtNTm/zIQj2GNleQbsjPp9+UQm4Q==
 
 "@types/pidusage@^2.0.5":
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,7 +2409,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
@@ -2941,6 +2941,11 @@
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
+
+"@types/parse-link-header@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/parse-link-header/-/parse-link-header-2.0.3.tgz#37ad650d12aecb055b64c2d43ddb1534e356ad33"
+  integrity sha512-ffLAxD6Xqcf2gSbtEJehj8yJ5R/2OZqD4liodQvQQ+hhO4kg1mk9ToEZQPMtNTm/zIQj2GNleQbsjPp9+UQm4Q==
 
 "@types/pidusage@^2.0.5":
   version "2.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,7 +2409,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
@@ -2941,11 +2941,6 @@
   version "4.0.2"
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz"
   integrity sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==
-
-"@types/parse-link-header@^2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@types/parse-link-header/-/parse-link-header-2.0.3.tgz#37ad650d12aecb055b64c2d43ddb1534e356ad33"
-  integrity sha512-ffLAxD6Xqcf2gSbtEJehj8yJ5R/2OZqD4liodQvQQ+hhO4kg1mk9ToEZQPMtNTm/zIQj2GNleQbsjPp9+UQm4Q==
 
 "@types/pidusage@^2.0.5":
   version "2.0.5"
@@ -11409,13 +11404,6 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
-
-parse-link-header@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/parse-link-header/-/parse-link-header-2.0.0.tgz"
-  integrity sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==
-  dependencies:
-    xtend "~4.0.1"
 
 parse-passwd@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,7 +2409,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@1.1.0", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
+"@rdfjs/types@*", "@rdfjs/types@>=1.0.0", "@rdfjs/types@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-1.1.0.tgz#098f180b7cccb03bb416c7b4d03baaa9d480e36b"
   integrity sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==
@@ -2813,6 +2813,13 @@
   version "1.0.5"
   resolved "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.5.tgz"
   integrity sha512-AxhIKR8UbyoqCTNp9rRepkktHuUOw3DjfOfDCaO9kwI8AYzjhxyrvZq4+mRw/2daD3hYDknrtSeV6SsPwmc71w==
+  dependencies:
+    "@types/node" "*"
+
+"@types/http-link-header@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/http-link-header/-/http-link-header-1.0.7.tgz#bb1a1671a8c6d93717e0057072e9253113fdc875"
+  integrity sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==
   dependencies:
     "@types/node" "*"
 
@@ -7779,9 +7786,9 @@ http-graceful-shutdown@^3.1.5:
   dependencies:
     debug "^4.3.4"
 
-http-link-header@^1.0.2:
+http-link-header@^1.0.2, http-link-header@^1.1.3:
   version "1.1.3"
-  resolved "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/http-link-header/-/http-link-header-1.1.3.tgz#b367b7a0ad1cf14027953f31aa1df40bb433da2a"
   integrity sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==
 
 http-proxy-agent@^5.0.0:


### PR DESCRIPTION
migrate `parse-link-header` to `http-link-header` in preparation for ESM support