### PR TITLE
Reduce the amount of ESLint exceptions and exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,13 +233,13 @@ jobs:
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Benchmarks detailed results
-          tool: 'customSmallerIsBetter'
+          tool: customSmallerIsBetter
           output-file-path: ghbench-detail.json
           github-token: ${{ secrets.PAT }}
           auto-push: true
           alert-comment-cc-users: '@rubensworks'
-          gh-repository: 'github.com/comunica/comunica-performance-results'
-          gh-pages-branch: 'master'
+          gh-repository: github.com/comunica/comunica-performance-results
+          gh-pages-branch: master
           benchmark-data-dir-path: ${{ env.BENCHMARK_DATA_DIR_PATH_DETAIL }}
       - name: Cleanup benchmark-action data
         run: rm -rf ./benchmark-data-repository
@@ -247,7 +247,7 @@ jobs:
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Benchmarks total results
-          tool: 'customSmallerIsBetter'
+          tool: customSmallerIsBetter
           output-file-path: ghbench-total.json
           github-token: ${{ secrets.PAT }}
           auto-push: true
@@ -256,8 +256,8 @@ jobs:
           comment-on-alert: true
           alert-comment-cc-users: '@rubensworks'
           summary-always: true
-          gh-repository: 'github.com/comunica/comunica-performance-results'
-          gh-pages-branch: 'master'
+          gh-repository: github.com/comunica/comunica-performance-results
+          gh-pages-branch: master
           benchmark-data-dir-path: ${{ env.BENCHMARK_DATA_DIR_PATH_TOTAL }}
       - name: Prepare comment on commit with link to performance results
         run: echo -e "Performance benchmarks succeeded! 🚀\n\n\[[Summarized results](https://comunica.github.io/comunica-performance-results/comunica/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}/benchmarks-total/)\] \[[Detailed results](https://comunica.github.io/comunica-performance-results/comunica/${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}/benchmarks-detail/)\]" > ./commit-comment-body.txt

--- a/engines/query-sparql-file/lib/index-browser.ts
+++ b/engines/query-sparql-file/lib/index-browser.ts
@@ -1,3 +1,1 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
 export * from './QueryEngine';

--- a/engines/query-sparql-file/test/QuerySparqlFile-test.ts
+++ b/engines/query-sparql-file/test/QuerySparqlFile-test.ts
@@ -8,7 +8,6 @@ import { QueryEngine } from '../lib/QueryEngine';
 
 describe('System test: QuerySparqlFile', () => {
   let engine: QueryEngine;
-  let spyQueryOrExplain: any;
 
   beforeEach(() => {
     engine = new QueryEngine();

--- a/engines/query-sparql-rdfjs-lite/lib/index-browser.ts
+++ b/engines/query-sparql-rdfjs-lite/lib/index-browser.ts
@@ -1,3 +1,1 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
 export * from './QueryEngine';

--- a/engines/query-sparql-rdfjs/lib/index-browser.ts
+++ b/engines/query-sparql-rdfjs/lib/index-browser.ts
@@ -1,3 +1,1 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
 export * from './QueryEngine';

--- a/engines/query-sparql/lib/index-browser.ts
+++ b/engines/query-sparql/lib/index-browser.ts
@@ -1,3 +1,1 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
 export * from './QueryEngine';

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -353,10 +353,9 @@ describe('System test: QuerySparql', () => {
           integerType = DF.namedNode('http://www.w3.org/2001/XMLSchema#integer');
           funcAllow = 'allowAll';
           baseFunctions = {
-            'http://example.org/functions#allowAll': async(args: RDF.Term[]) => DF.literal('true', booleanType),
+            'http://example.org/functions#allowAll': async() => DF.literal('true', booleanType),
           };
-          baseFunctionCreator = (functionName: RDF.NamedNode) =>
-            async(args: RDF.Term[]) => DF.literal('true', booleanType);
+          baseFunctionCreator = () => async() => DF.literal('true', booleanType);
           store = new Store();
           quads = [
             DF.quad(DF.namedNode('ex:a'), DF.namedNode('ex:p1'), DF.literal('apple', stringType)),

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,6 +40,7 @@ module.exports = config([
     // Specific rules for NodeJS-specific files
     files: [
       '**/test/**/*.ts',
+      '**/__mocks__/*.js',
       'packages/actor-dereference-file/**/*.ts',
       'packages/actor-http-native/**/*.ts',
       'packages/logger-bunyan/**/*.ts',
@@ -47,9 +48,19 @@ module.exports = config([
     ],
     rules: {
       'import/no-nodejs-modules': 'off',
-      'unused-imports/no-unused-vars': 'off',
       'ts/no-require-imports': 'off',
       'ts/no-var-requires': 'off',
+    },
+  },
+  {
+    files: [
+      // Browser versions of files cannot follow the camelCase naming scheme
+      '**/*-browser.ts',
+      // The funding YAML file needs the specific uppercase name
+      '.github/FUNDING.yml',
+    ],
+    rules: {
+      'unicorn/filename-case': 'off',
     },
   },
   {
@@ -94,27 +105,80 @@ module.exports = config([
     },
   },
   {
-    // Files that do not require linting
-    ignores: [
-      'setup-jest.js',
-      '**/engine-default.js',
-      '**/engine-browser.js',
-      '**/comunica-browser.js',
-      '.github/**',
-      '**/performance/*/combinations/**',
-      '**/bintest/**',
-      // TODO: Remove this once solid-client-authn supports node 18.
-      '**/QuerySparql-solid-test.ts',
+    // Spec test engines
+    files: [
+      '**/spec/*.js',
     ],
+    rules: {
+      'import/extensions': 'off',
+      'ts/no-var-requires': 'off',
+      'ts/no-require-imports': 'off',
+      'import/no-extraneous-dependencies': 'off',
+    },
   },
   {
-    files: [ '**/*.js' ],
+    // Webpack configurations
+    files: [
+      '**/webpack.config.js',
+    ],
     rules: {
-      'ts/no-require-imports': 'off',
       'ts/no-var-requires': 'off',
+      'ts/no-require-imports': 'off',
       'import/no-nodejs-modules': 'off',
       'import/no-extraneous-dependencies': 'off',
-      'import/extensions': 'off',
     },
+  },
+  {
+    // Karma config and Lerna custom script because they have identical rules
+    files: [
+      'karma.config.js',
+      'lerna-custom-script.js',
+    ],
+    rules: {
+      'ts/no-var-requires': 'off',
+      'ts/no-require-imports': 'off',
+      'import/no-nodejs-modules': 'off',
+    },
+  },
+  {
+    // Karma setup script
+    files: [
+      'karma-setup.js',
+    ],
+    rules: {
+      'import/no-nodejs-modules': 'off',
+      'import/no-extraneous-dependencies': 'off',
+    },
+  },
+  {
+    // Jest setup script
+    files: [
+      'setup-jest.js',
+    ],
+    rules: {
+      'ts/no-require-imports': 'off',
+      'import/no-extraneous-dependencies': 'off',
+    },
+  },
+  {
+    files: [
+      'eslint.config.js',
+    ],
+    rules: {
+      'ts/no-var-requires': 'off',
+      'ts/no-require-imports': 'off',
+    },
+  },
+  {
+    ignores: [
+      // The engine bundles are auto-generated code
+      'engines/*/engine-default.js',
+      'engines/*/engine-browser.js',
+      'engines/*/comunica-browser.js',
+      // The performance combination files are auto-generated
+      'performance/*/combinations/**',
+      // TODO: Remove this once solid-client-authn supports node 18.
+      'engines/query-sparql/test/QuerySparql-solid-test.ts',
+    ],
   },
 ]);

--- a/packages/actor-context-preprocess-query-source-identify/test/ActorContextPreprocessQuerySourceIdentify-test.ts
+++ b/packages/actor-context-preprocess-query-source-identify/test/ActorContextPreprocessQuerySourceIdentify-test.ts
@@ -6,7 +6,7 @@ import { KeysInitQuery, KeysQueryOperation, KeysStatistics }
 import type { IAction } from '@comunica/core';
 import { ActionContext, ActionContextKey, Bus } from '@comunica/core';
 import { StatisticLinkDereference } from '@comunica/statistic-link-dereference';
-import type { IActionContext, ILink, IQuerySourceWrapper } from '@comunica/types';
+import type { IActionContext, IQuerySourceWrapper } from '@comunica/types';
 import { RdfStore } from 'rdf-stores';
 import { ActorContextPreprocessQuerySourceIdentify } from '../lib/ActorContextPreprocessQuerySourceIdentify';
 import '@comunica/jest';
@@ -209,7 +209,7 @@ describe('ActorContextPreprocessQuerySourceIdentify', () => {
       });
 
       it('should record dereference events when passed dereference statistic', async() => {
-        const cb = jest.fn((data: ILink) => {});
+        const cb = jest.fn(() => {});
         jest.useFakeTimers();
         jest.setSystemTime(new Date('2021-01-01T00:00:00Z').getTime());
 
@@ -267,7 +267,6 @@ describe('ActorContextPreprocessQuerySourceIdentify', () => {
     let actor: ActorContextPreprocessQuerySourceIdentify;
     let mediatorQuerySourceIdentify: MediatorQuerySourceIdentify;
     let httpInvalidator: ActorHttpInvalidateListenable;
-    let listener = null;
 
     beforeEach(() => {
       mediatorQuerySourceIdentify = <any> {
@@ -276,7 +275,7 @@ describe('ActorContextPreprocessQuerySourceIdentify', () => {
         },
       };
       httpInvalidator = <any>{
-        addInvalidateListener: (l: any) => listener = l,
+        addInvalidateListener: jest.fn(),
       };
       actor = new ActorContextPreprocessQuerySourceIdentify({
         name: 'actor',

--- a/packages/actor-dereference-http/lib/ActorDereferenceHttp-browser.ts
+++ b/packages/actor-dereference-http/lib/ActorDereferenceHttp-browser.ts
@@ -1,8 +1,4 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
-import {
-  ActorDereferenceHttpBase,
-} from './ActorDereferenceHttpBase';
+import { ActorDereferenceHttpBase } from './ActorDereferenceHttpBase';
 
 /**
  * The browser variant of {@link ActorDereferenceHttp}.

--- a/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
+++ b/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
@@ -168,7 +168,6 @@ describe('ActorDereferenceHttp', () => {
     });
 
     it('should run with an text/plain content type', async() => {
-      const headers = new Headers({});
       const output = await actor.run({ url: 'https://www.google.com/plaincontenttype', context });
       expect(output.url).toBe('https://www.google.com/index.html');
       expect(output.headers).toEqual(new Headers({ 'content-type': 'text/plain' }));

--- a/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
+++ b/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
@@ -1,7 +1,6 @@
 import { Readable } from 'node:stream';
 import type {
   IActionAbstractMediaTypedHandle,
-  IActionAbstractMediaTypedMediaTypes,
   IActorOutputAbstractMediaTypedHandle,
   IActorOutputAbstractMediaTypedMediaTypes,
 } from '@comunica/actor-abstract-mediatyped';
@@ -61,12 +60,7 @@ describe('ActorAbstractDereferenceParse', () => {
       },
       // @ts-expect-error
       mediatorParseMediatypes: {
-        async mediate(action: IActionAbstractMediaTypedMediaTypes):
-        Promise<IActorOutputAbstractMediaTypedMediaTypes> {
-          return {
-            mediaTypes: {},
-          };
-        },
+        mediate: () => Promise.resolve<IActorOutputAbstractMediaTypedMediaTypes>({ mediaTypes: {}}),
       },
       mediaMappings: {
         x: 'y',

--- a/packages/actor-hash-bindings-murmur/test/ActorHashBindingsMurmur-test.ts
+++ b/packages/actor-hash-bindings-murmur/test/ActorHashBindingsMurmur-test.ts
@@ -2,7 +2,6 @@ import { BindingsFactory } from '@comunica/bindings-factory';
 import type { IActionHashBindings } from '@comunica/bus-hash-bindings';
 import { ActorHashBindings } from '@comunica/bus-hash-bindings';
 import { ActionContext, Bus } from '@comunica/core';
-import type { IActionContext } from '@comunica/types';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorHashBindingsMurmur } from '../lib/ActorHashBindingsMurmur';
 import '@comunica/jest';
@@ -12,11 +11,9 @@ const BF = new BindingsFactory(DF);
 
 describe('ActorHashBindingsMurmur', () => {
   let bus: any;
-  let context: IActionContext;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
-    context = new ActionContext();
   });
 
   describe('The ActorHashBindingsMurmur module', () => {

--- a/packages/actor-hash-quads-murmur/test/ActorHashQuadsMurmur-test.ts
+++ b/packages/actor-hash-quads-murmur/test/ActorHashQuadsMurmur-test.ts
@@ -1,7 +1,6 @@
 import type { IActionHashQuads } from '@comunica/bus-hash-quads';
 import { ActorHashQuads } from '@comunica/bus-hash-quads';
 import { ActionContext, Bus } from '@comunica/core';
-import type { IActionContext } from '@comunica/types';
 import type { Quad } from 'rdf-data-factory';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorHashQuadsMurmur } from '../lib/ActorHashQuadsMurmur';
@@ -11,11 +10,9 @@ const DF = new DataFactory();
 
 describe('ActorHashQuadsMurmur', () => {
   let bus: any;
-  let context: IActionContext;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
-    context = new ActionContext();
   });
 
   describe('The ActorHashQuadsMurmur module', () => {

--- a/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
+++ b/packages/actor-http-fetch/lib/FetchInitPreprocessor-browser.ts
@@ -1,6 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
-
 import { ActorHttp } from '@comunica/bus-http';
 import type { IFetchInitPreprocessor } from './IFetchInitPreprocessor';
 

--- a/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
+++ b/packages/actor-http-fetch/test/ActorHttpFetch-test.ts
@@ -10,7 +10,7 @@ import { ActorHttpFetch } from '../lib/ActorHttpFetch';
 import '@comunica/jest';
 
 // Mock fetch
-jest.spyOn(globalThis, 'fetch').mockImplementation((input: any, init?: any) => Promise.resolve(<Response> <unknown>{
+jest.spyOn(globalThis, 'fetch').mockImplementation((input: any) => Promise.resolve(<Response> <unknown>{
   status: input.url === 'https://www.google.com/' ? 200 : 404,
   ...input.url === 'NOBODY' ? {} : { body: { destroy: jest.fn(), on: jest.fn() }},
 }));
@@ -404,7 +404,7 @@ describe('ActorHttpFetch', () => {
         }),
       });
       const body = <Readable><any> response.body;
-      for await (const chunk of body) {
+      for await (const _ of body) {
         // We just want to consume everything
       }
       expect(clearTimeout).toHaveBeenCalledTimes(1);

--- a/packages/actor-http-native/lib/ActorHttpNative.ts
+++ b/packages/actor-http-native/lib/ActorHttpNative.ts
@@ -28,7 +28,7 @@ export class ActorHttpNative extends ActorHttp {
       `Browser-${globalThis.navigator.userAgent}`})`;
   }
 
-  public async test(action: IActionHttp): Promise<TestResult<IMediatorTypeTime>> {
+  public async test(_action: IActionHttp): Promise<TestResult<IMediatorTypeTime>> {
     return passTest({ time: Number.POSITIVE_INFINITY });
   }
 

--- a/packages/actor-http-native/lib/Requester-browser.ts
+++ b/packages/actor-http-native/lib/Requester-browser.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
 /* ! @license MIT ©2013-2016 Ruben Verborgh, Ghent University - imec */
 /* Single-function HTTP(S) request module for browsers */
 /* Translated from https://github.com/LinkedDataFragments/Client.js/blob/master/lib/browser/Request.js */

--- a/packages/actor-http-proxy/test/ActorHttpProxy-test.ts
+++ b/packages/actor-http-proxy/test/ActorHttpProxy-test.ts
@@ -15,9 +15,7 @@ describe('ActorHttpProxy', () => {
     bus = new Bus({ name: 'bus' });
     context = new ActionContext();
     mediatorHttp = {
-      mediate: jest.fn((args) => {
-        return { output: 'ABC', headers: new Headers({}) };
-      }),
+      mediate: jest.fn().mockReturnValue({ output: 'ABC', headers: new Headers({}) }),
     };
   });
 
@@ -80,9 +78,7 @@ describe('ActorHttpProxy', () => {
     it('should run when the proxy does return an x-final-url header', async() => {
       const input = 'http://example.org/';
       const headers = new Headers({ 'x-final-url': 'http://example.org/redirected/' });
-      jest.spyOn(mediatorHttp, 'mediate').mockImplementation((args) => {
-        return { output: 'ABC', headers };
-      });
+      jest.spyOn(mediatorHttp, 'mediate').mockImplementation(() => ({ output: 'ABC', headers }));
       await expect(actor.run({ input, context })).resolves
         .toEqual({ url: 'http://example.org/redirected/', output: 'ABC', headers });
       expect(mediatorHttp.mediate).toHaveBeenCalledWith(

--- a/packages/actor-init-query/lib/ActorInitQuery-browser.ts
+++ b/packages/actor-init-query/lib/ActorInitQuery-browser.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
 import { ActorInitQueryBase } from './ActorInitQueryBase';
 
 /* istanbul ignore next */

--- a/packages/actor-init-query/lib/index-browser.ts
+++ b/packages/actor-init-query/lib/index-browser.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/filename-case */
-/* eslint-enable unicorn/filename-case */
 export * from './ActorInitQueryBase';
 export * from './ActorInitQuery-browser';
 export { QueryEngineBase } from './QueryEngineBase';

--- a/packages/actor-init-query/test/ActorInitQuery-browser-test.ts
+++ b/packages/actor-init-query/test/ActorInitQuery-browser-test.ts
@@ -1,6 +1,5 @@
 import { Transform } from 'node:stream';
-import { ActionContext, Bus } from '@comunica/core';
-import type { IActionContext } from '@comunica/types';
+import { Bus } from '@comunica/core';
 import type { IActorInitQueryBaseArgs } from '../lib';
 import { ActorInitQuery } from '../lib/ActorInitQuery-browser';
 
@@ -9,15 +8,12 @@ describe('ActorInitQuery', () => {
   let mediatorQueryProcess: any;
   let mediatorSparqlSerialize: any;
   let mediatorHttpInvalidate: any;
-  let context: IActionContext;
   const defaultQueryInputFormat = 'sparql';
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     mediatorQueryProcess = <any>{
-      mediate: jest.fn((action: any) => {
-        return Promise.reject(new Error('Invalid query'));
-      }),
+      mediate: jest.fn().mockRejectedValue(new Error('Invalid query')),
     };
     mediatorSparqlSerialize = {
       mediate: (arg: any) => Promise.resolve(arg.mediaTypes ?
@@ -33,9 +29,8 @@ describe('ActorInitQuery', () => {
           }),
     };
     mediatorHttpInvalidate = {
-      mediate: (arg: any) => Promise.resolve(true),
+      mediate: () => Promise.resolve(true),
     };
-    context = new ActionContext();
   });
 
   describe('An ActorInitQuery instance', () => {

--- a/packages/actor-init-query/test/ActorInitQuery-noSources-test.ts
+++ b/packages/actor-init-query/test/ActorInitQuery-noSources-test.ts
@@ -17,7 +17,6 @@ describe('ActorInitQuery', () => {
   let input: Readable;
 
   const defaultQueryInputFormat = 'sparql';
-  const sourceHypermedia = 'http://example.org/';
   const queryString = 'SELECT * WHERE { ?s ?p ?o } LIMIT 100';
 
   beforeEach(() => {
@@ -55,7 +54,7 @@ describe('ActorInitQuery', () => {
       },
     };
     mediatorHttpInvalidate = {
-      mediate: (arg: any) => Promise.resolve(true),
+      mediate: () => Promise.resolve(true),
     };
     context = new ActionContext();
     input = new Readable({ objectMode: true });
@@ -69,7 +68,6 @@ describe('ActorInitQuery', () => {
 
   describe('An ActorInitQuery instance', () => {
     let actorAllowNoSources: ActorInitQuery;
-    let spyResultToString: any;
     let spyQueryOrExplain: any;
     beforeEach(() => {
       actorAllowNoSources = new ActorInitQuery({
@@ -84,7 +82,6 @@ describe('ActorInitQuery', () => {
         allowNoSources: true,
       });
 
-      spyResultToString = jest.spyOn(QueryEngineBase.prototype, 'resultToString');
       spyQueryOrExplain = jest.spyOn(QueryEngineBase.prototype, 'queryOrExplain');
     });
 

--- a/packages/actor-init-query/test/ActorInitQuery-test.ts
+++ b/packages/actor-init-query/test/ActorInitQuery-test.ts
@@ -72,7 +72,7 @@ describe('ActorInitQuery', () => {
       },
     };
     mediatorHttpInvalidate = {
-      mediate: (arg: any) => Promise.resolve(true),
+      mediate: () => Promise.resolve(true),
     };
     context = new ActionContext();
     input = new Readable({ objectMode: true });
@@ -797,19 +797,16 @@ LIMIT 100
 
       describe('output format', () => {
         it('defaults to application/json for bindingsStream', async() => {
-          const m1: any = {
-            mediate: (arg: any) => Promise.resolve({ type: 'bindings', bindingsStream: true, metadata: () => ({}) }),
-          };
-          const m2: any = {
+          const m: any = {
             mediate: (arg: any) => Promise.resolve({ handle: { data: arg.handleMediaType }}),
           };
           const actorThis = new ActorInitQuery({
             bus,
             mediatorQueryProcess,
             mediatorHttpInvalidate,
-            mediatorQueryResultSerialize: m2,
-            mediatorQueryResultSerializeMediaTypeCombiner: m2,
-            mediatorQueryResultSerializeMediaTypeFormatCombiner: m2,
+            mediatorQueryResultSerialize: m,
+            mediatorQueryResultSerializeMediaTypeCombiner: m,
+            mediatorQueryResultSerializeMediaTypeFormatCombiner: m,
             name: 'actor',
             queryString,
           });
@@ -824,7 +821,7 @@ LIMIT 100
 
         it('defaults to application/trig for quadStream', async() => {
           const m1: any = {
-            mediate: (arg: any) => Promise.resolve({ result: { type: 'quads', quadStream: true }}),
+            mediate: () => Promise.resolve({ result: { type: 'quads', quadStream: true }}),
           };
           const m2: any = {
             mediate: (arg: any) => Promise.resolve({ handle: { data: arg.handleMediaType }}),
@@ -850,7 +847,7 @@ LIMIT 100
 
         it('defaults to simple for boolean', async() => {
           const m1: any = {
-            mediate: (arg: any) => Promise.resolve({
+            mediate: () => Promise.resolve({
               result: { type: 'boolean', booleanResult: Promise.resolve(true) },
             }),
           };

--- a/packages/actor-init-query/test/ActorInitQueryBase-test.ts
+++ b/packages/actor-init-query/test/ActorInitQueryBase-test.ts
@@ -1,7 +1,6 @@
 import { Transform } from 'node:stream';
 import { ActorInit } from '@comunica/bus-init';
-import { ActionContext, Bus } from '@comunica/core';
-import type { IActionContext } from '@comunica/types';
+import { Bus } from '@comunica/core';
 import type { IActorInitQueryBaseArgs } from '../lib/ActorInitQueryBase';
 import { ActorInitQueryBase } from '../lib/ActorInitQueryBase';
 
@@ -10,16 +9,13 @@ describe('ActorInitQueryBase', () => {
   let mediatorQueryProcess: any;
   let mediatorSparqlSerialize: any;
   let mediatorHttpInvalidate: any;
-  let context: IActionContext;
 
   const defaultQueryInputFormat = 'sparql';
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     mediatorQueryProcess = <any>{
-      mediate: jest.fn((action: any) => {
-        return Promise.reject(new Error('Invalid query'));
-      }),
+      mediate: jest.fn().mockRejectedValue(new Error('Invalid query')),
     };
     mediatorSparqlSerialize = {
       mediate: (arg: any) => Promise.resolve(arg.mediaTypes ?
@@ -35,9 +31,8 @@ describe('ActorInitQueryBase', () => {
           }),
     };
     mediatorHttpInvalidate = {
-      mediate: (arg: any) => Promise.resolve(true),
+      mediate: () => Promise.resolve(true),
     };
-    context = new ActionContext();
   });
 
   describe('The ActorInitQueryBase module', () => {

--- a/packages/actor-init-query/test/QueryEngineBase-test.ts
+++ b/packages/actor-init-query/test/QueryEngineBase-test.ts
@@ -83,7 +83,7 @@ describe('QueryEngineBase', () => {
           }),
     };
     mediatorHttpInvalidate = {
-      mediate: (arg: any) => Promise.resolve(true),
+      mediate: () => Promise.resolve(true),
     };
     context = new ActionContext();
   });
@@ -202,7 +202,7 @@ describe('QueryEngineBase', () => {
       it('should return a rejected promise on an invalid request', async() => {
         const ctx: QueryStringContext = { sources: [ 'abc' ]};
         // Make it reject instead of reading input
-        mediatorQueryProcess.mediate = (action: any) => Promise.reject(new Error('a'));
+        mediatorQueryProcess.mediate = () => Promise.reject(new Error('a'));
         await expect(queryEngine.query('INVALID QUERY', ctx)).rejects.toBeTruthy();
       });
 
@@ -296,7 +296,7 @@ describe('QueryEngineBase', () => {
     describe('getResultMediaTypeFormats', () => {
       it('should return the media type formats', async() => {
         const med: any = {
-          mediate: (arg: any) => Promise.resolve({ mediaTypeFormats: { data: 'DATA' }}),
+          mediate: () => Promise.resolve({ mediaTypeFormats: { data: 'DATA' }}),
         };
         actor = new ActorInitQuery({
           bus,
@@ -339,7 +339,7 @@ describe('QueryEngineBase', () => {
 
     it('should return a rejected promise on an invalid request', async() => {
       // Make it reject instead of reading input
-      mediatorQueryProcess.mediate = (action: any) => Promise.reject(new Error('a'));
+      mediatorQueryProcess.mediate = () => Promise.reject(new Error('a'));
       await expect(queryEngine.query('INVALID QUERY', { sources: [ 'abc' ]})).rejects.toBeTruthy();
     });
   });

--- a/packages/actor-optimize-query-operation-group-sources/test/ActorOptimizeQueryOperationGroupSources-test.ts
+++ b/packages/actor-optimize-query-operation-group-sources/test/ActorOptimizeQueryOperationGroupSources-test.ts
@@ -47,30 +47,6 @@ describe('ActorOptimizeQueryOperationGroupSources', () => {
       }),
     },
   };
-  const sourceJoinOrPattern: IQuerySourceWrapper = <any> {
-    source: {
-      referenceValue: 'source1',
-      getSelectorShape: () => ({
-        type: 'disjunction',
-        children: [
-          {
-            type: 'operation',
-            operation: {
-              operationType: 'type',
-              type: Algebra.types.PATTERN,
-            },
-          },
-          {
-            type: 'operation',
-            operation: {
-              operationType: 'type',
-              type: Algebra.types.JOIN,
-            },
-          },
-        ],
-      }),
-    },
-  };
 
   const ctx = new ActionContext({ [KeysInitQuery.dataFactory.name]: DF });
 

--- a/packages/actor-query-operation-ask/test/ActorQueryOperationAsk-test.ts
+++ b/packages/actor-query-operation-ask/test/ActorQueryOperationAsk-test.ts
@@ -1,7 +1,7 @@
 import { BindingsFactory } from '@comunica/bindings-factory';
 import { ActorQueryOperation } from '@comunica/bus-query-operation';
 import { ActionContext, Bus } from '@comunica/core';
-import { ArrayIterator, BufferedIterator, range } from 'asynciterator';
+import { ArrayIterator, BufferedIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorQueryOperationAsk } from '../lib/ActorQueryOperationAsk';
 import '@comunica/jest';
@@ -14,7 +14,6 @@ describe('ActorQueryOperationAsk', () => {
   let mediatorQueryOperation: any;
   let mediatorQueryOperationEmpty: any;
   let mediatorQueryOperationError: any;
-  let mediatorQueryOperationInf: any;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
@@ -41,7 +40,7 @@ describe('ActorQueryOperationAsk', () => {
       }),
     };
     mediatorQueryOperationError = {
-      mediate: (arg: any) => new Promise((resolve, reject) => {
+      mediate: (arg: any) => new Promise((resolve) => {
         const bindingsStream = new BufferedIterator();
         setImmediate(() => bindingsStream.emit('error', new Error('Error!')));
         resolve({
@@ -51,15 +50,6 @@ describe('ActorQueryOperationAsk', () => {
           type: 'bindings',
           variables: [ DF.variable('a') ],
         });
-      }),
-    };
-    mediatorQueryOperationInf = {
-      mediate: (arg: any) => Promise.resolve({
-        bindingsStream: range(0, Number.POSITIVE_INFINITY),
-        metadata: () => Promise.resolve({ cardinality: 0 }),
-        operated: arg,
-        type: 'bindings',
-        variables: [ DF.variable('a') ],
       }),
     };
   });

--- a/packages/actor-query-operation-extend/test/ActorQueryOperationExtend-test.ts
+++ b/packages/actor-query-operation-extend/test/ActorQueryOperationExtend-test.ts
@@ -111,9 +111,7 @@ describe('ActorQueryOperationExtend', () => {
     let mediatorMergeBindingsContext: any;
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationExtend(

--- a/packages/actor-query-operation-filter/test/ActorQueryOperationFilter-test.ts
+++ b/packages/actor-query-operation-filter/test/ActorQueryOperationFilter-test.ts
@@ -35,11 +35,6 @@ function parse(query: string): Algebra.Expression {
 describe('ActorQueryOperationFilter', () => {
   let bus: any;
   let mediatorQueryOperation: any;
-  const simpleSPOInput = new Factory().createBgp([ new Factory().createPattern(
-    DF.variable('s'),
-    DF.variable('p'),
-    DF.variable('o'),
-  ) ]);
   const truthyExpression = parse('"nonemptystring"');
   const falsyExpression = parse('""');
   const erroringExpression = parse('?a + ?a');
@@ -94,9 +89,7 @@ describe('ActorQueryOperationFilter', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationFilter({

--- a/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
+++ b/packages/actor-query-operation-group/test/ActorQueryOperationGroup-test.ts
@@ -15,9 +15,7 @@ import '@comunica/jest';
 const DF = new DataFactory();
 const BF = new BindingsFactory(DF, {});
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 const simpleXYZinput = {
@@ -176,7 +174,7 @@ describe('ActorQueryOperationGroup', () => {
 
   describe('A GroupState instance', () => {
     it('should throw an error if collectResults is called multiple times', async() => {
-      const { actor, op } = constructCase({});
+      const { op } = constructCase({});
       const temp = new GroupsState(
 <Algebra.Group> op.operation,
 { dataFactory: DF },
@@ -188,7 +186,7 @@ BF,
     });
 
     it('should throw an error if consumeBindings is called after collectResults', async() => {
-      const { actor, op } = constructCase({});
+      const { op } = constructCase({});
       const temp = new GroupsState(
 <Algebra.Group> op.operation,
 { dataFactory: DF },

--- a/packages/actor-query-operation-leftjoin/test/ActorQueryOperationLeftJoin-test.ts
+++ b/packages/actor-query-operation-leftjoin/test/ActorQueryOperationLeftJoin-test.ts
@@ -20,9 +20,7 @@ describe('ActorQueryOperationLeftJoin', () => {
   let mediatorMergeBindingsContext: any;
   beforeEach(() => {
     mediatorMergeBindingsContext = {
-      mediate(arg: any) {
-        return {};
-      },
+      mediate: () => ({}),
     };
     bus = new Bus({ name: 'bus' });
     mediatorQueryOperation = {

--- a/packages/actor-query-operation-nop/test/ActorQueryOperationNop-test.ts
+++ b/packages/actor-query-operation-nop/test/ActorQueryOperationNop-test.ts
@@ -10,9 +10,7 @@ import '@comunica/jest';
 const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQueryOperationNop', () => {

--- a/packages/actor-query-operation-orderby/test/ActorQueryOperationOrderBy-test.ts
+++ b/packages/actor-query-operation-orderby/test/ActorQueryOperationOrderBy-test.ts
@@ -54,9 +54,7 @@ describe('ActorQueryOperationOrderBy with mixed term types', () => {
     let mediatorMergeBindingsContext: any;
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
       actor = new ActorQueryOperationOrderBy({
         name: 'actor',
@@ -136,9 +134,7 @@ describe('ActorQueryOperationOrderBySparqlee', () => {
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     mediatorMergeBindingsContext = {
-      mediate(arg: any) {
-        return {};
-      },
+      mediate: () => ({}),
     };
 
     mediatorQueryOperation = {
@@ -189,9 +185,7 @@ describe('ActorQueryOperationOrderBySparqlee', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -405,9 +399,7 @@ describe('ActorQueryOperationOrderBy with multiple comparators', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -620,9 +612,7 @@ describe('ActorQueryOperationOrderBy with integer type', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -717,9 +707,7 @@ describe('ActorQueryOperationOrderBy with double type', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -814,9 +802,7 @@ describe('ActorQueryOperationOrderBy with decimal type', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -911,9 +897,7 @@ describe('ActorQueryOperationOrderBy with float type', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -1008,9 +992,7 @@ describe('ActorQueryOperationOrderBy with mixed literal types', () => {
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -1100,14 +1082,11 @@ describe('Another ActorQueryOperationOrderBy with mixed types', () => {
   describe('An ActorQueryOperationOrderBy instance', () => {
     let actor: ActorQueryOperationOrderBy;
     let orderA: Algebra.TermExpression;
-    let descOrderA: Algebra.OperatorExpression;
     let mediatorMergeBindingsContext: any;
 
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationOrderBy({
@@ -1117,12 +1096,6 @@ describe('Another ActorQueryOperationOrderBy with mixed types', () => {
         mediatorMergeBindingsContext,
       });
       orderA = { type: Algebra.types.EXPRESSION, expressionType: Algebra.expressionTypes.TERM, term: DF.variable('a') };
-      descOrderA = {
-        type: Algebra.types.EXPRESSION,
-        expressionType: Algebra.expressionTypes.OPERATOR,
-        operator: 'desc',
-        args: [ orderA ],
-      };
     });
 
     it('should not sort since its not a literal ascending', async() => {

--- a/packages/actor-query-operation-path-one-or-more/test/ActorQueryOperationPathOneOrMore-test.ts
+++ b/packages/actor-query-operation-path-one-or-more/test/ActorQueryOperationPathOneOrMore-test.ts
@@ -102,9 +102,7 @@ describe('ActorQueryOperationPathOneOrMore', () => {
     let mediatorMergeBindingsContext: any;
     beforeEach(() => {
       mediatorMergeBindingsContext = {
-        mediate(arg: any) {
-          return {};
-        },
+        mediate: () => ({}),
       };
 
       actor = new ActorQueryOperationPathOneOrMore({

--- a/packages/actor-query-operation-path-zero-or-more/test/ActorQueryOperationPathZeroOrMore-test.ts
+++ b/packages/actor-query-operation-path-zero-or-more/test/ActorQueryOperationPathZeroOrMore-test.ts
@@ -28,9 +28,7 @@ describe('ActorQueryOperationPathZeroOrMore', () => {
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     mediatorMergeBindingsContext = {
-      mediate(arg: any) {
-        return {};
-      },
+      mediate: () => ({}),
     };
 
     mediatorQueryOperation = {

--- a/packages/actor-query-operation-path-zero-or-one/test/ActorQueryOperationPathZeroOrOne-test.ts
+++ b/packages/actor-query-operation-path-zero-or-one/test/ActorQueryOperationPathZeroOrOne-test.ts
@@ -84,9 +84,7 @@ describe('ActorQueryOperationPathZeroOrOne', () => {
     };
     // Mediator with no actors attached to it
     mediatorMergeBindingsContext = {
-      mediate(arg: any) {
-        return {};
-      },
+      mediate: () => ({}),
     };
     source1 = <any> {};
     source2 = <any> {};

--- a/packages/actor-query-operation-service/test/ActorQueryOperationService-test.ts
+++ b/packages/actor-query-operation-service/test/ActorQueryOperationService-test.ts
@@ -10,9 +10,7 @@ import '@comunica/jest';
 const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQueryOperationService', () => {
@@ -184,14 +182,6 @@ describe('ActorQueryOperationService', () => {
         operation: { type: 'service', silent: false, name: DF.literal('dummy') },
         context: new ActionContext({ [KeysInitQuery.dataFactory.name]: DF }),
       };
-      const actorThis = new ActorQueryOperationService({
-        bus,
-        forceSparqlEndpoint: true,
-        mediatorQueryOperation,
-        name: 'actor',
-        mediatorMergeBindingsContext,
-        mediatorQuerySourceIdentify,
-      });
 
       const output = ActorQueryOperation.getSafeBindings(await actor.run(op, undefined));
       expect((<any> output).operated.operation.metadata).toEqual({

--- a/packages/actor-query-operation-slice/test/ActorQueryOperationSlice-test.ts
+++ b/packages/actor-query-operation-slice/test/ActorQueryOperationSlice-test.ts
@@ -81,7 +81,7 @@ describe('ActorQueryOperationSlice', () => {
       }),
     };
     mediatorQueryOperationBoolean = {
-      mediate: (arg: any) => Promise.resolve({
+      mediate: () => Promise.resolve({
         execute: async() => true,
         type: 'boolean',
       }),

--- a/packages/actor-query-operation-source/test/ActorQueryOperationSource-test.ts
+++ b/packages/actor-query-operation-source/test/ActorQueryOperationSource-test.ts
@@ -32,12 +32,12 @@ describe('ActorQueryOperationSource', () => {
     source1 = <any> {
       source: {
         referenceValue: 'source1',
-        queryBindings: jest.fn((op) => {
+        queryBindings: jest.fn(() => {
           const bindingsStream = new ArrayIterator([], { autoStart: false });
           bindingsStream.setProperty('metadata', { cardinality: { value: 10 }, variables: []});
           return bindingsStream;
         }),
-        queryQuads: jest.fn((op) => {
+        queryQuads: jest.fn(() => {
           const quadStream = new ArrayIterator([], { autoStart: false });
           quadStream.setProperty('metadata', { cardinality: { value: 10 }});
           return quadStream;

--- a/packages/actor-query-operation-update-deleteinsert/test/ActorQueryOperationUpdateDeleteInsert-test.ts
+++ b/packages/actor-query-operation-update-deleteinsert/test/ActorQueryOperationUpdateDeleteInsert-test.ts
@@ -16,9 +16,7 @@ const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
 
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQueryOperationUpdateDeleteInsert', () => {

--- a/packages/actor-query-operation-update-load/test/ActorQueryOperationLoad-test.ts
+++ b/packages/actor-query-operation-update-load/test/ActorQueryOperationLoad-test.ts
@@ -21,13 +21,13 @@ describe('ActorQueryOperationLoad', () => {
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
     mediatorQueryOperation = {
-      mediate: jest.fn((arg: any) => Promise.resolve({
+      mediate: jest.fn().mockResolvedValue({
         quadStream: new ArrayIterator([
           DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o')),
         ], { autoStart: false }),
         metadata: () => Promise.resolve({ cardinality: 1 }),
         type: 'quads',
-      })),
+      }),
     };
     mediatorUpdateQuads = {
       mediate: jest.fn(() => Promise.resolve({
@@ -171,7 +171,7 @@ describe('ActorQueryOperationLoad', () => {
         },
         context: new ActionContext({ [KeysInitQuery.dataFactory.name]: DF }),
       };
-      mediatorQueryOperation.mediate = (arg: any) => Promise.resolve({
+      mediatorQueryOperation.mediate = () => Promise.resolve({
         quadStream: new ArrayIterator([], { autoStart: false }),
         metadata: () => Promise.resolve({ cardinality: 0 }),
         type: 'quads',

--- a/packages/actor-query-operation-values/test/ActorQueryOperationValues-test.ts
+++ b/packages/actor-query-operation-values/test/ActorQueryOperationValues-test.ts
@@ -9,9 +9,7 @@ import '@comunica/jest';
 const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQueryOperationValues', () => {

--- a/packages/actor-query-process-annotate-source-binding/test/ActorQueryProcessAnnotateSourceBinding-test.ts
+++ b/packages/actor-query-process-annotate-source-binding/test/ActorQueryProcessAnnotateSourceBinding-test.ts
@@ -53,7 +53,7 @@ describe('ActorQueryProcessAnnotateSourceBinding', () => {
       bindings = bindings.setContextEntry(KeysMergeBindingsContext.sourcesBinding, [ 'S1' ]);
 
       mediatorQueryProcess = {
-        async mediate(arg: any) {
+        async mediate() {
           return { result: { type: 'bindings', bindingsStream: new ArrayIterator([ bindings ]) }};
         },
       };
@@ -75,7 +75,7 @@ describe('ActorQueryProcessAnnotateSourceBinding', () => {
       bindings = bindings.setContextEntry(KeysMergeBindingsContext.sourcesBinding, [ 'S1', 'S2' ]);
 
       mediatorQueryProcess = {
-        async mediate(arg: any) {
+        async mediate() {
           return { result: { type: 'bindings', bindingsStream: new ArrayIterator([ bindings ]) }};
         },
       };
@@ -95,7 +95,7 @@ describe('ActorQueryProcessAnnotateSourceBinding', () => {
 
     it('should fail gracefully when binding does not have context', async() => {
       mediatorQueryProcess = {
-        async mediate(arg: any) {
+        async mediate() {
           return { result: { type: 'bindings', bindingsStream: new ArrayIterator([ bindings ]) }};
         },
       };
@@ -117,7 +117,7 @@ describe('ActorQueryProcessAnnotateSourceBinding', () => {
       bindings = bindings.setContextEntry(KeysMergeBindingsContext.sourcesBinding, []);
 
       mediatorQueryProcess = {
-        async mediate(arg: any) {
+        async mediate() {
           return { result: { type: 'bindings', bindingsStream: new ArrayIterator([ bindings ]) }};
         },
       };

--- a/packages/actor-query-process-explain-logical/test/ActorQueryProcessExplainLogical-test.ts
+++ b/packages/actor-query-process-explain-logical/test/ActorQueryProcessExplainLogical-test.ts
@@ -17,10 +17,10 @@ describe('ActorQueryProcessExplainLogical', () => {
 
     beforeEach(() => {
       queryProcessor = <any>{
-        async parse(query: string, context: any) {
+        async parse(query: string) {
           return { operation: `${query}PARSE` };
         },
-        async optimize(query: string, context: any) {
+        async optimize(query: string) {
           return { operation: `${query}OPT` };
         },
       };

--- a/packages/actor-query-process-explain-parsed/test/ActorQueryProcessExplainParsed-test.ts
+++ b/packages/actor-query-process-explain-parsed/test/ActorQueryProcessExplainParsed-test.ts
@@ -17,7 +17,7 @@ describe('ActorQueryProcessExplainParsed', () => {
 
     beforeEach(() => {
       queryProcessor = <any>{
-        async parse(query: string, context: any) {
+        async parse(query: string) {
           return { operation: `${query}OP` };
         },
       };

--- a/packages/actor-query-process-explain-physical/test/ActorQueryProcessExplainPhysical-test.ts
+++ b/packages/actor-query-process-explain-physical/test/ActorQueryProcessExplainPhysical-test.ts
@@ -25,7 +25,7 @@ describe('ActorQueryProcessExplainPhysical', () => {
         async optimize(query: string, context: any) {
           return { operation: `${query}OPT`, context };
         },
-        evaluate: jest.fn(async(query: string, context: any) => {
+        evaluate: jest.fn(async() => {
           return {
             type: 'bindings',
             bindingsStream: new ArrayIterator([], { autoStart: false }),
@@ -96,7 +96,7 @@ describe('ActorQueryProcessExplainPhysical', () => {
       });
 
       it('handles physical explain in context for quad outputs', async() => {
-        (<any> queryProcessor).evaluate = async(query: string, context: any) => {
+        (<any> queryProcessor).evaluate = async() => {
           return {
             type: 'quads',
             quadStream: new ArrayIterator([], { autoStart: false }),
@@ -117,7 +117,7 @@ describe('ActorQueryProcessExplainPhysical', () => {
       });
 
       it('handles physical explain in context for boolean outputs', async() => {
-        (<any> queryProcessor).evaluate = async(query: string, context: any) => {
+        (<any> queryProcessor).evaluate = async() => {
           return {
             type: 'boolean',
             execute: jest.fn(),
@@ -138,7 +138,7 @@ describe('ActorQueryProcessExplainPhysical', () => {
       });
 
       it('handles physical explain in context for void outputs', async() => {
-        (<any> queryProcessor).evaluate = async(query: string, context: any) => {
+        (<any> queryProcessor).evaluate = async() => {
           return {
             type: 'void',
             execute: jest.fn(),

--- a/packages/actor-query-process-sequential/test/ActorQueryProcessSequential-test.ts
+++ b/packages/actor-query-process-sequential/test/ActorQueryProcessSequential-test.ts
@@ -50,9 +50,7 @@ describe('ActorQueryProcessSequential', () => {
       })),
     };
     mediatorMergeBindingsContext = {
-      mediate(arg: any) {
-        return {};
-      },
+      mediate: () => ({}),
     };
   });
 

--- a/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
@@ -23,9 +23,7 @@ const v2 = DF.variable('v2');
 const v3 = DF.variable('v3');
 
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQuerySourceIdentifyHypermediaSourceAttribution', () => {

--- a/packages/actor-query-source-identify-hypermedia-annotate-source/test/mediatorQuerySourceIdentify-util.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/test/mediatorQuerySourceIdentify-util.ts
@@ -5,11 +5,9 @@ import { MetadataValidationState } from '@comunica/metadata';
 import type { IQuerySource } from '@comunica/types';
 import { wrap } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
-import { Factory } from 'sparqlalgebrajs';
 
 const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
-const AF = new Factory();
 
 // @ts-expect-error
 export const mediatorQuerySourceIdentifyHypermedia: MediatorQuerySourceIdentifyHypermedia = {

--- a/packages/actor-query-source-identify-hypermedia-none/test/ActorQuerySourceIdentifyHypermediaNone-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-none/test/ActorQuerySourceIdentifyHypermediaNone-test.ts
@@ -22,9 +22,7 @@ const v2 = DF.variable('v2');
 const v3 = DF.variable('v3');
 
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQuerySourceIdentifyHypermediaNone', () => {

--- a/packages/actor-query-source-identify-hypermedia-qpf/test/ActorQuerySourceIdentifyHypermediaQpf-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-qpf/test/ActorQuerySourceIdentifyHypermediaQpf-test.ts
@@ -13,9 +13,7 @@ const v3 = DF.variable('v3');
 const v4 = DF.variable('v4');
 
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQuerySourceIdentifyHypermediaQpf', () => {

--- a/packages/actor-query-source-identify-hypermedia-qpf/test/QuerySourceQpf-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-qpf/test/QuerySourceQpf-test.ts
@@ -3,7 +3,7 @@ import { Readable } from 'node:stream';
 import { BindingsFactory } from '@comunica/bindings-factory';
 import type { IActorDereferenceRdfOutput } from '@comunica/bus-dereference-rdf';
 import { KeysQueryOperation } from '@comunica/context-entries';
-import { ActionContext, Bus } from '@comunica/core';
+import { ActionContext } from '@comunica/core';
 import { MetadataValidationState } from '@comunica/metadata';
 import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
@@ -29,7 +29,6 @@ const pAllQuad = AF.createPattern(v1, v2, v3, v4);
 const pAllTriple = AF.createPattern(v1, v2, v3);
 
 describe('QuerySourceQpf', () => {
-  let bus: any;
   let metadata: any;
   let mediatorMetadata: any;
   let mediatorMetadataExtract: any;
@@ -42,8 +41,6 @@ describe('QuerySourceQpf', () => {
   let G: RDF.Term;
 
   beforeEach(() => {
-    bus = new Bus({ name: 'bus' });
-
     mediatorMetadata = {
       async mediate(args: any) {
         const data = new PassThrough({ objectMode: true });

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
@@ -8,9 +8,7 @@ import { QuerySourceSparql } from '../lib/QuerySourceSparql';
 import '@comunica/jest';
 
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 const DF = new DataFactory();

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
@@ -18,12 +18,6 @@ import '@comunica/jest';
 const DF = new DataFactory();
 const AF = new Factory();
 const BF = new BindingsFactory(DF);
-const v1 = DF.variable('v1');
-const v2 = DF.variable('v2');
-const v3 = DF.variable('v3');
-const v4 = DF.variable('v4');
-const pAllQuad = AF.createPattern(v1, v2, v3, v4);
-const pAllTriple = AF.createPattern(v1, v2, v3);
 
 // TODO: Remove when targeting NodeJS 18+
 if (!globalThis.ReadableStream) {
@@ -963,13 +957,11 @@ describe('QuerySourceSparql', () => {
   describe('queryQuads', () => {
     it('should return data', async() => {
       const thisMediator: any = {
-        mediate: jest.fn((action: any) => {
-          return {
-            headers: new Headers({ 'Content-Type': 'text/turtle' }),
-            body: Readable.from([ `<s1> <p1> <o1>. <s2> <p2> <o2>.` ]),
-            ok: true,
-          };
-        }),
+        mediate: jest.fn(() => ({
+          headers: new Headers({ 'Content-Type': 'text/turtle' }),
+          body: Readable.from([ `<s1> <p1> <o1>. <s2> <p2> <o2>.` ]),
+          ok: true,
+        })),
       };
       source = new QuerySourceSparql('http://example.org/sparql', ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10);
 
@@ -1043,13 +1035,11 @@ WHERE { undefined:s ?p undefined:o. }` }),
 
     it('should pass the original queryString if defined', async() => {
       const thisMediator: any = {
-        mediate: jest.fn((action: any) => {
-          return {
-            headers: new Headers({ 'Content-Type': 'text/turtle' }),
-            body: Readable.from([ `<s1> <p1> <o1>. <s2> <p2> <o2>.` ]),
-            ok: true,
-          };
-        }),
+        mediate: jest.fn(() => ({
+          headers: new Headers({ 'Content-Type': 'text/turtle' }),
+          body: Readable.from([ `<s1> <p1> <o1>. <s2> <p2> <o2>.` ]),
+          ok: true,
+        })),
       };
       source = new QuerySourceSparql('http://example.org/sparql', ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10);
 
@@ -1077,17 +1067,15 @@ WHERE { undefined:s ?p undefined:o. }` }),
   describe('queryBoolean', () => {
     it('should return data', async() => {
       const thisMediator: any = {
-        mediate: jest.fn((action: any) => {
-          return {
-            headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
-            body: Readable.from([ `{
+        mediate: jest.fn(() => ({
+          headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
+          body: Readable.from([ `{
   "head": { "vars": [ "p" ]
   } ,
   "boolean": true
 }` ]),
-            ok: true,
-          };
-        }),
+          ok: true,
+        })),
       };
       source = new QuerySourceSparql('http://example.org/sparql', ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10);
 
@@ -1109,17 +1097,15 @@ WHERE { undefined:s ?p undefined:o. }` }),
 
     it('should pass the original queryString if defined', async() => {
       const thisMediator: any = {
-        mediate: jest.fn((action: any) => {
-          return {
-            headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
-            body: Readable.from([ `{
+        mediate: jest.fn(() => ({
+          headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
+          body: Readable.from([ `{
   "head": { "vars": [ "p" ]
   } ,
   "boolean": true
 }` ]),
-            ok: true,
-          };
-        }),
+          ok: true,
+        })),
       };
       source = new QuerySourceSparql('http://example.org/sparql', ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10);
 
@@ -1143,13 +1129,11 @@ WHERE { undefined:s ?p undefined:o. }` }),
   describe('queryVoid', () => {
     it('should return data', async() => {
       const thisMediator: any = {
-        mediate: jest.fn((action: any) => {
-          return {
-            headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
-            body: Readable.from([ `OK` ]),
-            ok: true,
-          };
-        }),
+        mediate: jest.fn(() => ({
+          headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
+          body: Readable.from([ `OK` ]),
+          ok: true,
+        })),
       };
       source = new QuerySourceSparql('http://example.org/sparql', ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10);
 
@@ -1174,13 +1158,11 @@ WHERE { undefined:s ?p undefined:o. }` }),
 
     it('should pass the original queryString if defined', async() => {
       const thisMediator: any = {
-        mediate: jest.fn((action: any) => {
-          return {
-            headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
-            body: Readable.from([ `OK` ]),
-            ok: true,
-          };
-        }),
+        mediate: jest.fn(() => ({
+          headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
+          body: Readable.from([ `OK` ]),
+          ok: true,
+        })),
       };
       source = new QuerySourceSparql('http://example.org/sparql', ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10);
 

--- a/packages/actor-query-source-identify-hypermedia/test/ActorQuerySourceIdentifyHypermedia-test.ts
+++ b/packages/actor-query-source-identify-hypermedia/test/ActorQuerySourceIdentifyHypermedia-test.ts
@@ -23,9 +23,7 @@ const AF = new Factory();
 const BF = new BindingsFactory(DF);
 
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorQuerySourceIdentifyHypermedia', () => {

--- a/packages/actor-query-source-identify-hypermedia/test/LinkedRdfSourcesAsyncRdfIterator-test.ts
+++ b/packages/actor-query-source-identify-hypermedia/test/LinkedRdfSourcesAsyncRdfIterator-test.ts
@@ -67,7 +67,7 @@ class DummyIteratorMultiple extends DummyIterator {
 
 // Dummy class that produces multiple next page links
 class DummyIteratorErrorLinks extends DummyIterator {
-  protected override async getSourceLinks(metadata: Record<string, any>): Promise<ILink[]> {
+  protected override async getSourceLinks(): Promise<ILink[]> {
     throw new Error('DummyErrorLinks');
   }
 }
@@ -93,10 +93,7 @@ class DummyIteratorErrorLinkQueueLater extends DummyIterator {
 
 // Dummy class with a rejecting accumulateMetadata
 class DummyIteratorErrorAccumulate extends DummyIterator {
-  protected override accumulateMetadata(
-    accumulatedMetadata: MetadataBindings,
-    appendingMetadata: MetadataBindings,
-  ): Promise<MetadataBindings> {
+  protected override accumulateMetadata(): Promise<MetadataBindings> {
     return Promise.reject(new Error('accumulateMetadata error'));
   }
 }
@@ -682,7 +679,7 @@ describe('LinkedRdfSourcesAsyncRdfIterator', () => {
       })).rejects.toThrow(new Error('accumulateMetadata error'));
     });
     it('records dereference events when passed a dereference statistic', async() => {
-      const cb = jest.fn((data: ILink) => {});
+      const cb = jest.fn(() => {});
       jest.useFakeTimers();
       jest.setSystemTime(new Date('2021-01-01T00:00:00Z').getTime());
 

--- a/packages/actor-query-source-identify-hypermedia/test/MediatedLinkedRdfSourcesAsyncRdfIterator-test.ts
+++ b/packages/actor-query-source-identify-hypermedia/test/MediatedLinkedRdfSourcesAsyncRdfIterator-test.ts
@@ -1,5 +1,4 @@
 import { LinkQueueFifo } from '@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo';
-import { BindingsFactory } from '@comunica/bindings-factory';
 import type { MediatorRdfMetadataAccumulate } from '@comunica/bus-rdf-metadata-accumulate';
 import type { MediatorRdfResolveHypermediaLinks } from '@comunica/bus-rdf-resolve-hypermedia-links';
 import type { MediatorRdfResolveHypermediaLinksQueue } from '@comunica/bus-rdf-resolve-hypermedia-links-queue';
@@ -16,7 +15,6 @@ import { MediatedLinkedRdfSourcesAsyncRdfIterator } from '../lib/MediatedLinkedR
 
 const DF = new DataFactory();
 const AF = new Factory();
-const BF = new BindingsFactory(DF);
 
 setTaskScheduler(task => setImmediate(task));
 

--- a/packages/actor-query-source-identify-hypermedia/test/QuerySourceHypermedia-test.ts
+++ b/packages/actor-query-source-identify-hypermedia/test/QuerySourceHypermedia-test.ts
@@ -30,16 +30,12 @@ const BF = new BindingsFactory(DF);
 const quad = require('rdf-quad');
 const streamifyArray = require('streamify-array');
 
-const v = DF.variable('v');
-
 describe('QuerySourceHypermedia', () => {
   let context: IActionContext;
   let mediatorDereferenceRdf: MediatorDereferenceRdf;
   let mediatorMetadata: any;
   let mediatorMetadataExtract: any;
   let mediatorQuerySourceIdentifyHypermedia: any;
-  let mediatorRdfResolveHypermediaLinks: any;
-  let mediatorRdfResolveHypermediaLinksQueue: any;
   let mediators: any;
   let logWarning: (warningMessage: string) => void;
   let operation: Algebra.Operation;
@@ -54,8 +50,6 @@ describe('QuerySourceHypermedia', () => {
     mediatorMetadata = utilMediators.mediatorMetadata;
     mediatorMetadataExtract = utilMediators.mediatorMetadataExtract;
     mediatorQuerySourceIdentifyHypermedia = utilMediators.mediatorQuerySourceIdentifyHypermedia;
-    mediatorRdfResolveHypermediaLinks = utilMediators.mediatorRdfResolveHypermediaLinks;
-    mediatorRdfResolveHypermediaLinksQueue = utilMediators.mediatorRdfResolveHypermediaLinksQueue;
     mediators = utilMediators;
     logWarning = jest.fn();
     operation = AF.createPattern(
@@ -312,7 +306,7 @@ describe('QuerySourceHypermedia', () => {
           mediate: () => Promise.resolve({ links: i < 3 ? [{ url: `next${i}` }] : []}),
         };
         mediatorsThis.mediatorQuerySourceIdentifyHypermedia = {
-          mediate(args: any) {
+          mediate() {
             if (i < 3) {
               i++;
             }
@@ -860,7 +854,7 @@ describe('QuerySourceHypermedia', () => {
           mediate: () => Promise.resolve({ links: i < 3 ? [{ url: `next${i}` }] : []}),
         };
         mediatorsThis.mediatorQuerySourceIdentifyHypermedia = {
-          mediate: jest.fn((args: any) => {
+          mediate: jest.fn(() => {
             if (i < 3) {
               i++;
             }
@@ -973,7 +967,7 @@ describe('QuerySourceHypermedia', () => {
           mediate: () => Promise.resolve({ links: i < 3 ? [{ url: `next${i}` }] : []}),
         };
         mediatorsThis.mediatorQuerySourceIdentifyHypermedia = {
-          mediate: jest.fn((args: any) => {
+          mediate: jest.fn(() => {
             if (i < 3) {
               i++;
             }

--- a/packages/actor-query-source-identify-hypermedia/test/StreamingStoreMetadata-test.ts
+++ b/packages/actor-query-source-identify-hypermedia/test/StreamingStoreMetadata-test.ts
@@ -7,7 +7,7 @@ describe('StreamingStoreMetadata', () => {
         undefined,
         () => Promise.reject(new Error('StreamingStoreMetadata error')),
       );
-      const it1 = store.match();
+      const _it1 = store.match();
       store.setBaseMetadata(<any>{}, true);
     });
   });

--- a/packages/actor-query-source-identify-rdfjs/test/ActorQuerySourceIdentifyRdfJs-test.ts
+++ b/packages/actor-query-source-identify-rdfjs/test/ActorQuerySourceIdentifyRdfJs-test.ts
@@ -1,7 +1,6 @@
 import { ActorQuerySourceIdentify } from '@comunica/bus-query-source-identify';
 import { KeysInitQuery } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
-import type { IActionContext } from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorQuerySourceIdentifyRdfJs, QuerySourceRdfJs } from '..';
@@ -9,19 +8,15 @@ import 'jest-rdf';
 import '@comunica/jest';
 
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 const DF = new DataFactory();
 
 describe('ActorQuerySourceIdentifyRdfJs', () => {
   let bus: any;
-  let context: IActionContext;
 
   beforeEach(() => {
     bus = new Bus({ name: 'bus' });
-    context = new ActionContext();
   });
 
   describe('The ActorQuerySourceIdentifyRdfJs module', () => {

--- a/packages/actor-rdf-join-inner-hash/lib/ActorRdfJoinHash.ts
+++ b/packages/actor-rdf-join-inner-hash/lib/ActorRdfJoinHash.ts
@@ -70,6 +70,7 @@ export class ActorRdfJoinHash extends ActorRdfJoin {
           output.bindingsStream,
           {
             multiTransform: (bindings: RDF.Bindings): AsyncIterator<RDF.Bindings> => new ArrayIterator<RDF.Bindings>(
+              // eslint-disable-next-line ts/no-unnecessary-type-assertion
               <RDF.Bindings[]>(index.get(bindings).flat())
                 .map(indexBindings => ActorRdfJoin.joinBindings(bindings, indexBindings))
                 .filter(b => b !== null),

--- a/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
@@ -21,9 +21,7 @@ const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
 const FACTORY = new Factory();
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorRdfJoinMultiBind', () => {
@@ -64,7 +62,7 @@ IQueryOperationResultBindings
       };
       context = new ActionContext({ a: 'b', [KeysInitQuery.dataFactory.name]: DF });
       mediatorQueryOperation = <any> {
-        mediate: jest.fn(async(arg: IActionQueryOperation): Promise<IQueryOperationResultBindings> => {
+        mediate: jest.fn(async(): Promise<IQueryOperationResultBindings> => {
           return {
             bindingsStream: new ArrayIterator<RDF.Bindings>([
               BF.bindings([

--- a/packages/actor-rdf-join-inner-multi-smallest-filter-bindings/test/ActorRdfJoinMultiSmallestFilterBindings-test.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest-filter-bindings/test/ActorRdfJoinMultiSmallestFilterBindings-test.ts
@@ -33,10 +33,7 @@ describe('ActorRdfJoinMultiSmallestFilterBindings', () => {
     let mediatorJoinEntriesSort: MediatorRdfJoinEntriesSort;
     let mediatorJoin: MediatorRdfJoin;
     let actor: ActorRdfJoinMultiSmallestFilterBindings;
-    let logSpy: jest.SpyInstance;
     let source1: IQuerySourceWrapper;
-    let source2: IQuerySourceWrapper;
-    let source3TriplePattern: IQuerySourceWrapper;
     let source4: IQuerySourceWrapper;
     let source5Context: IQuerySourceWrapper;
 
@@ -77,7 +74,7 @@ describe('ActorRdfJoinMultiSmallestFilterBindings', () => {
         mediatorJoinSelectivity,
         mediatorJoinEntriesSort,
       });
-      logSpy = jest.spyOn((<any> actor), 'logDebug').mockImplementation();
+      jest.spyOn((<any> actor), 'logDebug').mockImplementation();
       source1 = <IQuerySourceWrapper> <any> {
         source: {
           getSelectorShape() {
@@ -97,28 +94,6 @@ describe('ActorRdfJoinMultiSmallestFilterBindings', () => {
               autoStart: false,
             });
           }),
-        },
-      };
-      source2 = <IQuerySourceWrapper> <any> {
-        source: {
-          getSelectorShape() {
-            return {
-              type: 'operation',
-              operation: { operationType: 'type', type: Algebra.types.PROJECT },
-              filterBindings: true,
-            };
-          },
-        },
-      };
-      source3TriplePattern = <IQuerySourceWrapper> <any> {
-        source: {
-          getSelectorShape() {
-            return {
-              type: 'operation',
-              operation: { operationType: 'type', type: Algebra.types.PATTERN },
-              filterBindings: true,
-            };
-          },
         },
       };
       source4 = <IQuerySourceWrapper> <any> {

--- a/packages/actor-rdf-join-inner-none/test/ActorRdfJoinNone-test.ts
+++ b/packages/actor-rdf-join-inner-none/test/ActorRdfJoinNone-test.ts
@@ -11,9 +11,7 @@ import '@comunica/jest';
 const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorRdfJoinNone', () => {

--- a/packages/actor-rdf-join-optional-bind/test/ActorRdfJoinOptionalBind-test.ts
+++ b/packages/actor-rdf-join-optional-bind/test/ActorRdfJoinOptionalBind-test.ts
@@ -17,9 +17,7 @@ const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
 const FACTORY = new Factory();
 const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
+  mediate: () => ({}),
 };
 
 describe('ActorRdfJoinOptionalBind', () => {

--- a/packages/actor-rdf-join-optional-hash/lib/ActorRdfJoinOptionalHash.ts
+++ b/packages/actor-rdf-join-optional-hash/lib/ActorRdfJoinOptionalHash.ts
@@ -77,6 +77,7 @@ export class ActorRdfJoinOptionalHash extends ActorRdfJoin {
           output.bindingsStream,
           {
             multiTransform: (bindings: RDF.Bindings): AsyncIterator<RDF.Bindings> => new ArrayIterator<RDF.Bindings>(
+              // eslint-disable-next-line ts/no-unnecessary-type-assertion
               <RDF.Bindings[]>(index.get(bindings).flat())
                 .map(indexBindings => ActorRdfJoin.joinBindings(bindings, indexBindings))
                 .filter(b => b !== null),

--- a/packages/actor-rdf-metadata-all/test/ActorRdfMetadataAll-test.ts
+++ b/packages/actor-rdf-metadata-all/test/ActorRdfMetadataAll-test.ts
@@ -98,9 +98,9 @@ describe('ActorRdfMetadataAll', () => {
           output.data.on('data', () => {
             // Do nothing
           });
-          return Promise.all([ new Promise((resolve, reject) => {
+          return Promise.all([ new Promise((resolve) => {
             output.data.on('error', resolve);
-          }), new Promise((resolve, reject) => {
+          }), new Promise((resolve) => {
             output.metadata.on('error', resolve);
           }) ]).then((errors) => {
             expect(errors).toHaveLength(2);
@@ -112,9 +112,9 @@ describe('ActorRdfMetadataAll', () => {
       await actor.run({ url: '', quads: input, context })
         .then((output) => {
           setImmediate(() => input.emit('error', new Error('RDF Meta Primary Topic error')));
-          return Promise.all([ new Promise((resolve, reject) => {
+          return Promise.all([ new Promise((resolve) => {
             output.data.on('error', resolve);
-          }), new Promise((resolve, reject) => {
+          }), new Promise((resolve) => {
             output.metadata.on('error', resolve);
           }) ]).then((errors) => {
             expect(errors).toHaveLength(2);

--- a/packages/actor-rdf-metadata-primary-topic/test/ActorRdfMetadataPrimaryTopic-test.ts
+++ b/packages/actor-rdf-metadata-primary-topic/test/ActorRdfMetadataPrimaryTopic-test.ts
@@ -206,9 +206,9 @@ describe('ActorRdfMetadataPrimaryTopic', () => {
           output.data.on('data', () => {
             // Do nothing
           });
-          return Promise.all([ new Promise((resolve, reject) => {
+          return Promise.all([ new Promise((resolve) => {
             output.data.on('error', resolve);
-          }), new Promise((resolve, reject) => {
+          }), new Promise((resolve) => {
             output.metadata.on('error', resolve);
           }) ]).then((errors) => {
             expect(errors).toHaveLength(2);

--- a/packages/actor-rdf-parse-shaclc/test/ActorRdfParseShaclc-test.ts
+++ b/packages/actor-rdf-parse-shaclc/test/ActorRdfParseShaclc-test.ts
@@ -11,7 +11,6 @@ const quad = require('rdf-quad');
 
 describe('ActorRdfParseShaclc', () => {
   let bus: any;
-  let mediatorHttp: any;
   let context: IActionContext;
 
   beforeEach(() => {
@@ -78,9 +77,6 @@ describe('ActorRdfParseShaclc', () => {
   describe('An ActorRdfParseShaclc instance', () => {
     let actor: ActorRdfParseShaclc;
     let input: Readable;
-    // Let inputGraphs: Readable;
-    let inputLinkHeader: Readable;
-    let inputSkipped: Readable;
 
     beforeEach(() => {
       actor = new ActorRdfParseShaclc({ bus, mediaTypePriorities: {
@@ -95,17 +91,6 @@ describe('ActorRdfParseShaclc', () => {
     });
 
     describe('for parsing', () => {
-      beforeEach(() => {
-        inputLinkHeader = Readable.from([ `{
-          "@id": "http://www.example.org/",
-          "term": "value"
-        }` ]);
-        inputSkipped = Readable.from([ `{
-          "@id": "http://www.example.org/",
-          "skipped": "value"
-        }` ]);
-      });
-
       it('should test on text/shaclc', async() => {
         await expect(actor
           .test({ handle: { data: input, context }, handleMediaType: 'text/shaclc', context }))

--- a/packages/bindings-factory/test/BindingsFactory-test.ts
+++ b/packages/bindings-factory/test/BindingsFactory-test.ts
@@ -4,11 +4,6 @@ import { Bindings } from '../lib/Bindings';
 import { BindingsFactory } from '../lib/BindingsFactory';
 
 const DF = new DataFactory();
-const mediatorMergeBindingsContext: any = {
-  mediate(arg: any) {
-    return {};
-  },
-};
 
 describe('BindingsFactory', () => {
   let factory: RDF.BindingsFactory;

--- a/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
+++ b/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
@@ -67,10 +67,7 @@ IActorRdfJoinSelectivityOutput
     return { result, physicalPlanMetadata: { meta: true }};
   }
 
-  protected getJoinCoefficients(
-    action: IActionRdfJoin,
-    sideData: IActorRdfJoinTestSideData,
-  ): Promise<TestResult<IMediatorTypeJoinCoefficients, IActorRdfJoinTestSideData>> {
+  protected getJoinCoefficients(): Promise<TestResult<IMediatorTypeJoinCoefficients, IActorRdfJoinTestSideData>> {
     return Promise.resolve(passTestWithSideData({
       iterations: 5,
       persistedItems: 2,

--- a/packages/core/test/ActionContext-test.ts
+++ b/packages/core/test/ActionContext-test.ts
@@ -7,7 +7,6 @@ describe('ActionContext', () => {
   const key1: IActionContextKey<string> = new ActionContextKey<string>('key1');
   const key2: IActionContextKey<number> = new ActionContextKey<number>('key2');
   const key3: IActionContextKey<boolean[]> = new ActionContextKey<boolean[]>('key3');
-  const key4: IActionContextKey<boolean[]> = new ActionContextKey<boolean[]>('key4');
 
   describe('for an empty instance', () => {
     let context: IActionContext;
@@ -47,7 +46,7 @@ describe('ActionContext', () => {
 
       it('should fail during compilation for an incorrect key value', () => {
         // @ts-expect-error
-        const a: number = context.get(key1);
+        const _a: number = context.get(key1);
       });
     });
 
@@ -75,12 +74,12 @@ describe('ActionContext', () => {
 
       it('should fail during compilation for an incorrect key value', () => {
         // @ts-expect-error
-        const a: number = context.getSafe(key1);
+        const _a: number = context.getSafe(key1);
       });
 
       it('should fail during compilation for an undefined casting', () => {
         // @ts-expect-error
-        const a: undefined = context.getSafe(key1);
+        const _a: undefined = context.getSafe(key1);
       });
     });
 

--- a/packages/core/test/TestResult-test.ts
+++ b/packages/core/test/TestResult-test.ts
@@ -28,17 +28,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const value: number = result.get();
+          const _value: number = result.get();
         } else {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         } else {
-          const value: number = result.get();
+          const _value: number = result.get();
         }
       });
     });
@@ -65,17 +65,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         } else {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         } else {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         }
       });
     });
@@ -123,17 +123,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const value: number = result.get();
+          const _value: number = result.get();
         } else {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         } else {
-          const value: number = result.get();
+          const _value: number = result.get();
         }
       });
     });
@@ -160,17 +160,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         } else {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         } else {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         }
       });
     });
@@ -218,17 +218,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const value: any = result.get();
+          const _value: any = result.get();
         } else {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         } else {
-          const value: any = result.get();
+          const _value: any = result.get();
         }
       });
     });
@@ -255,17 +255,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         } else {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         } else {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         }
       });
     });
@@ -297,17 +297,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const value: any = result.get();
+          const _value: any = result.get();
         } else {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         } else {
-          const value: any = result.get();
+          const _value: any = result.get();
         }
       });
     });
@@ -334,17 +334,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         } else {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         } else {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         }
       });
     });
@@ -376,17 +376,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const value: number = result.get();
+          const _value: number = result.get();
         } else {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const value: undefined = result.get();
+          const _value: undefined = result.get();
         } else {
-          const value: number = result.get();
+          const _value: number = result.get();
         }
       });
     });
@@ -411,17 +411,17 @@ describe('TestResult', () => {
 
       it('should be type-narrowed after isPassed', () => {
         if (result.isPassed()) {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         } else {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         }
       });
 
       it('should be type-narrowed after isFailed', () => {
         if (result.isFailed()) {
-          const message: string = result.getFailMessage();
+          const _message: string = result.getFailMessage();
         } else {
-          const message: undefined = result.getFailMessage();
+          const _message: undefined = result.getFailMessage();
         }
       });
     });

--- a/packages/expression-evaluator/test/integration/evaluators/RecursiveEvaluator-test.ts
+++ b/packages/expression-evaluator/test/integration/evaluators/RecursiveEvaluator-test.ts
@@ -113,7 +113,7 @@ describe('recursive evaluators', () => {
       expect(() => evaluator.evaluate({
         expressionType: ExpressionType.AsyncExtension,
         name: DF.namedNode('http://example.com'),
-        async apply(_) {
+        async apply() {
           throw new Error('Error');
         },
         args: [],
@@ -220,7 +220,7 @@ describe('recursive evaluators', () => {
       await expect(evaluator.evaluate({
         expressionType: ExpressionType.SyncExtension,
         name: DF.namedNode('http://example.com'),
-        apply(_) {
+        apply() {
           throw new Error('Error');
         },
         args: [],

--- a/packages/expression-evaluator/test/integration/functions/extension-test.ts
+++ b/packages/expression-evaluator/test/integration/functions/extension-test.ts
@@ -26,7 +26,7 @@ describe('extension functions:', () => {
         };
       }
       if (functionNamedNode.value === 'https://example.org/functions#bad') {
-        return (args: RDF.Term[]) => {
+        return () => {
           throw new Error('error');
         };
       }

--- a/packages/expression-evaluator/test/integration/functions/onStrings-test.ts
+++ b/packages/expression-evaluator/test/integration/functions/onStrings-test.ts
@@ -179,7 +179,7 @@ describe('string functions', () => {
         type: 'sync',
         config: {
           dataFactory: DF,
-          getSuperType: unknownType => TypeURL.XSD_STRING,
+          getSuperType: () => TypeURL.XSD_STRING,
         },
       },
       testTable: `

--- a/packages/expression-evaluator/test/integration/functions/op.addition-test.ts
+++ b/packages/expression-evaluator/test/integration/functions/op.addition-test.ts
@@ -65,7 +65,7 @@ describe('evaluation of \'+\' like', () => {
       type: 'sync',
       config: {
         dataFactory: DF,
-        getSuperType: unknownType => TypeURL.XSD_INTEGER,
+        getSuperType: () => TypeURL.XSD_INTEGER,
       },
     },
     testTable: `

--- a/packages/expression-evaluator/test/integration/functions/op.division-test.ts
+++ b/packages/expression-evaluator/test/integration/functions/op.division-test.ts
@@ -48,7 +48,7 @@ describe('evaluation of \'/\' like', () => {
       type: 'sync',
       config: {
         dataFactory: DF,
-        getSuperType: unknownType => TypeURL.XSD_INTEGER,
+        getSuperType: () => TypeURL.XSD_INTEGER,
       },
     },
     testTable: `

--- a/packages/expression-evaluator/test/integration/functions/op.equality-test.ts
+++ b/packages/expression-evaluator/test/integration/functions/op.equality-test.ts
@@ -47,7 +47,7 @@ describe('evaluation of \'=\'', () => {
       config: {
         type: 'sync',
         config: {
-          getSuperType: unknownType => TypeURL.XSD_INTEGER,
+          getSuperType: () => TypeURL.XSD_INTEGER,
           dataFactory: DF,
         },
       },

--- a/packages/expression-evaluator/test/integration/transformers/AlgebraTransformer-test.ts
+++ b/packages/expression-evaluator/test/integration/transformers/AlgebraTransformer-test.ts
@@ -12,7 +12,7 @@ describe('AlgebraTransformer', () => {
   let algebraTransformer: AlgebraTransformer;
   beforeEach(() => {
     algebraTransformer = new AlgebraTransformer({
-      creator: _ => args => DF.namedNode('http://example.com'),
+      creator: _ => () => DF.namedNode('http://example.com'),
       type: 'sync',
       ...getDefaultSharedContext(),
     });

--- a/packages/expression-evaluator/test/util/TestTable.ts
+++ b/packages/expression-evaluator/test/util/TestTable.ts
@@ -118,7 +118,7 @@ export class UnaryTable extends Table<[string, string]> {
 
   public test(): void {
     for (const row of this.parser.table) {
-      const [ arg, result ] = row;
+      const [ _, result ] = row;
       const { operation } = this.def;
       const aliases = this.def.aliases ?? {};
       test(`${this.format(operation, row)} should return ${result}`, async() => {

--- a/packages/jest/test/matchers/toFailTest-test.ts
+++ b/packages/jest/test/matchers/toFailTest-test.ts
@@ -1,10 +1,5 @@
-import { BindingsFactory } from '@comunica/bindings-factory';
 import { failTest, passTest } from '@comunica/core';
-import { DataFactory } from 'rdf-data-factory';
 import '../../lib';
-
-const DF = new DataFactory();
-const BF = new BindingsFactory(DF);
 
 describe('toFailTest', () => {
   it('should succeed for an equal fail message', () => {

--- a/packages/jest/test/matchers/toPassTest-test.ts
+++ b/packages/jest/test/matchers/toPassTest-test.ts
@@ -1,10 +1,5 @@
-import { BindingsFactory } from '@comunica/bindings-factory';
 import { failTest, passTest } from '@comunica/core';
-import { DataFactory } from 'rdf-data-factory';
 import '../../lib';
-
-const DF = new DataFactory();
-const BF = new BindingsFactory(DF);
 
 describe('toPassTest', () => {
   it('should not succeed for a failed test', () => {

--- a/packages/jest/test/matchers/toPassTestVoid-test.ts
+++ b/packages/jest/test/matchers/toPassTestVoid-test.ts
@@ -1,10 +1,5 @@
-import { BindingsFactory } from '@comunica/bindings-factory';
 import { failTest, passTest, passTestVoid } from '@comunica/core';
-import { DataFactory } from 'rdf-data-factory';
 import '../../lib';
-
-const DF = new DataFactory();
-const BF = new BindingsFactory(DF);
 
 describe('toPassTestVoid', () => {
   it('should not succeed for a failed test', () => {

--- a/packages/mediator-all/test/MediatorAll-test.ts
+++ b/packages/mediator-all/test/MediatorAll-test.ts
@@ -139,17 +139,17 @@ class DummyActor extends Actor<IAction, IDummyTest, IDummyTest> {
     this.fail = fail;
   }
 
-  public test(action: IAction): Promise<TestResult<IDummyTest>> {
+  public test(): Promise<TestResult<IDummyTest>> {
     if (this.fail) {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve) => {
         setTimeout(() => resolve(failTest(`${this.id}`)), 10);
       });
     }
-    return new Promise((resolve, reject) => setTimeout(() => resolve(passTest({ field: this.id })), this.delay));
+    return new Promise(resolve => setTimeout(() => resolve(passTest({ field: this.id })), this.delay));
   }
 
-  public run(action: IAction): Promise<IDummyTest> {
-    return new Promise((resolve, reject) => setTimeout(() => resolve({ field: this.id }), this.delay));
+  public run(): Promise<IDummyTest> {
+    return new Promise(resolve => setTimeout(() => resolve({ field: this.id }), this.delay));
   }
 }
 

--- a/packages/mediator-combine-pipeline/test/MediatorCombinePipeline-test.ts
+++ b/packages/mediator-combine-pipeline/test/MediatorCombinePipeline-test.ts
@@ -231,7 +231,7 @@ class DummyActor extends Actor<IDummyAction, IActorTest, IDummyOutput> {
     this.testOutput = testOutput;
   }
 
-  public async test(action: IDummyAction): Promise<TestResult<IActorTest>> {
+  public async test(): Promise<TestResult<IActorTest>> {
     return passTest(this.testOutput ?? true);
   }
 
@@ -249,7 +249,7 @@ class DummyThrowActor extends DummyActor {
     super(id, bus, testOutput);
   }
 
-  public override async test(action: IDummyAction): Promise<TestResult<IActorTest>> {
+  public override async test(): Promise<TestResult<IActorTest>> {
     return failTest('Dummy Error');
   }
 }
@@ -267,7 +267,7 @@ class DummyConcatActor extends Actor<IDummyConcatAction, IActorTest, IDummyConca
     this.testOutput = testOutput;
   }
 
-  public async test(action: IDummyConcatAction): Promise<TestResult<IActorTest>> {
+  public async test(): Promise<TestResult<IActorTest>> {
     return passTest(this.testOutput ?? true);
   }
 

--- a/packages/mediator-combine-union/test/MediatorCombineUnion-test.ts
+++ b/packages/mediator-combine-union/test/MediatorCombineUnion-test.ts
@@ -98,11 +98,11 @@ class DummyActor extends Actor<IAction, IDummyTest, IDummyTest> {
     this.data = data;
   }
 
-  public async test(action: IAction): Promise<TestResult<IDummyTest>> {
+  public async test(): Promise<TestResult<IDummyTest>> {
     return passTest({ field: this.data, otherField: 'ignored' });
   }
 
-  public async run(action: IAction): Promise<IDummyTest> {
+  public async run(): Promise<IDummyTest> {
     return { field: this.data, otherField: 'ignored' };
   }
 }
@@ -116,7 +116,7 @@ class DummyThrowActor extends DummyActor {
     super(id, data, bus);
   }
 
-  public override async test(action: IAction): Promise<TestResult<IDummyTest>> {
+  public override async test(): Promise<TestResult<IDummyTest>> {
     return failTest('Dummy Error');
   }
 }

--- a/packages/mediator-join-coefficients-fixed/test/MediatorJoinCoefficientsFixed-test.ts
+++ b/packages/mediator-join-coefficients-fixed/test/MediatorJoinCoefficientsFixed-test.ts
@@ -3,7 +3,6 @@ import { KeysCore, KeysQueryOperation } from '@comunica/context-entries';
 import type { IAction, IActorOutput, TestResult } from '@comunica/core';
 import { failTest, passTest, ActionContext, Actor, Bus } from '@comunica/core';
 import type { IMediatorTypeJoinCoefficients } from '@comunica/mediatortype-join-coefficients';
-import type { IActionContext } from '@comunica/types';
 import { DataFactory } from 'rdf-data-factory';
 import { MediatorJoinCoefficientsFixed } from '../lib/MediatorJoinCoefficientsFixed';
 
@@ -12,14 +11,12 @@ const DF = new DataFactory();
 describe('MediatorJoinCoefficientsFixed', () => {
   describe('An MediatorJoinCoefficientsFixed instance', () => {
     let bus: any;
-    let context: IActionContext;
     let mediator: MediatorJoinCoefficientsFixed;
     let debugLog: any;
     let action: IActionRdfJoin;
 
     beforeEach(() => {
       bus = new Bus({ name: 'bus' });
-      context = new ActionContext();
       mediator = new MediatorJoinCoefficientsFixed({
         name: 'mediator',
         bus,
@@ -478,14 +475,14 @@ class DummyActor extends Actor<IAction, IMediatorTypeJoinCoefficients, IDummyOut
     this.reject = reject;
   }
 
-  public async test(action: IAction): Promise<TestResult<IMediatorTypeJoinCoefficients>> {
+  public async test(): Promise<TestResult<IMediatorTypeJoinCoefficients>> {
     if (this.reject) {
       return failTest(`Actor ${this.id} fails`);
     }
     return passTest(this.coeffs);
   }
 
-  public async run(action: IAction): Promise<IDummyOutput> {
+  public async run(): Promise<IDummyOutput> {
     return { id: this.id };
   }
 }

--- a/packages/mediator-number/test/MediatorNumber-test.ts
+++ b/packages/mediator-number/test/MediatorNumber-test.ts
@@ -241,11 +241,11 @@ class DummyActor extends Actor<IAction, IDummyTest, IDummyTest> {
     this.id = id;
   }
 
-  public async test(action: IAction): Promise<TestResult<IDummyTest>> {
+  public async test(): Promise<TestResult<IDummyTest>> {
     return passTest({ field: this.id });
   }
 
-  public async run(action: IAction): Promise<IDummyTest> {
+  public async run(): Promise<IDummyTest> {
     return { field: this.id };
   }
 }
@@ -258,17 +258,17 @@ class DummyActorInvalid extends Actor<IAction, IDummyTest, IDummyTest> {
     this.id = id;
   }
 
-  public async test(action: IAction): Promise<TestResult<IDummyTest>> {
+  public async test(): Promise<TestResult<IDummyTest>> {
     return passTest(<any> {});
   }
 
-  public async run(action: IAction): Promise<IDummyTest> {
+  public async run(): Promise<IDummyTest> {
     return { field: this.id };
   }
 }
 
 class ErrorDummyActor extends DummyActor {
-  public override async test(action: IAction): Promise<TestResult<IDummyTest>> {
+  public override async test(): Promise<TestResult<IDummyTest>> {
     return failTest('abc');
   }
 }

--- a/packages/mediator-race/test/MediatorRace-test.ts
+++ b/packages/mediator-race/test/MediatorRace-test.ts
@@ -60,16 +60,13 @@ describe('MediatorRace', () => {
     describe('with passing and failing actors', () => {
       let busm: Bus<DummyActor, IAction, IDummyTest, IDummyTest>;
       let mediator: MediatorRace<DummyActor, IAction, IDummyTest, IDummyTest>;
-      let actor0;
-      let actor1;
-      let actor2;
 
       beforeEach(() => {
         busm = new Bus({ name: 'bus' });
         mediator = new MediatorRace({ name: 'mediator', bus: busm });
-        busm.subscribe(actor0 = new DummyActor(10, 100, busm, false));
-        busm.subscribe(actor1 = new DummyActor(100, 0, busm, true));
-        busm.subscribe(actor2 = new DummyActor(1, 200, busm, false));
+        busm.subscribe(new DummyActor(10, 100, busm, false));
+        busm.subscribe(new DummyActor(100, 0, busm, true));
+        busm.subscribe(new DummyActor(1, 200, busm, false));
       });
 
       it('should mediate to the earliest non-rejecting resolver', async() => {
@@ -80,16 +77,13 @@ describe('MediatorRace', () => {
     describe('with passing and rejecting actors', () => {
       let busm: Bus<DummyActor, IAction, IDummyTest, IDummyTest>;
       let mediator: MediatorRace<DummyActor, IAction, IDummyTest, IDummyTest>;
-      let actor0;
-      let actor1;
-      let actor2;
 
       beforeEach(() => {
         busm = new Bus({ name: 'bus' });
         mediator = new MediatorRace({ name: 'mediator', bus: busm });
-        busm.subscribe(actor0 = new DummyActor(10, 100, busm, false));
-        busm.subscribe(actor1 = new DummyActor(100, 0, busm, false, true));
-        busm.subscribe(actor2 = new DummyActor(1, 200, busm, false));
+        busm.subscribe(new DummyActor(10, 100, busm, false));
+        busm.subscribe(new DummyActor(100, 0, busm, false, true));
+        busm.subscribe(new DummyActor(1, 200, busm, false));
       });
 
       it('should throw when mediating', async() => {
@@ -119,18 +113,18 @@ class DummyActor extends Actor<IAction, IDummyTest, IDummyTest> {
     this.reject = Boolean(reject);
   }
 
-  public async test(action: IAction): Promise<TestResult<IDummyTest>> {
+  public async test(): Promise<TestResult<IDummyTest>> {
     if (this.fail) {
       return failTest(`${this.id}`);
     }
     if (this.reject) {
       throw new Error(`${this.id}`);
     }
-    return new Promise((resolve, reject) => setTimeout(() => resolve(passTest({ field: this.id })), this.delay));
+    return new Promise(resolve => setTimeout(() => resolve(passTest({ field: this.id })), this.delay));
   }
 
-  public async run(action: IAction): Promise<IDummyTest> {
-    return new Promise((resolve, reject) => setTimeout(() => resolve({ field: this.id }), this.delay));
+  public async run(): Promise<IDummyTest> {
+    return new Promise(resolve => setTimeout(() => resolve({ field: this.id }), this.delay));
   }
 }
 

--- a/packages/packager/bin/package.ts
+++ b/packages/packager/bin/package.ts
@@ -60,7 +60,6 @@ if (args.e) {
 
 const dependencyRegex = /require\('([^']*)'\)/ug;
 
-const referencePackageJson = require(Path.join(__dirname, '..', 'package.json'));
 compileConfig(mainModulePath, configPath, 'urn:comunica:default:Runner', exportVariableName, false, true)
   .then((document: string) => {
     // Find dependency package names

--- a/packages/statistic-base/test/StatisticBase-test.ts
+++ b/packages/statistic-base/test/StatisticBase-test.ts
@@ -2,7 +2,7 @@ import type { ILink } from '@comunica/types';
 import { StatisticBase } from '../lib';
 
 class MockStatisticBase<T> extends StatisticBase<T> {
-  public updateStatistic(...data: any[]): void {}
+  public updateStatistic(): void {}
 }
 
 describe('StatisticLinkDiscovery', () => {
@@ -12,8 +12,8 @@ describe('StatisticLinkDiscovery', () => {
 
   beforeEach(() => {
     mockStatisticBase = new MockStatisticBase();
-    cb = jest.fn((data: ILink) => {});
-    cb1 = jest.fn((data1: ILink) => {});
+    cb = jest.fn(() => {});
+    cb1 = jest.fn(() => {});
   });
 
   describe('An StatisticLinkDereference instance should', () => {

--- a/packages/statistic-link-dereference/test/StatisticLinkDereference-test.ts
+++ b/packages/statistic-link-dereference/test/StatisticLinkDereference-test.ts
@@ -1,4 +1,3 @@
-import { Bus } from '@comunica/core';
 import type {
   ILink,
   BindingsStream,
@@ -31,11 +30,9 @@ class MockQuerySource implements IQuerySource {
 }
 
 describe('StatisticLinkDereference', () => {
-  let bus: any;
   let statisticLinkDereference: StatisticLinkDereference;
 
   beforeEach(() => {
-    bus = new Bus({ name: 'bus' });
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2021-01-01T00:00:00Z').getTime());
     statisticLinkDereference = new StatisticLinkDereference();
@@ -48,7 +45,7 @@ describe('StatisticLinkDereference', () => {
 
     beforeEach(() => {
       link = { url: 'url', metadata: { key: 'value' }};
-      cb = jest.fn((data: ILink) => {});
+      cb = jest.fn(() => {});
 
       source = new MockQuerySource('url');
     });

--- a/packages/statistic-link-discovery/test/StatisticLinkDiscovery-test.ts
+++ b/packages/statistic-link-discovery/test/StatisticLinkDiscovery-test.ts
@@ -1,13 +1,10 @@
-import { Bus } from '@comunica/core';
 import type { ILink, IDiscoverEventData } from '@comunica/types';
 import { StatisticLinkDiscovery } from '../lib/StatisticLinkDiscovery';
 
 describe('StatisticLinkDiscovery', () => {
-  let bus: any;
   let statisticLinkDiscovery: StatisticLinkDiscovery;
 
   beforeEach(() => {
-    bus = new Bus({ name: 'bus' });
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2021-01-01T00:00:00Z').getTime());
     statisticLinkDiscovery = new StatisticLinkDiscovery();
@@ -31,7 +28,7 @@ describe('StatisticLinkDiscovery', () => {
           childkey: 5,
         },
       };
-      cb = jest.fn((arg0: IDiscoverEventData) => {});
+      cb = jest.fn(() => {});
     });
 
     // TODO Move to statisticBase


### PR DESCRIPTION
Here are some changes to reduce the amount of files that are excluded by linting, or that have an unnecessary amount of exceptions. Most notably, the linter now checks the test files for unused variables, which should help improve the quality of the tests. The configuration/tooling JavaScript files are also no longer just ignored, but have actual rule exceptions applied.

Most of the PR consist of linter fixes following these changes, with most of the changes coming from the removal of unused variables in tests.

Any feedback is welcome. I am targeting this for next major since I happened to be working on that branch. :slightly_smiling_face: 