### PR TITLE
Add HTTP rate limit actor

### DIFF
--- a/engines/config-query-sparql/config/config-default-v4-1-0.json
+++ b/engines/config-query-sparql/config/config-default-v4-1-0.json
@@ -15,7 +15,7 @@
     "ccqs:config/hash-bindings/mediators.json",
     "ccqs:config/hash-quads/actors.json",
     "ccqs:config/hash-quads/mediators.json",
-    "ccqs:config/http/actors.json",
+    "ccqs:config/http/actors-v4-1-0.json",
     "ccqs:config/http/mediators.json",
     "ccqs:config/http-invalidate/actors.json",
     "ccqs:config/http-invalidate/mediators.json",

--- a/engines/config-query-sparql/config/http/actors-limit-rate.json
+++ b/engines/config-query-sparql/config/http/actors-limit-rate.json
@@ -1,0 +1,16 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^4.0.0/components/context.jsonld",
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-limit-rate/^4.0.0/components/context.jsonld"
+  ],
+  "@id": "urn:comunica:default:Runner",
+  "@type": "Runner",
+  "actors": [
+    {
+      "@id": "urn:comunica:default:http/actors#limit-rate",
+      "@type": "ActorHttpLimitRate",
+      "mediatorHttp": { "@id": "urn:comunica:default:http/mediators#main" },
+      "beforeActors": { "@id": "urn:comunica:default:http/actors#proxy" }
+    }
+  ]
+}

--- a/engines/config-query-sparql/config/http/actors-v4-1-0.json
+++ b/engines/config-query-sparql/config/http/actors-v4-1-0.json
@@ -1,0 +1,10 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/config-query-sparql/^4.0.0/components/context.jsonld"
+  ],
+  "import": [
+    "ccqs:config/http/actors-fetch.json",
+    "ccqs:config/http/actors-limit-rate.json",
+    "ccqs:config/http/actors-wayback.json"
+  ]
+}

--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -178,6 +178,7 @@
     "@comunica/actor-hash-bindings-murmur": "^4.1.0",
     "@comunica/actor-hash-quads-murmur": "^4.1.0",
     "@comunica/actor-http-fetch": "^4.1.0",
+    "@comunica/actor-http-limit-rate": "^4.1.0",
     "@comunica/actor-http-proxy": "^4.1.0",
     "@comunica/actor-http-retry": "^4.1.0",
     "@comunica/actor-http-wayback": "^4.1.0",

--- a/packages/actor-http-limit-rate/README.md
+++ b/packages/actor-http-limit-rate/README.md
@@ -1,0 +1,46 @@
+# Comunica HTTP Rate Limit Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-http-limit-rate.svg)](https://www.npmjs.com/package/@comunica/actor-http-limit-rate)
+
+An [HTTP](https://github.com/comunica/comunica/tree/master/packages/bus-http) actor that performs rate limiting,
+by spacing out future requests based on past request durations,
+in an attempt to match the number of requests sent per second to the number of responses served per second by the server.
+By default, the actor waits for the first request to fail for a given host prior to spacing out requests.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica),
+and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
+
+[Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-http-limit-rate
+```
+
+## Configure
+
+After installing, this package can be added to your engine's configuration as follows:
+
+```json
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-http-limit-rate/^4.0.0/components/context.jsonld"
+  ],
+  "actors": [
+    {
+      "@id": "urn:comunica:default:http/actors#limit-rate",
+      "@type": "ActorHttpLimitRate"
+    }
+  ]
+}
+```
+
+### Config Parameters
+
+* `mediatorHttp`: A mediator over the [HTTP bus](https://github.com/comunica/comunica/tree/master/packages/bus-http).
+* `httpInvalidator`: A mediator over the [HTTP invalidate bus](https://github.com/comunica/comunica/tree/master/packages/bus-http-invalidate).
+* `correctionMultiplier`: How aggressively the request interval should follow the latest response time. Defaults to `0.1`.
+* `failureMultiplier`: The response time of a failed request is taken into account with this multiplier applied. Defaults to `10.0`.
+* `limitByDefault`: Whether the actor should do rate limiting by default, already before a request fails. Defaults to `false`.
+* `allowOverlap`: Whether the actor should allow overlapping requests to be sent to the server when rate limiting is applied. Defaults to `false`.

--- a/packages/actor-http-limit-rate/lib/ActorHttpLimitRate.ts
+++ b/packages/actor-http-limit-rate/lib/ActorHttpLimitRate.ts
@@ -1,0 +1,174 @@
+import type { IActionHttp, IActorHttpOutput, IActorHttpArgs, MediatorHttp } from '@comunica/bus-http';
+import { ActorHttp } from '@comunica/bus-http';
+import type { ActorHttpInvalidateListenable, IActionHttpInvalidate } from '@comunica/bus-http-invalidate';
+import type { TestResult } from '@comunica/core';
+import { ActionContextKey, failTest, passTest } from '@comunica/core';
+import type { IMediatorTypeTime } from '@comunica/mediatortype-time';
+
+export class ActorHttpLimitRate extends ActorHttp {
+  private readonly hostData: Map<string, IHostData>;
+  private readonly correctionMultiplier: number;
+  private readonly failureMultiplier: number;
+  private readonly limitByDefault: boolean;
+  private readonly allowOverlap: boolean;
+  private readonly httpInvalidator: ActorHttpInvalidateListenable;
+  private readonly mediatorHttp: MediatorHttp;
+
+  // Context key to indicate that the actor has already wrapped the given request
+  private static readonly keyWrapped = new ActionContextKey<boolean>('urn:comunica:actor-http-limit-rate#wrapped');
+
+  public constructor(args: IActorHttpLimitRateArgs) {
+    super(args);
+    this.mediatorHttp = args.mediatorHttp;
+    this.httpInvalidator = args.httpInvalidator;
+    this.httpInvalidator.addInvalidateListener(action => this.handleHttpInvalidateEvent(action));
+    this.correctionMultiplier = args.correctionMultiplier;
+    this.failureMultiplier = args.failureMultiplier;
+    this.limitByDefault = args.limitByDefault;
+    this.allowOverlap = args.allowOverlap;
+    this.hostData = new Map();
+  }
+
+  public async test(action: IActionHttp): Promise<TestResult<IMediatorTypeTime>> {
+    if (action.context.has(ActorHttpLimitRate.keyWrapped)) {
+      return failTest(`${this.name} can only wrap a request once`);
+    }
+    return passTest({ time: 0 });
+  }
+
+  public async run(action: IActionHttp): Promise<IActorHttpOutput> {
+    const requestUrl = ActorHttp.getInputUrl(action.input);
+    let requestHostData = this.hostData.get(requestUrl.host);
+
+    if (!requestHostData) {
+      requestHostData = {
+        latestRequestTimestamp: 0,
+        rateLimited: this.limitByDefault,
+        requestInterval: Number.NEGATIVE_INFINITY,
+      };
+      this.hostData.set(requestUrl.host, requestHostData);
+    }
+
+    const currentTimestamp = Date.now();
+    let currentRequestDelay = 0;
+
+    if (requestHostData.rateLimited) {
+      currentRequestDelay = Math.max(
+        0,
+        requestHostData.latestRequestTimestamp + requestHostData.requestInterval - currentTimestamp,
+      );
+    }
+
+    // Update the latest request timestamp before waiting, so that further requests will be delayed correctly.
+    // When overlap is disallowed, the timestamp is set to the expected despatch time of the current request,
+    // which will help smooth out request bursts by spacing them out evently. With overlap allowed, however,
+    // the timestamp is set to current time, which will result in overlapping requests and prevent smoothing.
+    requestHostData.latestRequestTimestamp = currentTimestamp + (this.allowOverlap ? 0 : 1) * currentRequestDelay;
+
+    if (currentRequestDelay > 0) {
+      this.logDebug(action.context, 'Delaying request to match host response intervals', () => ({
+        url: requestUrl.href,
+        host: requestUrl.host,
+        hostIntervalMilliseconds: requestHostData.requestInterval,
+        requestDelayMilliseconds: currentRequestDelay,
+      }));
+      await new Promise(resolve => setTimeout(resolve, currentRequestDelay));
+    }
+
+    const registerCompletedRequest = (success: boolean): void => {
+      const requestDuration = (success ? 1 : this.failureMultiplier) *
+        (Date.now() - currentTimestamp - currentRequestDelay);
+      if (!success && !requestHostData.rateLimited) {
+        requestHostData.rateLimited = true;
+      }
+      if (requestHostData.requestInterval < 0) {
+        requestHostData.requestInterval = requestDuration * this.correctionMultiplier;
+      } else {
+        requestHostData.requestInterval += Math.round(this.correctionMultiplier * (
+          requestDuration - requestHostData.requestInterval
+        ));
+      }
+    };
+
+    try {
+      const response = await this.mediatorHttp.mediate({
+        ...action,
+        context: action.context.set(ActorHttpLimitRate.keyWrapped, true),
+      });
+      registerCompletedRequest(response.ok);
+      return response;
+    } catch (error: unknown) {
+      registerCompletedRequest(false);
+      throw error;
+    }
+  }
+
+  /**
+   * Handles HTTP cache invalidation events.
+   * @param {IActionHttpInvalidate} action The invalidation action
+   */
+  public handleHttpInvalidateEvent(action: IActionHttpInvalidate): void {
+    if (action.url) {
+      const invalidatedHost = new URL(action.url).host;
+      this.hostData.delete(invalidatedHost);
+    } else {
+      this.hostData.clear();
+    }
+  }
+}
+
+interface IHostData {
+  /**
+   * The determined request interval for the host.
+   */
+  requestInterval: number;
+  /**
+   * The timestamp of the latest request to the host.
+   */
+  latestRequestTimestamp: number;
+  /**
+   * Whether the host is being rate limited.
+   */
+  rateLimited: boolean;
+}
+
+export interface IActorHttpLimitRateArgs extends IActorHttpArgs {
+  /**
+   * The HTTP mediator.
+   */
+  mediatorHttp: MediatorHttp;
+  /* eslint-disable max-len */
+  /**
+   * An actor that listens to HTTP invalidation events
+   * @default {<default_invalidator> a <npmd:@comunica/bus-http-invalidate/^4.0.0/components/ActorHttpInvalidateListenable.jsonld#ActorHttpInvalidateListenable>}
+   */
+  httpInvalidator: ActorHttpInvalidateListenable;
+  /* eslint-enable max-len */
+  /**
+   * Multiplier for how aggressively the delay should follow the latest response time, ideally in range ]0.0, 1.0].
+   * @range {float}
+   * @default {0.1}
+   */
+  correctionMultiplier: number;
+  /**
+   * The response time of a failed request is taken into account with this multiplier applied.
+   * @range {float}
+   * @default {10.0}
+   */
+  failureMultiplier: number;
+  /**
+   * Whether rate limiting should be applied from the first request onwards, instead of waiting for a request to fail.
+   * Enabling this behaviour can help avoid spamming a server with large amounts of requests when execution begins.
+   * @range {boolean}
+   * @default {false}
+   */
+  limitByDefault: boolean;
+  /**
+   * Whether requests should be allowed to overlap, instead of being effectively queued one after another for a host.
+   * Enabling this behaviour may help with overall performance, but will make the rate limiter less accurate,
+   * and make it impossible for the limiter to smooth out large bursts of requests to a given host.
+   * @range {boolean}
+   * @default {false}
+   */
+  allowOverlap: boolean;
+}

--- a/packages/actor-http-limit-rate/lib/index.ts
+++ b/packages/actor-http-limit-rate/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './ActorHttpLimitRate';

--- a/packages/actor-http-limit-rate/package.json
+++ b/packages/actor-http-limit-rate/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@comunica/actor-http-limit-rate",
+  "version": "4.1.0",
+  "description": "Comunica HTTP bus actor that performs rate limiting",
+  "lsd:module": true,
+  "license": "MIT",
+  "homepage": "https://comunica.dev/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/comunica/comunica.git",
+    "directory": "packages/actor-http-limit-rate"
+  },
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "keywords": [
+    "comunica",
+    "runner"
+  ],
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "typings": "lib/index",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.js.map"
+  ],
+  "scripts": {
+    "build": "yarn run build:ts && yarn run build:components",
+    "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
+    "build:components": "componentsjs-generator"
+  },
+  "dependencies": {
+    "@comunica/bus-http": "^4.1.0",
+    "@comunica/bus-http-invalidate": "^4.1.0",
+    "@comunica/core": "^4.1.0",
+    "@comunica/mediatortype-time": "^4.1.0"
+  }
+}

--- a/packages/actor-http-limit-rate/test/ActorHttpLimitRate-test.ts
+++ b/packages/actor-http-limit-rate/test/ActorHttpLimitRate-test.ts
@@ -1,0 +1,209 @@
+import type { MediatorHttp } from '@comunica/bus-http';
+import type { IActionHttpInvalidate } from '@comunica/bus-http-invalidate';
+import { ActionContext, Bus } from '@comunica/core';
+import { ActorHttpLimitRate } from '../lib/ActorHttpLimitRate';
+import '@comunica/utils-jest';
+
+describe('ActorHttpLimitRate', () => {
+  let bus: any;
+  let actor: ActorHttpLimitRate;
+  let mediatorHttp: MediatorHttp;
+  let actorHostData: Map<string, { requestInterval: number; latestRequestTimestamp: number; rateLimited: boolean }>;
+  let invalidateListeners: ((event: IActionHttpInvalidate) => void)[];
+
+  const correctionMultiplier = 0.1;
+  const failureMultiplier = 10;
+
+  const url = 'http://localhost:3000/some/url';
+  const host = 'localhost:3000';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    bus = new Bus({ name: 'bus' });
+    invalidateListeners = [];
+    mediatorHttp = <any>{
+      mediate: jest.fn().mockRejectedValue(new Error('mediatorHttp.mediate')),
+    };
+    actor = new ActorHttpLimitRate({
+      bus,
+      correctionMultiplier,
+      failureMultiplier,
+      limitByDefault: false,
+      allowOverlap: false,
+      httpInvalidator: <any>{
+        addInvalidateListener: jest.fn(listener => invalidateListeners.push(listener)),
+      },
+      mediatorHttp,
+      name: 'actor',
+    });
+    actorHostData = (<any>actor).hostData;
+    jest.spyOn((<any>actor), 'logDebug').mockImplementation((...args) => (<() => unknown>args[2])());
+  });
+
+  describe('test', () => {
+    it('should wrap operation', async() => {
+      const context = new ActionContext({});
+      await expect(actor.test({ context, input: url })).resolves.toPassTest({ time: 0 });
+    });
+
+    it('should wrap operation only once', async() => {
+      const context = new ActionContext({});
+      await expect(actor.test({
+        context: context.set((<any>ActorHttpLimitRate).keyWrapped, true),
+        input: url,
+      })).resolves.toFailTest(`${actor.name} can only wrap a request once`);
+    });
+  });
+
+  describe('run', () => {
+    it('should handle successful requests', async() => {
+      const response = { ok: true };
+      const duration = 100;
+      jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(duration);
+      jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(<any>response);
+      jest.spyOn(globalThis, 'setTimeout').mockImplementation(callback => <any>callback());
+      const action = { context: new ActionContext({}), input: url };
+      expect(actorHostData.has(host)).toBeFalsy();
+      await expect(actor.run(action)).resolves.toEqual(response);
+      expect(globalThis.setTimeout).not.toHaveBeenCalled();
+      expect(actorHostData.get(host)).toEqual({
+        requestInterval: duration * correctionMultiplier,
+        latestRequestTimestamp: 0,
+        rateLimited: false,
+      });
+    });
+
+    it('should delay requests when host is rate limited', async() => {
+      const response = { ok: true };
+      const interval = 100;
+      const responseTime = 200;
+      jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(responseTime);
+      jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(<any>response);
+      jest.spyOn(globalThis, 'setTimeout').mockImplementation(callback => <any>callback());
+      actorHostData.set(host, { latestRequestTimestamp: 0, rateLimited: true, requestInterval: interval });
+      const action = { context: new ActionContext({}), input: url };
+      await expect(actor.run(action)).resolves.toEqual(response);
+      expect(globalThis.setTimeout).toHaveBeenCalledTimes(1);
+      expect(globalThis.setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), interval);
+      expect(actorHostData.get(host)).toEqual({
+        requestInterval: interval + correctionMultiplier * (responseTime - interval - interval),
+        latestRequestTimestamp: interval,
+        rateLimited: true,
+      });
+    });
+
+    it('should delay requests when host is rate limited and overlap is allowed', async() => {
+      const response = { ok: true };
+      const interval = 100;
+      const responseTime = 200;
+      (<any>actor).allowOverlap = true;
+      jest.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(responseTime);
+      jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(<any>response);
+      jest.spyOn(globalThis, 'setTimeout').mockImplementation(callback => <any>callback());
+      actorHostData.set(host, { latestRequestTimestamp: 0, rateLimited: true, requestInterval: interval });
+      const action = { context: new ActionContext({}), input: url };
+      await expect(actor.run(action)).resolves.toEqual(response);
+      expect(globalThis.setTimeout).toHaveBeenCalledTimes(1);
+      expect(globalThis.setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), interval);
+      expect(actorHostData.get(host)).toEqual({
+        requestInterval: interval + correctionMultiplier * (responseTime - interval - interval),
+        // Note: the timestamp should be 0 because the interval is not applied!
+        // This is the major difference between the overlap and non-overlap test
+        latestRequestTimestamp: 0,
+        rateLimited: true,
+      });
+    });
+
+    it('should delay requests by default when configured to', async() => {
+      const duration1 = 100;
+      const duration2 = 200;
+      const interval1 = duration1 * correctionMultiplier;
+      const interval2 = interval1 + correctionMultiplier * (duration2 - interval1 - interval1);
+      const response = { ok: true };
+      (<any>actor).limitByDefault = true;
+      jest.spyOn(Date, 'now')
+        .mockReturnValueOnce(0).mockReturnValueOnce(duration1)
+        .mockReturnValueOnce(0).mockReturnValueOnce(duration2);
+      jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(<any>response);
+      jest.spyOn(globalThis, 'setTimeout').mockImplementation(callback => <any>callback());
+      const action = { context: new ActionContext({}), input: url };
+      expect(actorHostData.has(host)).toBeFalsy();
+      // First call, when the duration is assigned as the delay
+      await expect(actor.run(action)).resolves.toEqual(response);
+      expect(globalThis.setTimeout).not.toHaveBeenCalled();
+      expect(actorHostData.get(host)).toEqual({
+        requestInterval: interval1,
+        latestRequestTimestamp: 0,
+        rateLimited: true,
+      });
+      // Second call, when the delay is adjusted based on the correction multiplier
+      await expect(actor.run(action)).resolves.toEqual(response);
+      expect(globalThis.setTimeout).toHaveBeenCalledTimes(1);
+      expect(globalThis.setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), interval1);
+      expect(actorHostData.get(host)).toEqual({
+        requestInterval: interval2,
+        latestRequestTimestamp: interval1,
+        rateLimited: true,
+      });
+    });
+
+    it('should handle failing requests', async() => {
+      const duration1 = 400;
+      const duration2 = 600;
+      const interval1 = duration1 * failureMultiplier * correctionMultiplier;
+      const interval2 = interval1 + correctionMultiplier * (failureMultiplier * (duration2 - interval1) - interval1);
+      const response = { ok: false };
+      jest.spyOn(Date, 'now')
+        .mockReturnValueOnce(0).mockReturnValueOnce(duration1)
+        .mockReturnValueOnce(0).mockReturnValueOnce(duration2);
+      jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(<any>response);
+      jest.spyOn(globalThis, 'setTimeout').mockImplementation(callback => <any>callback());
+      const action = { context: new ActionContext({}), input: url };
+      expect(actorHostData.has(host)).toBeFalsy();
+      // First call, when the duration is assigned as the delay
+      await expect(actor.run(action)).resolves.toEqual(response);
+      expect(globalThis.setTimeout).not.toHaveBeenCalled();
+      expect(actorHostData.get(host)).toEqual({
+        requestInterval: interval1,
+        latestRequestTimestamp: 0,
+        rateLimited: true,
+      });
+      // Second call, when the delay is adjusted based on the correction multiplier
+      await expect(actor.run(action)).resolves.toEqual(response);
+      expect(globalThis.setTimeout).toHaveBeenCalledTimes(1);
+      expect(globalThis.setTimeout).toHaveBeenNthCalledWith(1, expect.any(Function), interval1);
+      expect(actorHostData.get(host)).toEqual({
+        requestInterval: interval2,
+        latestRequestTimestamp: interval1,
+        rateLimited: true,
+      });
+    });
+
+    it('should forward mediator errors', async() => {
+      const errorMessage = 'HTTP error';
+      jest.spyOn(Date, 'now').mockReturnValueOnce(0);
+      jest.spyOn(Date, 'now').mockReturnValueOnce(100);
+      jest.spyOn(mediatorHttp, 'mediate').mockRejectedValue(new Error(errorMessage));
+      jest.spyOn(globalThis, 'setTimeout').mockImplementation(callback => <any>callback());
+      const action = { context: new ActionContext({}), input: url };
+      await expect(actor.run(action)).rejects.toThrow(errorMessage);
+      expect(globalThis.setTimeout).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleHttpInvalidateEvent', () => {
+    it.each([
+      [ 'specific host data when specified', url, 1 ],
+      [ 'all host data when not specified', undefined, 0 ],
+    ])('correctly clears %s', async(_, url, expectedSize) => {
+      actorHostData.set(host, { latestRequestTimestamp: 0, rateLimited: true, requestInterval: 0 });
+      actorHostData.set('otherhost:3000', { latestRequestTimestamp: 0, rateLimited: true, requestInterval: 0 });
+      expect(actorHostData.size).toBe(2);
+      for (const listener of invalidateListeners) {
+        listener({ context: <any>{}, url });
+      }
+      expect(actorHostData.size).toBe(expectedSize);
+    });
+  });
+});


### PR DESCRIPTION
Here is a draft PR for the simple rate limit actor, after a lot of revisions back and forth.
* The actor current keeps track of the *n* previous request durations as a sliding list/window (not sure what the correct term it), measured from when the request was sent, to when the server replied, excluding the time taken to read the request body. Based on these previous request durations, it spaces out future requests in a way that avoids request spikes.
* The actor also maintains a concurrent request limit per host. When a request to a host is successful, and there is a considerable number of requests in queue for it (currently >10x the concurrent request limit), the actor will increase the concurrent request limit by 1. When a request fails, it will halve the limit.

The actor is really simple in the way it functions, because after multiple revisions, I decided that it is better to keep it simple. For example, tracking a host-specific processing time budget client-side (such as the Wikidata 60s of processing every 60s) would make the implementation unnecessarily complicated, and would limit the concurrent request count to 1 because the estimated running time for a query would have to be infinite to avoid budget overruns. While this would work for SPARQL endpoints, it would be unnecessarily slow for document-based servers.

Any feedback would be welcome. :slightly_smiling_face: When I find the time, I will try to do some more benchmarks on this to see the impact. From what I have noticed, it does not unnecessarily slow down things, but the history length does impact how fast it will ramp up the requests per second initially.