### PR TITLE
Remove separate engine and package projects from Jest config

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,16 +1,13 @@
 import type { Config } from '@jest/types';
 
-const moduleFileExtensions: string[] = [ 'ts', 'js' ];
-
-const transform: Record<string, Config.TransformerConfig> = {
-  '\\.ts$': [ 'ts-jest', {
-    // Enabling this can fix issues when using prereleases of typings packages
-    // isolatedModules: true
-  }],
-};
-
 const config: Config.InitialOptions = {
   collectCoverage: true,
+  coveragePathIgnorePatterns: [
+    '/test/',
+    '/node_modules/',
+    'engine-default.js',
+    'index.js',
+  ],
   coverageProvider: 'babel',
   coverageThreshold: {
     global: {
@@ -20,68 +17,25 @@ const config: Config.InitialOptions = {
       statements: 100,
     },
   },
-  projects: [
-    {
-      // This combined test runs both the package unit tests and the engine system tests,
-      // and produces the original 100% coverage across the entire monorepo,
-      // because the package tests rely on the engine tests to reach their coverage target
-      displayName: 'combined',
-      moduleFileExtensions,
-      testEnvironment: 'node',
-      testMatch: [
-        '<rootDir>/engines/*/test/**/*-test.ts',
-        '<rootDir>/packages/*/test/**/*-test.ts',
-      ],
-      testPathIgnorePatterns: [
-        // TODO: Remove this once solid-client-authn supports node 18.
-        'QuerySparql-solid-test.ts',
-      ],
-      transform,
-      coveragePathIgnorePatterns: [
-        '/test/',
-        '/node_modules/',
-        'engine-default.js',
-        'index.js',
-      ],
-    },
-    {
-      // This will only run the system tests for engines
-      displayName: 'engines',
-      moduleFileExtensions,
-      testEnvironment: 'node',
-      testMatch: [
-        '<rootDir>/engines/*/test/**/*-test.ts',
-      ],
-      testPathIgnorePatterns: [
-        // TODO: Remove this once solid-client-authn supports node 18.
-        'QuerySparql-solid-test.ts',
-      ],
-      transform,
-      coveragePathIgnorePatterns: [
-        '<rootDir>/packages/',
-        '/test/',
-        '/node_modules/',
-        'engine-default.js',
-        'index.js',
-      ],
-    },
-    {
-      // This will only run the unit tests for packages
-      displayName: 'packages',
-      moduleFileExtensions,
-      testEnvironment: 'node',
-      testMatch: [
-        '<rootDir>/packages/*/test/**/*-test.ts',
-      ],
-      transform,
-      coveragePathIgnorePatterns: [
-        '<rootDir>/engines/',
-        '/test/',
-        '/node_modules/',
-        'index.js',
-      ],
-    },
+  moduleFileExtensions: [
+    'ts',
+    'js',
   ],
+  testEnvironment: 'node',
+  testMatch: [
+    '<rootDir>/engines/*/test/**/*-test.ts',
+    '<rootDir>/packages/*/test/**/*-test.ts',
+  ],
+  testPathIgnorePatterns: [
+    // TODO: Remove this once solid-client-authn supports node 18.
+    'QuerySparql-solid-test.ts',
+  ],
+  transform: {
+    '\\.ts$': [ 'ts-jest', {
+      // Enabling this can fix issues when using prereleases of typings packages
+      // isolatedModules: true
+    }],
+  },
   // The default test timeout is not enough for engine tests, but is enough for packages
   testTimeout: 20_000,
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:changed": "lerna run test --since HEAD",
     "test:ci": "yarn run test:node --ci --maxWorkers=4",
     "test:integration": "lerna run integration --concurrency 1",
-    "test:node": "jest --selectProjects combined",
+    "test:node": "jest",
     "test:spec": "lerna run spec --concurrency 1",
     "version": "manual-git-changelog onversion"
   },


### PR DESCRIPTION
This is just to remove the separate engine and package test setups from Jest, since the unit tests will probably not be separated from the engine ones in the near future coverage-wise, and having the projects in there seems to interfere with running only specific tests locally.

Any feedback would be welcome, though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Simplified Jest configuration by consolidating multiple project settings into a single configuration object.
	- Updated the `test:node` script in `package.json` to streamline test execution by removing project selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->