### PR TITLE
Fix the test function of ActorQuerySourceIdentifyHypermediaAnnotateSource

### DIFF
--- a/packages/actor-query-source-identify-hypermedia-annotate-source/lib/ActorQuerySourceIdentifyHypermediaAnnotateSource.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/lib/ActorQuerySourceIdentifyHypermediaAnnotateSource.ts
@@ -8,7 +8,7 @@ import type {
 } from '@comunica/bus-query-source-identify-hypermedia';
 import { ActorQuerySourceIdentifyHypermedia } from '@comunica/bus-query-source-identify-hypermedia';
 import type { TestResult } from '@comunica/core';
-import { ActionContextKey, passTest } from '@comunica/core';
+import { ActionContextKey, failTest, passTest } from '@comunica/core';
 import { QuerySourceAddSourceAttribution } from './QuerySourceAddSourceAttribution';
 
 /**
@@ -26,7 +26,7 @@ export class ActorQuerySourceIdentifyHypermediaAnnotateSource extends ActorQuery
     action: IActionQuerySourceIdentifyHypermedia,
   ): Promise<TestResult<IActorQuerySourceIdentifyHypermediaTest>> {
     if (action.context.get(KEY_CONTEXT_WRAPPED)) {
-      throw new Error('Unable to wrap query source multiple times');
+      return failTest('Unable to wrap query source multiple times');
     }
     return passTest({ filterFactor: Number.POSITIVE_INFINITY });
   }

--- a/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
@@ -1,5 +1,5 @@
 import { KeysInitQuery } from '@comunica/context-entries';
-import { ActionContext, Bus } from '@comunica/core';
+import { ActionContext, Bus, failTest } from '@comunica/core';
 import type { BindingsStream, IActionContext } from '@comunica/types';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { MetadataValidationState } from '@comunica/utils-metadata';
@@ -87,8 +87,8 @@ describe('ActorQuerySourceIdentifyHypermediaSourceAttribution', () => {
       ]);
       context = context.set(KEY_CONTEXT_WRAPPED, true);
       await expect(actor.test({ metadata: <any> null, quads, url: 'URL', context }))
-        .rejects
-        .toThrow('Unable to wrap query source multiple times');
+        .resolves
+        .toEqual(failTest('Unable to wrap query source multiple times'));
     });
   });
 });

--- a/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
@@ -1,5 +1,5 @@
 import { KeysInitQuery } from '@comunica/context-entries';
-import { ActionContext, Bus, failTest } from '@comunica/core';
+import { ActionContext, Bus } from '@comunica/core';
 import type { BindingsStream, IActionContext } from '@comunica/types';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { MetadataValidationState } from '@comunica/utils-metadata';
@@ -88,7 +88,7 @@ describe('ActorQuerySourceIdentifyHypermediaSourceAttribution', () => {
       context = context.set(KEY_CONTEXT_WRAPPED, true);
       await expect(actor.test({ metadata: <any> null, quads, url: 'URL', context }))
         .resolves
-        .toFailTest('Unable to wrap query source multiple times'); 
+        .toFailTest('Unable to wrap query source multiple times');
     });
   });
 });

--- a/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/test/ActorQuerySourceIdentifyHypermediaAnnotateSource-test.ts
@@ -88,7 +88,7 @@ describe('ActorQuerySourceIdentifyHypermediaSourceAttribution', () => {
       context = context.set(KEY_CONTEXT_WRAPPED, true);
       await expect(actor.test({ metadata: <any> null, quads, url: 'URL', context }))
         .resolves
-        .toEqual(failTest('Unable to wrap query source multiple times'));
+        .toFailTest('Unable to wrap query source multiple times'); 
     });
   });
 });


### PR DESCRIPTION
The test function has not yet been updated to reflect API changes in Comunica V4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling in the query source identification process, providing structured test results instead of exceptions.
  
- **Bug Fixes**
	- Updated test cases to align with the new error handling logic, ensuring accurate assertions on query source wrapping failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->