### PR TITLE
Add Regex spec tests

### DIFF
--- a/engines/query-sparql-rdfjs-lite/webpack.config.ts
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.ts
@@ -3,8 +3,8 @@ import { createConfig } from '../../webpack.config';
 const liteConfig = createConfig(__dirname);
 
 if (typeof liteConfig.performance === 'object') {
-  liteConfig.performance.maxAssetSize = 900_000;
-  liteConfig.performance.maxEntrypointSize = 900_000;
+  liteConfig.performance.maxAssetSize = 910_000;
+  liteConfig.performance.maxEntrypointSize = 910_000;
 }
 
 export default liteConfig;

--- a/packages/actor-function-factory-term-regex/README.md
+++ b/packages/actor-function-factory-term-regex/README.md
@@ -11,7 +11,6 @@ The `x` and `q` flag not present in the JS engine are implemented by preprocessi
 As a result of using the JS regex engine, the bundle size of this package is small, but some non-spec compliant edge cases are present.
 Examples are the skipped tests in [op.regex-test.ts](https://github.com/comunica/comunica/blob/master/packages/actor-function-factory-term-regex/test/op.regex-test.ts).
 
-
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
 

--- a/packages/actor-function-factory-term-regex/README.md
+++ b/packages/actor-function-factory-term-regex/README.md
@@ -5,6 +5,12 @@
 A [function factory](https://github.com/comunica/comunica/tree/master/packages/bus-function-factory) actor
 that constructs a [term function](https://github.com/comunica/comunica/tree/master/packages/bus-function-factory/lib/ActorFunctionFactory.ts)
 capable of evaluating the [Regex](https://www.w3.org/TR/sparql11-query/#func-regex) function.
+The regex evaluation uses the JavaScript regex engine in 'unicode-mode'
+thereby eliminating [Annex B](https://262.ecma-international.org/6.0/#sec-regular-expressions-patterns) behavior.
+The `x` and `q` flag not present in the JS engine are implemented by preprocessing of the pattern.
+As a result of using the JS regex engine, the bundle size of this package is small, but some non-spec compliant edge cases are present.
+Examples are the skipped tests in [op.regex-test.ts](https://github.com/comunica/comunica/blob/master/packages/actor-function-factory-term-regex/test/op.regex-test.ts).
+
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).

--- a/packages/actor-function-factory-term-regex/lib/TermFunctionRegex.ts
+++ b/packages/actor-function-factory-term-regex/lib/TermFunctionRegex.ts
@@ -57,7 +57,7 @@ export class TermFunctionRegex extends TermFunctionBase {
     return reg.test(text);
   }
 
-  private static cleanFlags(flags: string): string {
+  public static cleanFlags(flags: string): string {
     // Check flag validity
     if (!/^[imsxq]*$/u.test(flags)) {
       throw new Error('Invalid flags');
@@ -77,7 +77,7 @@ export class TermFunctionRegex extends TermFunctionBase {
     return `${flags}u`;
   }
 
-  private static flagX(pattern: string): string {
+  public static flagX(pattern: string): string {
     if (!pattern) {
       return pattern;
     }
@@ -103,7 +103,7 @@ export class TermFunctionRegex extends TermFunctionBase {
     return pattern;
   }
 
-  private static flagQ(pattern: string): string {
+  public static flagQ(pattern: string): string {
     // Escape all metacharacters in the pattern
     return pattern
       .replaceAll(/([?+*.{}()[\]\\|])/gu, '\\$1')

--- a/packages/actor-function-factory-term-regex/lib/TermFunctionRegex.ts
+++ b/packages/actor-function-factory-term-regex/lib/TermFunctionRegex.ts
@@ -27,11 +27,48 @@ export class TermFunctionRegex extends TermFunctionBase {
 
   // https://www.w3.org/TR/xpath-functions/#func-matches
   // https://www.w3.org/TR/xpath-functions/#flags
-  private static matches(text: string, pattern: string, flags?: string): boolean {
-    // TODO: Only flags 'i' and 'm' match between XPath and JS.
-    // 's', 'x', 'q', would need proper implementation.
-    const reg = new RegExp(pattern, flags);
+  private static matches(text: string, pattern: string, flags = ''): boolean {
+    // Flags:
+    //   i: case-insensitive: same as the 'i' flag in JavaScript
+    //   m: multi-line mode: same as the 'm' flag in JavaScript
+    //   s: dot-all mode: matches 's' flag in JavaScript very well.
+    //   x: whitespace characters (#x9, #xA, #xD and #x20)
+    //      in the regular expression are removed prior to matching with one exception
+    //   q: regex-no-metacharacters:
+    //      all characters in the regular expression are treated as representing themselves, not as metacharacters
+    //      If it is used together with the m, s, or x flag, that flag has no effect.
+    flags = TermFunctionRegex.cleanFlags(flags);
+
+    if (flags?.includes('x')) {
+      // Remove all spaces in the pattern, excluding those in character classes
+    }
+    if (flags?.includes('q')) {
+      // Escape all metacharacters in the pattern
+      pattern = pattern
+        .replaceAll(/([?+*.{}()[\]\\|])/gu, '\\$1')
+        .replaceAll(/^\^/gu, '\\^')
+        .replaceAll(/\$$/gu, '\\$');
+    }
+
+    const reg = new RegExp(pattern, flags.replaceAll(/[qx]/gu, ''));
     return reg.test(text);
+  }
+
+  private static cleanFlags(flags: string): string {
+    // Check flag validity
+    if (!/[imsxq]*/u.test(flags)) {
+      throw new Error('Invalid flags');
+    }
+    const duplicateFlag = [ ...flags ]
+      .find((value, index, self) => self.indexOf(value) !== index);
+    if (duplicateFlag) {
+      throw new Error(`Duplicate flag: ${duplicateFlag}`);
+    }
+    // If the 'q' flag is used, the 'm', 's', and 'x' flags have no effect
+    if (flags?.includes('q')) {
+      flags = flags.replaceAll(/[msx]/gu, '');
+    }
+    return flags;
   }
 
   private static regex2(): (text: string, pattern: string) => BooleanLiteral {

--- a/packages/actor-function-factory-term-regex/lib/index.ts
+++ b/packages/actor-function-factory-term-regex/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './ActorFunctionFactoryTermRegex';
+export * from './TermFunctionRegex';

--- a/packages/actor-function-factory-term-regex/test/op.regex-test.ts
+++ b/packages/actor-function-factory-term-regex/test/op.regex-test.ts
@@ -27,6 +27,7 @@ describe('evaluation of \'regex\' like', () => {
       '"helloworld"' '"hello[ ]world"' "x" = false
       '"hello world"' '"hello\\\\ sworld"' "x" = true
       '"hello world"' '"hello world"' "x" = false
+      '""' '""' "x" = true
       `,
     errorTable: `
       '"Invalid flags'" '"a"' '"a"' = 'Invalid flags'

--- a/packages/actor-function-factory-term-regex/test/op.regex-test.ts
+++ b/packages/actor-function-factory-term-regex/test/op.regex-test.ts
@@ -23,6 +23,14 @@ describe('evaluation of \'regex\' like', () => {
       "a\\na" ".+" "s" = true
       "a\\nb\\nc" "^b$" = false
       "a\\nb\\nc" "^b$" "m" = true
+      '"helloworld"' '"hello world"' "x" = true
+      '"helloworld"' '"hello[ ]world"' "x" = false
+      '"hello world"' '"hello\\\\ sworld"' "x" = true
+      '"hello world"' '"hello world"' "x" = false
       `,
+    errorTable: `
+      '"Invalid flags'" '"a"' '"a"' = 'Invalid flags'
+      '"Duplicate flag"' '"a"' '"ii"' = 'Duplicate flag'
+    `,
   });
 });

--- a/packages/actor-function-factory-term-regex/test/op.regex-test.ts
+++ b/packages/actor-function-factory-term-regex/test/op.regex-test.ts
@@ -3,8 +3,9 @@ import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
 import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
 import { ActorFunctionFactoryTermRegex } from '../lib';
 
-describe('evaluation of \'regex\' like', () => {
-  // TODO: Test better
+// Eventually, it might be nice to have a spec compliant regex engine
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('unfortunately our engine is not spec compliant', () => {
   runFuncTestTable({
     registeredActors: [
       args => new ActorFunctionFactoryTermRegex(args),
@@ -13,25 +14,63 @@ describe('evaluation of \'regex\' like', () => {
     operation: 'regex',
     notation: Notation.Function,
     aliases: bool,
-    testTable: `
-      "simple" "simple" = true
-      "aaaaaa" "a" = true
-      "simple" "blurgh" = false
-      "aaa" "a+" = true
-      "AAA" "a+" = false
-      "AAA" "a+" "i" = true
-      "a\\na" ".+" "s" = true
-      "a\\nb\\nc" "^b$" = false
-      "a\\nb\\nc" "^b$" "m" = true
-      '"helloworld"' '"hello world"' "x" = true
-      '"helloworld"' '"hello[ ]world"' "x" = false
-      '"hello world"' '"hello\\\\ sworld"' "x" = true
-      '"hello world"' '"hello world"' "x" = false
-      '""' '""' "x" = true
-      `,
-    errorTable: `
-      '"Invalid flags'" '"a"' '"a"' = 'Invalid flags'
-      '"Duplicate flag"' '"a"' '"ii"' = 'Duplicate flag'
-    `,
+    testArray: [
+      // From https://www.w3.org/TR/xpath-functions/#flags
+      [ '"apple"', '"^\\\\p{Lu}*$"', '"i"', 'false' ],
+      [ '"APPLE"', '"^\\\\p{Lu}*$"', '"i"', 'true' ],
+      [ '"APPLE"', '"^[A-Z-[IO]]*$"', 'true' ],
+    ],
+  });
+});
+
+describe('evaluation of \'regex\' like', () => {
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    operation: 'regex',
+    notation: Notation.Function,
+    aliases: bool,
+    testArray: [
+      // [ '"simple"', '"simple"', 'true' ],
+      // [ '"aaaaaa"', '"a"', 'true' ],
+      // [ '"simple"', '"blurgh"', 'false' ],
+      // [ '"a"', '"^ab?$"', 'true' ],
+      // [ '"ab"', '"^ab?$"', 'true' ],
+      // [ '"aaa"', '"a+"', 'true' ],
+      // [ '"AAA"', '"a+"', 'false' ],
+      // [ '"AAA"', '"a+"', '"i"', 'true' ],
+      // [ '"a\\na"', '".+"', '"s"', 'true' ],
+      // [ '"a\\nb\\nc"', '"^b$"', 'false' ],
+      // [ '"a\\nb\\nc"', '"^b$"', '"m"', 'true' ],
+      //
+      // // From https://www.w3.org/TR/xpath-functions/#flags
+      // [ '"helloworld"', '"hello world"', '"x"', 'true' ],
+      // [ '"helloworld"', '"hello[ ]world"', '"x"', 'false' ],
+      [ '"hello world"', '"hello\\\\ sworld"', '"x"', 'true' ],
+      [ '"hello world"', '"hello world"', '"x"', 'false' ],
+
+      [ '""', '""', '"x"', 'true' ],
+      [ `"""An 
+apple
+not pear"""`, '"^apple"', '"m"', 'true' ],
+      [ `"""An 
+apple
+not pear"""`, '"^pear"', '"m"', 'false' ],
+
+      // From https://www.w3.org/TR/xpath-functions/#flags
+      [ '"Mum"', '"([md])[aeiou]\\\\1"', '"i"', 'true' ],
+      [ '"mom"', '"([md])[aeiou]\\\\1"', '"i"', 'true' ],
+      [ '"Dad"', '"([md])[aeiou]\\\\1"', '"i"', 'true' ],
+      [ '"DUD"', '"([md])[aeiou]\\\\1"', '"i"', 'true' ],
+
+      [ '"abcd"', '"B. OBAMA"', '"iq"', 'false' ],
+      [ '"Mr. B. Obama"', '"B. OBAMA"', '"iq"', 'true' ],
+    ],
+    errorArray: [
+      [ '"Invalid flags"', '"a"', '"a"', 'Invalid flags' ],
+      [ '"Duplicate flag"', '"a"', '"ii"', 'Duplicate flag' ],
+    ],
   });
 });

--- a/packages/actor-function-factory-term-regex/test/regex-case-insensitive-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-case-insensitive-spec-test.ts
@@ -1,0 +1,75 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-case-insensitive.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "abc", "i")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-case-insensitive a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with the i option" ;
+ *       mf:action
+ *           [ qt:query  <regex-case-insensitive.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-case-insensitive.srx> .
+ */
+
+describe('We should respect the regex-case-insensitive spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' "abc" "i" = false
+      '${s2}' "abc" "i" = true
+      '${s3}' "abc" "i" = false
+      '${s4}' "abc" "i" = false
+      '${s5}' "abc" "i" = false
+      '${s6}' "abc" "i" = false
+      '${s7}' "abc" "i" = false
+      '${s8}' "abc" "i" = true
+      '${s9}' "abc" "i" = false
+      '${s10}' "abc" "i" = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-case-insensitive.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abc</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>ABC</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-char-class-expression-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-char-class-expression-spec-test.ts
@@ -1,0 +1,77 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-char-class-expression.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "a[b\\n]c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-char-class-expression a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with [] expression" ;
+ *       mf:action
+ *           [ qt:query  <regex-char-class-expression.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-char-class-expression.srx> .
+ */
+
+describe('We should respect the regex-char-class-expression spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 2,
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' "a[b\\n]c" = false
+      '${s2}' "a[b\\n]c" = true
+      '${s3}' "a[b\\n]c" = false
+      '${s4}' "a[b\\n]c" = false
+      '${s5}' "a[b\\n]c" = true
+      '${s6}' "a[b\\n]c" = false
+      '${s7}' "a[b\\n]c" = false
+      '${s8}' "a[b\\n]c" = false
+      '${s9}' "a[b\\n]c" = false
+      '${s10}' "a[b\\n]c" = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-char-class-expression.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abc</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a
+ * c</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-dot-all-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-dot-all-spec-test.ts
@@ -1,0 +1,82 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-dot-all.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "a.c", "s")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-dot-all a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with an . operator and the s option" ;
+ *       mf:action
+ *           [ qt:query  <regex-dot-all.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-dot-all.srx> .
+ */
+
+describe('We should respect the regex-dot-all spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' "a.c" "s" = false
+      '${s2}' "a.c" "s" = true
+      '${s3}' "a.c" "s" = false
+      '${s4}' "a.c" "s" = false
+      '${s5}' "a.c" "s" = true
+      '${s6}' "a.c" "s" = false
+      '${s7}' "a.c" "s" = true
+      '${s8}' "a.c" "s" = false
+      '${s9}' "a.c" "s" = false
+      '${s10}' "a.c" "s" = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-dot-all.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *   <head>
+ *     <variable name="val"/>
+ *   </head>
+ *   <results>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>abc</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>a
+ * c</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>a.c</literal>
+ *       </binding>
+ *     </result>
+ *   </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-dot-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-dot-spec-test.ts
@@ -1,0 +1,76 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-dot.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "a.c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-dot a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with an . operator" ;
+ *       mf:action
+ *           [ qt:query  <regex-dot.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-dot.srx> .
+ */
+
+describe('We should respect the regex-dot spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' "a.c" = false
+      '${s2}' "a.c" = true
+      '${s3}' "a.c" = false
+      '${s4}' "a.c" = false
+      '${s5}' "a.c" = false
+      '${s6}' "a.c" = false
+      '${s7}' "a.c" = true
+      '${s8}' "a.c" = false
+      '${s9}' "a.c" = false
+      '${s10}' "a.c" = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-dot.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *   <head>
+ *     <variable name="val"/>
+ *   </head>
+ *   <results>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>abc</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>a.c</literal>
+ *       </binding>
+ *     </result>
+ *   </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-class-expression-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-class-expression-spec-test.ts
@@ -27,7 +27,9 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-ignore-whitespaces-class-expression.srx> .
  */
 
-describe('We should respect the regex-ignore-whitespaces-class-expression', () => {
+// We do not support the 'x' flag yet.
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('We should respect the regex-ignore-whitespaces-class-expression', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [
@@ -37,18 +39,18 @@ describe('We should respect the regex-ignore-whitespaces-class-expression', () =
     notation: Notation.Function,
     operation: 'regex',
     aliases: bool,
-    testTable: `
-      '${s1}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s2}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s3}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s4}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s5}' '" a\n\r\t[\\n]c "' "x" = true
-      '${s6}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s7}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s8}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s9}' '" a\n\r\t[\\n]c "' "x" = false
-      '${s10}' '" a\n\r\t[\\n]c "' "x" = false
-    `,
+    testArray: [
+      [ `'${s1}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s2}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s3}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s4}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s5}'`, '""" a\n\r\t[\\n]c """', '"x"', 'true' ],
+      [ `'${s6}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s7}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s8}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s9}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+      [ `'${s10}'`, '""" a\n\r\t[\\n]c """', '"x"', 'false' ],
+    ],
   });
 });
 

--- a/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-class-expression-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-class-expression-spec-test.ts
@@ -27,9 +27,7 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-ignore-whitespaces-class-expression.srx> .
  */
 
-// We do not support the 'x' flag yet.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('We should respect the regex-ignore-whitespaces-class-expression', () => {
+describe('We should respect the regex-ignore-whitespaces-class-expression', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [

--- a/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-class-expression-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-class-expression-spec-test.ts
@@ -1,0 +1,72 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-ignore-whitespaces-class-expression.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, " a\n\r\t[\\n]c ", "x")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-ignore-whitespaces-class-expression a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with the ignore spacing (x) option with class expression" ;
+ *       mf:action
+ *           [ qt:query  <regex-ignore-whitespaces-class-expression.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-ignore-whitespaces-class-expression.srx> .
+ */
+
+describe('We should respect the regex-ignore-whitespaces-class-expression', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s2}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s3}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s4}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s5}' '" a\n\r\t[\\n]c "' "x" = true
+      '${s6}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s7}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s8}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s9}' '" a\n\r\t[\\n]c "' "x" = false
+      '${s10}' '" a\n\r\t[\\n]c "' "x" = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-ignore-whitespaces-class-expression.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a
+ * c</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-spec-test.ts
@@ -1,0 +1,71 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-ignore-whitespaces.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, " a\n\tc ", "x")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-ignore-whitespaces a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with the ignore spacing (x) option" ;
+ *       mf:action
+ *           [ qt:query  <regex-ignore-whitespaces.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-ignore-whitespaces.srx> .
+ */
+
+describe('We should respect the regex-ignore-whitespaces spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '" a\n\tc "' '"x"' = true
+      '${s2}' '" a\n\tc "' '"x"' = false
+      '${s3}' '" a\n\tc "' '"x"' = false
+      '${s4}' '" a\n\tc "' '"x"' = false
+      '${s5}' '" a\n\tc "' '"x"' = false
+      '${s6}' '" a\n\tc "' '"x"' = false
+      '${s7}' '" a\n\tc "' '"x"' = false
+      '${s8}' '" a\n\tc "' '"x"' = false
+      '${s9}' '" a\n\tc "' '"x"' = false
+      '${s10}' '" a\n\tc "' '"x"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-ignore-whitespaces.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>ac</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-spec-test.ts
@@ -27,7 +27,9 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-ignore-whitespaces.srx> .
  */
 
-describe('We should respect the regex-ignore-whitespaces spec', () => {
+// We do not support the 'x' flag yet.
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('We should respect the regex-ignore-whitespaces spec', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [
@@ -37,18 +39,18 @@ describe('We should respect the regex-ignore-whitespaces spec', () => {
     notation: Notation.Function,
     operation: 'regex',
     aliases: bool,
-    testTable: `
-      '${s1}' '" a\n\tc "' '"x"' = true
-      '${s2}' '" a\n\tc "' '"x"' = false
-      '${s3}' '" a\n\tc "' '"x"' = false
-      '${s4}' '" a\n\tc "' '"x"' = false
-      '${s5}' '" a\n\tc "' '"x"' = false
-      '${s6}' '" a\n\tc "' '"x"' = false
-      '${s7}' '" a\n\tc "' '"x"' = false
-      '${s8}' '" a\n\tc "' '"x"' = false
-      '${s9}' '" a\n\tc "' '"x"' = false
-      '${s10}' '" a\n\tc "' '"x"' = false
-    `,
+    testArray: [
+      [ `'${s1}'`, '""" a\n\tc """', '"x"', 'true' ],
+      [ `'${s2}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s3}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s4}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s5}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s6}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s7}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s8}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s9}'`, '""" a\n\tc """', '"x"', 'false' ],
+      [ `'${s10}'`, '""" a\n\tc """', '"x"', 'false' ],
+    ],
   });
 });
 

--- a/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-ignore-whitespaces-spec-test.ts
@@ -27,9 +27,7 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-ignore-whitespaces.srx> .
  */
 
-// We do not support the 'x' flag yet.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('We should respect the regex-ignore-whitespaces spec', () => {
+describe('We should respect the regex-ignore-whitespaces spec', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [

--- a/packages/actor-function-factory-term-regex/test/regex-negative-char-class-expression-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-negative-char-class-expression-spec-test.ts
@@ -1,0 +1,77 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-negative-char-class-expression.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "a[^b]c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-negative-char-class-expression a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with a [^] expression" ;
+ *       mf:action
+ *           [ qt:query  <regex-negative-char-class-expression.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-negative-char-class-expression.srx> .
+ */
+
+describe('We should respect the regex-negative-char-class-expression spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"a[^b]c"' = false
+      '${s2}' '"a[^b]c"' = false
+      '${s3}' '"a[^b]c"' = false
+      '${s4}' '"a[^b]c"' = false
+      '${s5}' '"a[^b]c"' = true
+      '${s6}' '"a[^b]c"' = false
+      '${s7}' '"a[^b]c"' = true
+      '${s8}' '"a[^b]c"' = false
+      '${s9}' '"a[^b]c"' = false
+      '${s10}' '"a[^b]c"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-negative-char-class-expression.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a
+ * c</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a.c</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
@@ -13,7 +13,7 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  * SELECT ?val
  * WHERE {
  *    ex:foo rdf:value ?val .
- *    FILTER regex(?val, "a?+*.{}()C", "iq")
+ *    FILTER regex(?val, "a?+*.{}()[]C", "iq")
  * }
  */
 
@@ -38,24 +38,22 @@ describe('We should respect the regex-no-metacharacters-case-insensitive spec', 
     operation: 'regex',
     aliases: bool,
     testTable: `
-      '${s1}' '"a?+*.{}()C"' '"iq"' = false
-      '${s2}' '"a?+*.{}()C"' '"iq"' = false
-      '${s3}' '"a?+*.{}()C"' '"iq"' = false
-      '${s4}' '"a?+*.{}()C"' '"iq"' = false
-      '${s5}' '"a?+*.{}()C"' '"iq"' = false
-      '${s6}' '"a?+*.{}()C"' '"iq"' = false
-      '${s7}' '"a?+*.{}()C"' '"iq"' = false
-      '${s8}' '"a?+*.{}()C"' '"iq"' = false
-      '${s9}' '"a?+*.{}()C"' '"iq"' = false
-      '${s10}' '"a?+*.{}()C"' '"iq"' = false
+      '${s1}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s2}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s3}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s4}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s5}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s6}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s7}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s8}' '"a?+*.{}()[]C"' '"iq"' = false
+      '${s9}' '"a?+*.{}()[]C"' '"iq"' = true
+      '${s10}' '"a?+*.{}()[]C"' '"iq"' = false
     `,
   });
 });
 
-/// TODO: missing result-set??
-
 /**
- * RESULTS: regex-no-metacharacters-case-insensitive.srx
+ * RESULTS: regex-no-metacharacters.srx
  *
  * <?xml version="1.0"?>
  * <sparql>
@@ -65,13 +63,7 @@ describe('We should respect the regex-no-metacharacters-case-insensitive spec', 
  *    <results>
  *        <result>
  *            <binding name="val">
- *                <literal>a
- * c</literal>
- *            </binding>
- *        </result>
- *        <result>
- *            <binding name="val">
- *                <literal>a.c</literal>
+ *                <literal>a?+*.{}()[]c</literal>
  *            </binding>
  *        </result>
  *    </results>

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
@@ -1,0 +1,79 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-no-metacharacters-case-insensitive.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "a?+*.{}()C", "iq")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-no-metacharacters-case-insensitive a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with the iq option" ;
+ *       mf:action
+ *           [ qt:query  <regex-no-metacharacters-case-insensitive.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-no-metacharacters.srx> .
+ */
+
+describe('We should respect the regex-no-metacharacters-case-insensitive spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"a?+*.{}()C"' '"iq"' = false
+      '${s2}' '"a?+*.{}()C"' '"iq"' = false
+      '${s3}' '"a?+*.{}()C"' '"iq"' = false
+      '${s4}' '"a?+*.{}()C"' '"iq"' = false
+      '${s5}' '"a?+*.{}()C"' '"iq"' = false
+      '${s6}' '"a?+*.{}()C"' '"iq"' = false
+      '${s7}' '"a?+*.{}()C"' '"iq"' = false
+      '${s8}' '"a?+*.{}()C"' '"iq"' = false
+      '${s9}' '"a?+*.{}()C"' '"iq"' = false
+      '${s10}' '"a?+*.{}()C"' '"iq"' = false
+    `,
+  });
+});
+
+/// TODO: missing result-set??
+
+/**
+ * RESULTS: regex-no-metacharacters-case-insensitive.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a
+ * c</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a.c</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
@@ -27,9 +27,7 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-no-metacharacters.srx> .
  */
 
-// We do not support the 'q' flag yet.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('We should respect the regex-no-metacharacters-case-insensitive spec', () => {
+describe('We should respect the regex-no-metacharacters-case-insensitive spec', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-case-insensitive-spec-test.ts
@@ -27,7 +27,9 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-no-metacharacters.srx> .
  */
 
-describe('We should respect the regex-no-metacharacters-case-insensitive spec', () => {
+// We do not support the 'q' flag yet.
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('We should respect the regex-no-metacharacters-case-insensitive spec', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
@@ -27,7 +27,9 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-no-metacharacters.srx> .
  */
 
-describe('We should respect the regex-no-metacharacters spec', () => {
+// We do not support the 'q' flag yet.
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('We should respect the regex-no-metacharacters spec', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
@@ -27,9 +27,7 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  *       mf:result  <regex-no-metacharacters.srx> .
  */
 
-// We do not support the 'q' flag yet.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('We should respect the regex-no-metacharacters spec', () => {
+describe('We should respect the regex-no-metacharacters spec', () => {
   const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
   runFuncTestTable({
     registeredActors: [

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
@@ -13,7 +13,7 @@ import { ActorFunctionFactoryTermRegex } from '../lib';
  * SELECT ?val
  * WHERE {
  *    ex:foo rdf:value ?val .
- *    FILTER regex(?val, "a?+*.{}()c", "q")
+ *    FILTER regex(?val, "a?+*.{}()[]c", "q")
  * }
  */
 
@@ -38,16 +38,16 @@ describe('We should respect the regex-no-metacharacters spec', () => {
     operation: 'regex',
     aliases: bool,
     testTable: `
-      '${s1}' '"a?+*.{}()c"' '"q"' = false
-      '${s2}' '"a?+*.{}()c"' '"q"' = false
-      '${s3}' '"a?+*.{}()c"' '"q"' = false
-      '${s4}' '"a?+*.{}()c"' '"q"' = false
-      '${s5}' '"a?+*.{}()c"' '"q"' = false
-      '${s6}' '"a?+*.{}()c"' '"q"' = false
-      '${s7}' '"a?+*.{}()c"' '"q"' = false
-      '${s8}' '"a?+*.{}()c"' '"q"' = false
-      '${s9}' '"a?+*.{}()c"' '"q"' = true
-      '${s10}' '"a?+*.{}()c"' '"q"' = false
+      '${s1}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s2}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s3}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s4}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s5}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s6}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s7}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s8}' '"a?+*.{}()[]c"' '"q"' = false
+      '${s9}' '"a?+*.{}()[]c"' '"q"' = true
+      '${s10}' '"a?+*.{}()[]c"' '"q"' = false
     `,
   });
 });
@@ -63,7 +63,7 @@ describe('We should respect the regex-no-metacharacters spec', () => {
  *    <results>
  *        <result>
  *            <binding name="val">
- *                <literal>a?+*.{}()c</literal>
+ *                <literal>a?+*.{}()[]c</literal>
  *            </binding>
  *        </result>
  *    </results>

--- a/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-no-metacharacters-spec-test.ts
@@ -1,0 +1,71 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-no-metacharacters.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "a?+*.{}()c", "q")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-no-metacharacters a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with the q option" ;
+ *       mf:action
+ *           [ qt:query  <regex-no-metacharacters.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-no-metacharacters.srx> .
+ */
+
+describe('We should respect the regex-no-metacharacters spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"a?+*.{}()c"' '"q"' = false
+      '${s2}' '"a?+*.{}()c"' '"q"' = false
+      '${s3}' '"a?+*.{}()c"' '"q"' = false
+      '${s4}' '"a?+*.{}()c"' '"q"' = false
+      '${s5}' '"a?+*.{}()c"' '"q"' = false
+      '${s6}' '"a?+*.{}()c"' '"q"' = false
+      '${s7}' '"a?+*.{}()c"' '"q"' = false
+      '${s8}' '"a?+*.{}()c"' '"q"' = false
+      '${s9}' '"a?+*.{}()c"' '"q"' = true
+      '${s10}' '"a?+*.{}()c"' '"q"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-no-metacharacters.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a?+*.{}()c</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-quantifier-counted-exact-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-quantifier-counted-exact-spec-test.ts
@@ -1,0 +1,71 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-quantifier-counted-exact.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "ab{2}c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-quantifier-counted-exact a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with an {2} quantifier" ;
+ *       mf:action
+ *           [ qt:query  <regex-quantifier-counted-exact.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-quantifier-counted-exact.srx> .
+ */
+
+describe('We should respect the regex-quantifier-counted-exact spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"ab{2}c"' = false
+      '${s2}' '"ab{2}c"' = false
+      '${s3}' '"ab{2}c"' = true
+      '${s4}' '"ab{2}c"' = false
+      '${s5}' '"ab{2}c"' = false
+      '${s6}' '"ab{2}c"' = false
+      '${s7}' '"ab{2}c"' = false
+      '${s8}' '"ab{2}c"' = false
+      '${s9}' '"ab{2}c"' = false
+      '${s10}' '"ab{2}c"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-quantifier-counted-exact.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abbc</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-quantifier-counted-lower-bound-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-quantifier-counted-lower-bound-spec-test.ts
@@ -1,0 +1,81 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-quantifier-counted-lower-bound.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "ab{1,}c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-quantifier-counted-lower-bound a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with an {,2} quantifier" ;
+ *       mf:action
+ *           [ qt:query  <regex-quantifier-counted-lower-bound.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-quantifier-counted-lower-bound.srx> .
+ */
+
+describe('We should respect the regex-quantifier-counted-lower-bound spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"ab{1,}c"' = false
+      '${s2}' '"ab{1,}c"' = true
+      '${s3}' '"ab{1,}c"' = true
+      '${s4}' '"ab{1,}c"' = true
+      '${s5}' '"ab{1,}c"' = false
+      '${s6}' '"ab{1,}c"' = false
+      '${s7}' '"ab{1,}c"' = false
+      '${s8}' '"ab{1,}c"' = false
+      '${s9}' '"ab{1,}c"' = false
+      '${s10}' '"ab{1,}c"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-quantifier-counted-lower-bound.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abc</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abbc</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abbbc</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-quantifier-counted-lower-upper-bounds-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-quantifier-counted-lower-upper-bounds-spec-test.ts
@@ -1,0 +1,76 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-quantifier-counted-lower-upper-bounds.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "ab{1,2}c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-quantifier-counted-lower-upper-bounds a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with an {2,} quantifier" ;
+ *       mf:action
+ *           [ qt:query  <regex-quantifier-counted-lower-upper-bounds.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-quantifier-counted-lower-upper-bounds.srx>
+ */
+
+describe('We should respect the regex-quantifier-counted-lower-upper-bounds spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"ab{1,2}c"' = false
+      '${s2}' '"ab{1,2}c"' = true
+      '${s3}' '"ab{1,2}c"' = true
+      '${s4}' '"ab{1,2}c"' = false
+      '${s5}' '"ab{1,2}c"' = false
+      '${s6}' '"ab{1,2}c"' = false
+      '${s7}' '"ab{1,2}c"' = false
+      '${s8}' '"ab{1,2}c"' = false
+      '${s9}' '"ab{1,2}c"' = false
+      '${s10}' '"ab{1,2}c"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-quantifier-counted-lower-upper-bounds.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abc</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>abbc</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-quantifier-one-or-more-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-quantifier-one-or-more-spec-test.ts
@@ -1,0 +1,81 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-quantifier-one-or-more.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "ab+c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-quantifier-one-or-more a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with a + quantifier" ;
+ *       mf:action
+ *           [ qt:query  <regex-quantifier-one-or-more.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-quantifier-one-or-more.srx> .
+ */
+
+describe('We should respect the regex-quantifier-one-or-more spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"ab+c"' = false
+      '${s2}' '"ab+c"' = true
+      '${s3}' '"ab+c"' = true
+      '${s4}' '"ab+c"' = true
+      '${s5}' '"ab+c"' = false
+      '${s6}' '"ab+c"' = false
+      '${s7}' '"ab+c"' = false
+      '${s8}' '"ab+c"' = false
+      '${s9}' '"ab+c"' = false
+      '${s10}' '"ab+c"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-quantifier-one-or-more.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *   <head>
+ *     <variable name="val"/>
+ *   </head>
+ *   <results>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>abc</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>abbc</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *         <literal>abbbc</literal>
+ *       </binding>
+ *     </result>
+ *   </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-quantifier-optional-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-quantifier-optional-spec-test.ts
@@ -1,0 +1,76 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-quantifier-optional.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "ab?c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-data-quantifier-optional a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with an ? quantifier" ;
+ *       mf:action
+ *           [ qt:query  <regex-quantifier-optional.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-quantifier-optional.srx> .
+ */
+
+describe('We should respect the regex-data-quantifier-optional spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"ab?c"' = true
+      '${s2}' '"ab?c"' = true
+      '${s3}' '"ab?c"' = false
+      '${s4}' '"ab?c"' = false
+      '${s5}' '"ab?c"' = false
+      '${s6}' '"ab?c"' = false
+      '${s7}' '"ab?c"' = false
+      '${s8}' '"ab?c"' = false
+      '${s9}' '"ab?c"' = false
+      '${s10}' '"ab?c"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-quantifier-optional.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *   <head>
+ *     <variable name="val"/>
+ *   </head>
+ *   <results>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>ac</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>abc</literal>
+ *       </binding>
+ *     </result>
+ *   </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-quantifier-zero-or-more-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-quantifier-zero-or-more-spec-test.ts
@@ -1,0 +1,86 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-quantifier-zero-or-more.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "ab*c")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-quantifier-zero-or-more a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with an * quantifier" ;
+ *       mf:action
+ *           [ qt:query  <regex-quantifier-zero-or-more.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-quantifier-zero-or-more.srx> .
+ */
+
+describe('We should respect the regex-quantifier-zero-or-more spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"ab*c"' = true
+      '${s2}' '"ab*c"' = true
+      '${s3}' '"ab*c"' = true
+      '${s4}' '"ab*c"' = true
+      '${s5}' '"ab*c"' = false
+      '${s6}' '"ab*c"' = false
+      '${s7}' '"ab*c"' = false
+      '${s8}' '"ab*c"' = false
+      '${s9}' '"ab*c"' = false
+      '${s10}' '"ab*c"' = false
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-quantifier-zero-or-more.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *   <head>
+ *     <variable name="val"/>
+ *   </head>
+ *   <results>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>ac</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>abc</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *           <literal>abbc</literal>
+ *       </binding>
+ *     </result>
+ *     <result>
+ *       <binding name="val">
+ *         <literal>abbbc</literal>
+ *       </binding>
+ *     </result>
+ *   </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-start-end-multiline-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-start-end-multiline-spec-test.ts
@@ -1,0 +1,78 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-start-end-multiline.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "^b$", "m")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-start-end-multiline a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with ^ and $ and m option" ;
+ *       mf:action
+ *           [ qt:query  <regex-start-end-multiline.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-start-end-multiline.srx> .
+ */
+
+describe('We should respect the regex-start-end-multiline spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"^b$"' '"m"' = false
+      '${s2}' '"^b$"' '"m"' = false
+      '${s3}' '"^b$"' '"m"' = false
+      '${s4}' '"^b$"' '"m"' = false
+      '${s5}' '"^b$"' '"m"' = false
+      '${s6}' '"^b$"' '"m"' = true
+      '${s7}' '"^b$"' '"m"' = false
+      '${s8}' '"^b$"' '"m"' = false
+      '${s9}' '"^b$"' '"m"' = false
+      '${s10}' '"^b$"' '"m"' = true
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-start-end-multiline.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>b</literal>
+ *            </binding>
+ *        </result>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>a
+ * b
+ * c</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-regex/test/regex-start-end-spec-test.ts
+++ b/packages/actor-function-factory-term-regex/test/regex-start-end-spec-test.ts
@@ -1,0 +1,71 @@
+import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
+import * as Data from '@comunica/utils-expression-evaluator/test/spec/_data';
+import { bool } from '@comunica/utils-expression-evaluator/test/util/Aliases';
+import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
+import { ActorFunctionFactoryTermRegex } from '../lib';
+
+/**
+ * REQUEST: regex-start-end.rq
+ *
+ * PREFIX  rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+ * PREFIX  ex: <http://example.com/#>
+ *
+ * SELECT ?val
+ * WHERE {
+ *    ex:foo rdf:value ?val .
+ *    FILTER regex(?val, "^b$")
+ * }
+ */
+
+/**
+ * Manifest Entry
+ * :regex-start-end a mf:QueryEvaluationTest ;
+ *       mf:name    "REGEX with ^ and $" ;
+ *       mf:action
+ *           [ qt:query  <regex-start-end.rq> ;
+ *             qt:data   <regex-data-quantifiers.ttl> ] ;
+ *       mf:result  <regex-start-end.srx> .
+ */
+
+describe('We should respect the regex-start-end spec', () => {
+  const { s1, s2, s3, s4, s5, s6, s7, s8, s9, s10 } = Data.dataRegexQuantifiers();
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermRegex(args),
+    ],
+    arity: 'vary',
+    notation: Notation.Function,
+    operation: 'regex',
+    aliases: bool,
+    testTable: `
+      '${s1}' '"^b$"' = false
+      '${s2}' '"^b$"' = false
+      '${s3}' '"^b$"' = false
+      '${s4}' '"^b$"' = false
+      '${s5}' '"^b$"' = false
+      '${s6}' '"^b$"' = false
+      '${s7}' '"^b$"' = false
+      '${s8}' '"^b$"' = false
+      '${s9}' '"^b$"' = false
+      '${s10}' '"^b$"' = true
+    `,
+  });
+});
+
+/**
+ * RESULTS: regex-start-end.srx
+ *
+ * <?xml version="1.0"?>
+ * <sparql>
+ *    <head>
+ *        <variable name="val"/>
+ *    </head>
+ *    <results>
+ *        <result>
+ *            <binding name="val">
+ *                <literal>b</literal>
+ *            </binding>
+ *        </result>
+ *    </results>
+ * </sparql>
+ */

--- a/packages/actor-function-factory-term-replace/README.md
+++ b/packages/actor-function-factory-term-replace/README.md
@@ -11,7 +11,7 @@ The `x` and `q` flag not present in the JS engine are implemented by preprocessi
 following the implementation provided by [actor-function-factory-term-regex](https://github.com/comunica/comunica/tree/master/packages/actor-function-factory-term-regex).
 As a result of using the JS regex engine, the bundle size of this package is small,
 but some non-spec compliant edge cases are present.
-Examples are the skipped tests in [op.replace-test.ts](https://github.com/comunica/comunica/blob/74beef86b11059fb192bf67274c22ee370ba59c8/packages/actor-function-factory-term-replace/test/op.replace-test.ts).
+Examples are the skipped tests in [op.replace-test.ts](https://github.com/comunica/comunica/blob/master/packages/actor-function-factory-term-replace/test/op.replace-test.ts).
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).

--- a/packages/actor-function-factory-term-replace/README.md
+++ b/packages/actor-function-factory-term-replace/README.md
@@ -11,7 +11,7 @@ The `x` and `q` flag not present in the JS engine are implemented by preprocessi
 following the implementation provided by [actor-function-factory-term-regex](https://github.com/comunica/comunica/tree/master/packages/actor-function-factory-term-regex).
 As a result of using the JS regex engine, the bundle size of this package is small,
 but some non-spec compliant edge cases are present.
-Examples are the skipped tests in [op.regex-test.ts](https://github.com/comunica/comunica/blob/master/packages/actor-function-factory-term-regex/test/op.regex-test.ts).
+Examples are the skipped tests in [op.replace-test.ts](https://github.com/comunica/comunica/blob/74beef86b11059fb192bf67274c22ee370ba59c8/packages/actor-function-factory-term-replace/test/op.replace-test.ts).
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).

--- a/packages/actor-function-factory-term-replace/README.md
+++ b/packages/actor-function-factory-term-replace/README.md
@@ -5,6 +5,13 @@
 A [function factory](https://github.com/comunica/comunica/tree/master/packages/bus-function-factory) actor
 that constructs a [term function](https://github.com/comunica/comunica/tree/master/packages/bus-function-factory/lib/ActorFunctionFactory.ts)
 capable of evaluating the [Replace](https://www.w3.org/TR/sparql11-query/#func-replace) function.
+The regex evaluation uses the JavaScript regex engine in 'unicode-mode'
+thereby eliminating [Annex B](https://262.ecma-international.org/6.0/#sec-regular-expressions-patterns) behavior.
+The `x` and `q` flag not present in the JS engine are implemented by preprocessing of the pattern,
+following the implementation provided by [actor-function-factory-term-regex](https://github.com/comunica/comunica/tree/master/packages/actor-function-factory-term-regex).
+As a result of using the JS regex engine, the bundle size of this package is small,
+but some non-spec compliant edge cases are present.
+Examples are the skipped tests in [op.regex-test.ts](https://github.com/comunica/comunica/blob/master/packages/actor-function-factory-term-regex/test/op.regex-test.ts).
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).

--- a/packages/actor-function-factory-term-replace/lib/TermFunctionReplace.ts
+++ b/packages/actor-function-factory-term-replace/lib/TermFunctionReplace.ts
@@ -1,3 +1,4 @@
+import { TermFunctionRegex } from '@comunica/actor-function-factory-term-regex';
 import { TermFunctionBase } from '@comunica/bus-function-factory';
 import type {
   StringLiteral,
@@ -55,14 +56,17 @@ export class TermFunctionReplace extends TermFunctionBase {
     });
   }
 
-  // TODO: Fix flags
   // https://www.w3.org/TR/xpath-functions/#func-replace
-  private static replace(arg: string, pattern: string, replacement: string, flags?: string): string {
-    let reg = new RegExp(pattern, flags);
-    if (!reg.global) {
-      const flags_ = flags ?? '';
-      reg = new RegExp(pattern, `${flags_}g`);
+  private static replace(arg: string, pattern: string, replacement: string, flags = ''): string {
+    flags = TermFunctionRegex.cleanFlags(flags);
+    if (flags.includes('x')) {
+      pattern = TermFunctionRegex.flagX(pattern);
     }
-    return arg.replace(reg, replacement);
+    if (flags.includes('q')) {
+      pattern = TermFunctionRegex.flagQ(pattern);
+    } else {
+      replacement = replacement.replaceAll('$0', () => '$&');
+    }
+    return arg.replaceAll(new RegExp(pattern, `${flags.replaceAll(/[qx]/gu, '')}g`), replacement);
   }
 }

--- a/packages/actor-function-factory-term-replace/lib/TermFunctionReplace.ts
+++ b/packages/actor-function-factory-term-replace/lib/TermFunctionReplace.ts
@@ -67,6 +67,7 @@ export class TermFunctionReplace extends TermFunctionBase {
     } else {
       replacement = replacement.replaceAll('$0', () => '$&');
     }
-    return arg.replaceAll(new RegExp(pattern, `${flags.replaceAll(/[qx]/gu, '')}g`), replacement);
+    flags = `${flags.replaceAll(/[qx]/gu, '')}g`;
+    return arg.replaceAll(new RegExp(pattern, flags), replacement);
   }
 }

--- a/packages/actor-function-factory-term-replace/package.json
+++ b/packages/actor-function-factory-term-replace/package.json
@@ -37,8 +37,8 @@
     "build:components": "componentsjs-generator"
   },
   "dependencies": {
-    "@comunica/bus-function-factory": "^4.0.2",
     "@comunica/actor-function-factory-term-regex": "^4.0.2",
+    "@comunica/bus-function-factory": "^4.0.2",
     "@comunica/utils-expression-evaluator": "^4.0.2"
   }
 }

--- a/packages/actor-function-factory-term-replace/package.json
+++ b/packages/actor-function-factory-term-replace/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@comunica/bus-function-factory": "^4.0.2",
+    "@comunica/actor-function-factory-term-regex": "^4.0.2",
     "@comunica/utils-expression-evaluator": "^4.0.2"
   }
 }

--- a/packages/actor-function-factory-term-replace/test/op.replace-test.ts
+++ b/packages/actor-function-factory-term-replace/test/op.replace-test.ts
@@ -2,6 +2,26 @@ import { runFuncTestTable } from '@comunica/bus-function-factory/test/util';
 import { Notation } from '@comunica/utils-expression-evaluator/test/util/TestTable';
 import { ActorFunctionFactoryTermReplace } from '../lib';
 
+// Eventually, it might be nice to have a spec compliant regex engine
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('unfortunately our engine is not spec compliant', () => {
+  runFuncTestTable({
+    registeredActors: [
+      args => new ActorFunctionFactoryTermReplace(args),
+    ],
+    arity: 'vary',
+    operation: 'replace',
+    notation: Notation.Function,
+    testArray: [
+      // According to note 3 of https://www.w3.org/TR/xpath-functions/#func-replace
+      //  this should result in the empty string.
+      [ '"abc"', '"(a)(b)c"', '"$3"', '""' ],
+      // Tests note 4
+      [ '"abc"', '"(a)(b)c"', '"$83"', '""' ],
+    ],
+  });
+});
+
 describe('evaluation of \'replace\' like', () => {
   runFuncTestTable({
     registeredActors: [
@@ -10,12 +30,28 @@ describe('evaluation of \'replace\' like', () => {
     arity: 'vary',
     operation: 'replace',
     notation: Notation.Function,
+    // Parts from: https://www.w3.org/TR/xpath-functions/#flags
     testTable: `
       "baaab" "a+" "c" = "bcb"
       "bAAAb" "a+" "c" = "bAAAb"
       "bAAAb" "a+" "c" "i" = "bcb"
       "baaab"@en "a+" "c" = "bcb"@en
       "bAAAb"@en "a+" "c" "i" = "bcb"@en
+      
+      "apple" "apple" '"$0 $0"' = '"apple apple"'
+      "abcde" "(a)(b)(c)?(d)(e)" '"$1$2$3$4$5"' = '"abcde"'
+      "abde" "(a)(b)(c)?(d)(e)" '"$1$2$3$4$5"' = '"abde"'
+      '"abc"' '"(a)(b)c"' '"$13"' = '"a3"'
+      "abcdefghijklmno" "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)" '"$1$2$3$4$5$6$7$8$9$10$11$12$13$14$15"' = '"abcdefghijklmno"'  
+
+      '"a\\\\b\\\\c"' '"\\\\"' '"\\\\\\\\"'  '"q"' = '"a\\\\b\\\\c"'
+      '"a/b/c"' '"/"' '"$"' '"q"' = '"a$b$c"'
+      '"(a/b)/c"' '"/"' '"$1"' '"q"' = '"(a$1b)$1c"'
+      '"(a/b)/c"' '"/"' '"$0"' '"q"' = '"(a$0b)$0c"'
+      '"helloworld"' '"hello world"' '"apple'" '"x"' = '"apple"'
+      '"helloworld"' '"hello[ ]world"' '"apple"' '"x"' = '"helloworld"'
+      '"hello world"' '"hello\\\\ sworld"' '"apple"' '"x"' = '"apple"'
+      '"hello world"' '"hello world"' '"apple"' '"x"' = '"hello world"'
       `,
   });
 });

--- a/packages/utils-expression-evaluator/test/spec/_data.ts
+++ b/packages/utils-expression-evaluator/test/spec/_data.ts
@@ -165,6 +165,29 @@ export function dataBuiltin3() {
   };
 }
 
+// Regex data Quantifiers ----------------------------------------------------------------------
+// @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+// @prefix ex: <http://example.com/#> .
+//
+// ex:foo rdf:value "ac" , "abc" , "abbc" , "abbbc" , "a\nc", "a\nb\nc" , "a.c" , "ABC" , "a?+*.{}()c" , "b" .
+
+// https://github.com/w3c/rdf-tests/sparql/sparql10/regex/regex-data-quantifiers.ttl
+
+export function dataRegexQuantifiers() {
+  return {
+    s1: '"ac"',
+    s2: '"abc"',
+    s3: '"abbc"',
+    s4: '"abbbc"',
+    s5: '"a\\nc"',
+    s6: '"a\\nb\\nc"',
+    s7: '"a.c"',
+    s8: '"ABC"',
+    s9: '"a?+*.{}()c"',
+    s10: '"b"',
+  };
+}
+
 // Hash unicode ----------------------------------------------------------------
 // @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 // @prefix : <http://example.org/> .

--- a/packages/utils-expression-evaluator/test/spec/_data.ts
+++ b/packages/utils-expression-evaluator/test/spec/_data.ts
@@ -169,7 +169,7 @@ export function dataBuiltin3() {
 // @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 // @prefix ex: <http://example.com/#> .
 //
-// ex:foo rdf:value "ac" , "abc" , "abbc" , "abbbc" , "a\nc", "a\nb\nc" , "a.c" , "ABC" , "a?+*.{}()c" , "b" .
+// ex:foo rdf:value "ac" , "abc" , "abbc" , "abbbc" , "a\nc", "a\nb\nc" , "a.c" , "ABC" , "a?+*.{}()[]c" , "b" .
 
 // https://github.com/w3c/rdf-tests/sparql/sparql10/regex/regex-data-quantifiers.ttl
 
@@ -183,7 +183,7 @@ export function dataRegexQuantifiers() {
     s6: '"a\\nb\\nc"',
     s7: '"a.c"',
     s8: '"ABC"',
-    s9: '"a?+*.{}()c"',
+    s9: '"a?+*.{}()[]c"',
     s10: '"b"',
   };
 }


### PR DESCRIPTION
A [new PR on the rdf-tests repo](https://github.com/w3c/rdf-tests/pull/155) aims to add tests for the regex function.
This PR aims to add those tests to the Comunica suite. I expect some tests will need to be skipped, since our implementation of the regex function just calls the JavaScript regex function. Seen here: https://github.com/comunica/comunica/blob/master/packages/actor-function-factory-term-regex/lib/TermFunctionRegex.ts#L31-L32

Status:
* Most tests pass,
* Tests with the q flag fail since JS regex does not know that flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced multiple test files to validate various regex functionalities, including case insensitivity, character class expressions, and quantifiers.
  - Added tests for regex operations with whitespace handling, multiline contexts, and specific quantifier behaviors.
  - Expanded dataset for testing regex quantifiers with new string properties.

- **Bug Fixes**
  - Implemented comprehensive testing for regex patterns to ensure expected behavior across different scenarios.

- **Documentation**
  - Each test file includes manifest entries detailing the queries, expected results, and data used for validation.
  - Updated README files for both the regex and replace packages to clarify regex evaluation capabilities and handling of specific flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->