### PR TITLE
Make the dummy field comment part of jsdoc

### DIFF
--- a/packages/types/lib/IActionContext.ts
+++ b/packages/types/lib/IActionContext.ts
@@ -39,7 +39,9 @@ export interface IActionContext {
  */
 export interface IActionContextKey<V> {
   readonly name: string;
-  // A dummy field that we must define to make TypeScript bind the type `V`, otherwise it would always be `any`.
-  // This field will be undefined, so it will never exist in JavaScript.
+  /**
+   * A dummy field that we must define to make TypeScript bind the type `V`, otherwise it would always be `any`.
+   * This field will be undefined, so it will never exist in JavaScript.
+   */
   readonly dummy: V | undefined;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity of the `dummy` field documentation in the `IActionContextKey<V>` interface with a structured JSDoc comment format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->