### PR TITLE
Fix source attribution for qpf and SPARQL endpoints

### DIFF
--- a/packages/actor-query-source-identify-hypermedia-annotate-source/lib/ActorQuerySourceIdentifyHypermediaAnnotateSource.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/lib/ActorQuerySourceIdentifyHypermediaAnnotateSource.ts
@@ -27,7 +27,7 @@ export class ActorQuerySourceIdentifyHypermediaAnnotateSource extends ActorQuery
     if (action.context.get(KEY_CONTEXT_WRAPPED)) {
       throw new Error('Unable to wrap query source multiple times');
     }
-    return { filterFactor: 0 };
+    return { filterFactor: Number.POSITIVE_INFINITY };
   }
 
   public async run(action: IActionQuerySourceIdentifyHypermedia): Promise<IActorQuerySourceIdentifyHypermediaOutput> {

--- a/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
@@ -47,7 +47,7 @@ describe('ActorQuerySourceIdentifyHypermediaSourceAttribution', () => {
 
     it('should test', async() => {
       await expect(actor.test({ metadata: <any> null, quads: <any> null, url: '', context }))
-        .resolves.toEqual({ filterFactor: 0 });
+        .resolves.toEqual({ filterFactor: Number.POSITIVE_INFINITY });
     });
 
     it('should run', async() => {

--- a/packages/actor-query-source-identify-hypermedia-qpf/lib/QuerySourceQpf.ts
+++ b/packages/actor-query-source-identify-hypermedia-qpf/lib/QuerySourceQpf.ts
@@ -5,6 +5,7 @@ import { filterMatchingQuotedQuads, quadsToBindings } from '@comunica/bus-query-
 import type { MediatorRdfMetadata, IActorRdfMetadataOutput } from '@comunica/bus-rdf-metadata';
 import type { MediatorRdfMetadataExtract } from '@comunica/bus-rdf-metadata-extract';
 import { KeysQueryOperation } from '@comunica/context-entries';
+import { MetadataValidationState } from '@comunica/metadata';
 import type {
   IQuerySource,
   BindingsStream,
@@ -114,7 +115,7 @@ export class QuerySourceQpf implements IQuerySource {
       if (this.defaultGraph) {
         wrappedQuads = this.reverseMapQuadsToDefaultGraph(wrappedQuads);
       }
-      wrappedQuads.setProperty('metadata', metadata);
+      wrappedQuads.setProperty('metadata', { ...metadata, state: new MetadataValidationState() });
       this.cacheQuads(wrappedQuads, DF.variable(''), DF.variable(''), DF.variable(''), DF.variable(''));
     }
   }
@@ -238,6 +239,7 @@ export class QuerySourceQpf implements IQuerySource {
           // Without union-default-graph, the default graph must be empty.
           const quads = new ArrayIterator<RDF.Quad>([], { autoStart: false });
           quads.setProperty('metadata', {
+            state: new MetadataValidationState(),
             requestTime: 0,
             cardinality: { type: 'exact', value: 0 },
             first: null,
@@ -296,7 +298,10 @@ export class QuerySourceQpf implements IQuerySource {
           metadata: rdfMetadataOuput.metadata,
           requestTime: dereferenceRdfOutput.requestTime,
         });
-      quads!.setProperty('metadata', { ...metadata, canContainUndefs: false, subsetOf: self.url });
+      quads!.setProperty(
+        'metadata',
+        { ...metadata, state: new MetadataValidationState(), canContainUndefs: false, subsetOf: self.url },
+      );
 
       // While we could resolve this before metadata extraction, we do it afterwards to ensure metadata emission
       // before the end event is emitted.

--- a/packages/actor-query-source-identify-hypermedia-qpf/package.json
+++ b/packages/actor-query-source-identify-hypermedia-qpf/package.json
@@ -46,6 +46,7 @@
     "@comunica/bus-rdf-metadata": "^3.2.1",
     "@comunica/bus-rdf-metadata-extract": "^3.2.1",
     "@comunica/context-entries": "^3.2.1",
+    "@comunica/metadata": "^3.2.1",
     "@comunica/types": "^3.2.1",
     "@rdfjs/types": "*",
     "asynciterator": "^3.9.0",

--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
@@ -2,6 +2,7 @@ import type { BindingsFactory } from '@comunica/bindings-factory';
 import type { MediatorHttp } from '@comunica/bus-http';
 import { KeysInitQuery } from '@comunica/context-entries';
 import { Actor } from '@comunica/core';
+import { MetadataValidationState } from '@comunica/metadata';
 import type {
   IQuerySource,
   BindingsStream,
@@ -214,11 +215,13 @@ export class QuerySourceSparql implements IQuerySource {
       }
     })
       .then(cardinality => target.setProperty('metadata', {
+        state: new MetadataValidationState(),
         cardinality,
         canContainUndefs,
         variables: variablesCount,
       }))
       .catch(() => target.setProperty('metadata', {
+        state: new MetadataValidationState(),
         cardinality: COUNT_INFINITY,
         canContainUndefs,
         variables: variablesCount,

--- a/packages/actor-query-source-identify-hypermedia-sparql/package.json
+++ b/packages/actor-query-source-identify-hypermedia-sparql/package.json
@@ -43,6 +43,7 @@
     "@comunica/bus-query-source-identify-hypermedia": "^3.2.1",
     "@comunica/context-entries": "^3.2.1",
     "@comunica/core": "^3.2.1",
+    "@comunica/metadata": "^3.2.1",
     "@comunica/types": "^3.2.1",
     "@rdfjs/types": "*",
     "asynciterator": "^3.9.0",


### PR DESCRIPTION
This fix should solve the problems encountered in #1396. It prioritizes the source attribution wrapper by setting the filter factor to positive infinity (as higher is better in this case). Furthermore, it adds Invalidation states to binding stream metadata obtained from SPARQL endpoints and QPF. 

Question:
Some tests are failing as the QPF and SPARQL endpoint tests don't expect a state in the metadata of these bindings. As these tests explicitly omit the invalidation states I'm not confident these states weren't omitted for a reason. Were they? If so, doesn't the metadata interface require a state?