### PR TITLE
fix floating point error for very low cardinalities

### DIFF
--- a/packages/bus-rdf-join/lib/ActorRdfJoin.ts
+++ b/packages/bus-rdf-join/lib/ActorRdfJoin.ts
@@ -251,7 +251,11 @@ TS
             value: acc.value * (optional ? Math.max(1, cardinalityThis.value) : cardinalityThis.value),
           };
         }, { type: 'exact', value: 1 });
-      cardinalityJoined.value *= (await this.mediatorJoinSelectivity.mediate({ entries, context })).selectivity;
+      if (cardinalityJoined.value > 1e-9) {
+        cardinalityJoined.value *= (await this.mediatorJoinSelectivity.mediate({ entries, context })).selectivity;
+      } else {
+        cardinalityJoined.value = 1e-9;
+      }
     }
 
     return {

--- a/packages/bus-rdf-join/lib/ActorRdfJoin.ts
+++ b/packages/bus-rdf-join/lib/ActorRdfJoin.ts
@@ -256,7 +256,7 @@ TS
           };
         }, { type: 'exact', value: 1 });
       // The cardinality should only be zero if one of the entries has zero cardinality, not due to float overflow
-      if (!hasZeroCardinality) {
+      if (!hasZeroCardinality || optional) {
         cardinalityJoined.value *= (await this.mediatorJoinSelectivity.mediate({ entries, context })).selectivity;
         if (cardinalityJoined.value === 0) {
           cardinalityJoined.value = Number.MIN_VALUE;

--- a/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
+++ b/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
@@ -880,6 +880,18 @@ IActorRdfJoinSelectivityOutput
           variables: [],
         },
       ], action.context, {})).cardinality.value).toBe(0);
+      expect((await instance.constructResultMetadata([], [
+        {
+          state: new MetadataValidationState(),
+          cardinality: { type: 'estimate', value: Number.MIN_VALUE },
+          variables: [],
+        },
+        {
+          state: new MetadataValidationState(),
+          cardinality: { type: 'estimate', value: 0 },
+          variables: [],
+        },
+      ], action.context, {}, true)).cardinality.value).toBe(1 * 0.8);
     });
 
     it('should join variables', async() => {

--- a/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
+++ b/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
@@ -855,23 +855,31 @@ IActorRdfJoinSelectivityOutput
       });
     });
 
-    it('should not decrease the cardinality too much', async() => {
-      await expect(instance.constructResultMetadata([], [
+    it('should only set the cardinality to 0 if an entry\'s cardinality is 0', async() => {
+      expect((await instance.constructResultMetadata([], [
         {
           state: new MetadataValidationState(),
-          cardinality: { type: 'estimate', value: 1e-9 },
+          cardinality: { type: 'estimate', value: Number.MIN_VALUE },
           variables: [],
         },
         {
           state: new MetadataValidationState(),
-          cardinality: { type: 'estimate', value: 1e-9 },
+          cardinality: { type: 'estimate', value: Number.MIN_VALUE },
           variables: [],
         },
-      ], action.context, {})).resolves.toEqual({
-        state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 1e-9 },
-        variables: [],
-      });
+      ], action.context, {})).cardinality.value).not.toBe(0);
+      expect((await instance.constructResultMetadata([], [
+        {
+          state: new MetadataValidationState(),
+          cardinality: { type: 'estimate', value: Number.MIN_VALUE },
+          variables: [],
+        },
+        {
+          state: new MetadataValidationState(),
+          cardinality: { type: 'estimate', value: 0 },
+          variables: [],
+        },
+      ], action.context, {})).cardinality.value).toBe(0);
     });
 
     it('should join variables', async() => {

--- a/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
+++ b/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
@@ -855,6 +855,25 @@ IActorRdfJoinSelectivityOutput
       });
     });
 
+    it('should not decrease the cardinality too much', async() => {
+      await expect(instance.constructResultMetadata([], [
+        {
+          state: new MetadataValidationState(),
+          cardinality: { type: 'estimate', value: 1e-9 },
+          variables: [],
+        },
+        {
+          state: new MetadataValidationState(),
+          cardinality: { type: 'estimate', value: 1e-9 },
+          variables: [],
+        },
+      ], action.context, {})).resolves.toEqual({
+        state: expect.any(MetadataValidationState),
+        cardinality: { type: 'estimate', value: 1e-9 },
+        variables: [],
+      });
+    });
+
     it('should join variables', async() => {
       await expect(instance.constructResultMetadata([], [
         {


### PR DESCRIPTION
I ran into an issue where comunica stopped producing results, I figured out that when joining low cardinalities the cardinality can keep decreasing until there is a floating point error and the cardinality is set to 0. This causes comunica to choose the join-multi-none actor and close the bindings streams. In reality, the cardinality was still one, but comunica didn't produce any results.

This PR is a possible fix, and I added a test for it as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced cardinality handling to prevent zero values in results, improving accuracy.
  
- **Bug Fixes**
	- Addressed potential float overflow issues related to cardinality calculations.

- **Tests**
	- Added new test cases to validate cardinality behavior under low value conditions, ensuring robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->