### PR TITLE
Fix the typo where the actor refers to QuerySourceQpf instead of QuerySourceRdfJs

### DIFF
--- a/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
+++ b/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
@@ -142,21 +142,21 @@ export class QuerySourceRdfJs implements IQuerySource {
     _operation: Algebra.Operation,
     _context: IActionContext,
   ): AsyncIterator<RDF.Quad> {
-    throw new Error('queryQuads is not implemented in QuerySourceQpf');
+    throw new Error('queryQuads is not implemented in QuerySourceRdfJs');
   }
 
   public queryBoolean(
     _operation: Algebra.Ask,
     _context: IActionContext,
   ): Promise<boolean> {
-    throw new Error('queryBoolean is not implemented in QuerySourceQpf');
+    throw new Error('queryBoolean is not implemented in QuerySourceRdfJs');
   }
 
   public queryVoid(
     _operation: Algebra.Update,
     _context: IActionContext,
   ): Promise<void> {
-    throw new Error('queryVoid is not implemented in QuerySourceQpf');
+    throw new Error('queryVoid is not implemented in QuerySourceRdfJs');
   }
 
   public toString(): string {

--- a/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
+++ b/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
@@ -578,21 +578,21 @@ describe('QuerySourceRdfJs', () => {
   describe('queryQuads', () => {
     it('should throw', () => {
       expect(() => source.queryQuads(<any> undefined, ctx))
-        .toThrow(`queryQuads is not implemented in QuerySourceQpf`);
+        .toThrow(`queryQuads is not implemented in QuerySourceRdfJs`);
     });
   });
 
   describe('queryBoolean', () => {
     it('should throw', () => {
       expect(() => source.queryBoolean(<any> undefined, ctx))
-        .toThrow(`queryBoolean is not implemented in QuerySourceQpf`);
+        .toThrow(`queryBoolean is not implemented in QuerySourceRdfJs`);
     });
   });
 
   describe('queryVoid', () => {
     it('should throw', () => {
       expect(() => source.queryVoid(<any> undefined, ctx))
-        .toThrow(`queryVoid is not implemented in QuerySourceQpf`);
+        .toThrow(`queryVoid is not implemented in QuerySourceRdfJs`);
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error messages for `queryQuads`, `queryBoolean`, and `queryVoid` methods to accurately reflect their implementation in `QuerySourceRdfJs`.

- **Tests**
	- Adjusted test cases to ensure error messages correspond to the correct class name, enhancing clarity and accuracy in error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->