### PR TITLE
Use VALUES to implement Initialbindings within a BIND operation

### DIFF
--- a/engines/query-sparql-rdfjs-lite/webpack.config.ts
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.ts
@@ -3,8 +3,8 @@ import { createConfig } from '../../webpack.config';
 const liteConfig = createConfig(__dirname);
 
 if (typeof liteConfig.performance === 'object') {
-  liteConfig.performance.maxAssetSize = 900_000;
-  liteConfig.performance.maxEntrypointSize = 900_000;
+  liteConfig.performance.maxAssetSize = 900_300;
+  liteConfig.performance.maxEntrypointSize = 900_300;
 }
 
 export default liteConfig;

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -894,6 +894,107 @@ SELECT ?obsId {
         expect(bindings2).toMatchObject(expectedResult);
       });
     });
+
+    describe('initialbindings', () => {
+      it('should handle bindings used in BIND (=extend) operator correctly', async() => {
+        const bindingsFactory = new BindingsFactory();
+        const initialBindings = bindingsFactory.bindings([
+          [DF.variable('this'), DF.namedNode('http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#InvalidResource')]
+        ]);
+        
+        
+        const context: QueryStringContext = {
+          sources: [
+            {
+              type: 'serialized',
+              value: `
+              @prefix dash: <http://datashapes.org/dash#> .
+              @prefix ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#> .
+              @prefix mf: <http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#> .
+              @prefix owl: <http://www.w3.org/2002/07/owl#> .
+              @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+              @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+              @prefix sh: <http://www.w3.org/ns/shacl#> .
+              @prefix sht: <http://www.w3.org/ns/shacl-test#> .
+              @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+              
+              ex:
+              \tsh:declare [
+              \t\tsh:prefix "ex" ;
+              \t\tsh:namespace "http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#"^^xsd:anyURI ;
+              \t] .
+              
+              ex:TestShape
+                rdf:type sh:NodeShape ;
+                rdfs:label "Test shape" ;
+                sh:sparql ex:TestShape-sparql ;
+                sh:targetNode ex:InvalidResource ;
+              .
+              ex:TestShape-sparql
+                sh:prefixes ex: ;
+                sh:select """
+                \tSELECT $this
+              \tWHERE {
+              \t\tBIND ($this AS ?that) .
+              \t\tFILTER (?that = ex:InvalidResource) .
+              \t}""" ;
+              .
+              ex:ValidResource1
+                rdf:type rdfs:Resource ;
+              .
+              <>
+                rdf:type mf:Manifest ;
+                mf:entries (
+                    <pre-binding-004>
+                  ) ;
+              .
+              <pre-binding-004>
+                rdf:type sht:Validate ;
+                rdfs:label "Test of pre-binding in BIND expressions" ;
+                mf:action [
+                    sht:dataGraph <> ;
+                    sht:shapesGraph <> ;
+                  ] ;
+                mf:result [
+                    rdf:type sh:ValidationReport ;
+                    sh:conforms "false"^^xsd:boolean ;
+                    sh:result [
+                        rdf:type sh:ValidationResult ;
+                        sh:focusNode ex:InvalidResource ;
+                        sh:resultSeverity sh:Violation ;
+                        sh:sourceConstraint ex:TestShape-sparql ;
+                        sh:sourceConstraintComponent sh:SPARQLConstraintComponent ;
+                        sh:sourceShape ex:TestShape ;
+                        sh:value ex:InvalidResource ;
+                      ] ;
+                  ] ;
+                mf:status sht:approved ;
+              .`,
+              mediaType: 'text/turtle',
+            },
+          ],
+          initialBindings: initialBindings,
+        };
+
+        const expectedResult = [
+          [
+            [ DF.variable('this'), DF.namedNode('http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#InvalidResource') ], //TODO example.org
+          ]
+        ];
+
+        const bindings = (await arrayifyStream(await engine.queryBindings(`
+          PREFIX ex: <http://datashapes.org/sh/tests/sparql/pre-binding/pre-binding-004.test#>
+            
+          SELECT $this
+          WHERE {
+            BIND ($this AS ?that) .
+            FILTER (?that = ex:InvalidResource) .
+          }
+        `, context))).map(binding => [ ...binding ].sort(([ var1, _c1 ], [ var2, _c2 ]) => var1.value.localeCompare(var2.value)));
+
+        expect(bindings).toMatchObject(expectedResult);
+      });
+    });
   });
 
   // We skip these tests in browsers due to CORS issues

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -1043,6 +1043,40 @@ SELECT ?obsId {
         await expect(bindings).toEqualBindingsStream([]);
       });
 
+      it('should consider initialbindings in the extend operation', async() => {
+        const initialBindings = BF.bindings([
+          [ DF.variable('initialBindingsVariable'), DF.namedNode('http://example.org/test#InitialBindingsValue') ],
+        ]);
+
+        const context: QueryStringContext = {
+          sources: [
+            {
+              type: 'serialized',
+              value: ``,
+              mediaType: 'text/turtle',
+            },
+          ],
+          initialBindings,
+        };
+
+        const bindings = (await engine.queryBindings(`
+        PREFIX ex: <http://example.org/test#>
+        
+        SELECT $initialBindingsVariable
+        \tWHERE {
+        \t\tBIND ($initialBindingsVariable AS ?b) .
+        \t\tFILTER (?b = ex:InitialBindingsValue) .
+        \t}`, context));
+
+        const expectedResult: Bindings[] = [
+          BF.bindings([
+            [ DF.variable('initialBindingsVariable'), DF.namedNode('http://example.org/test#InitialBindingsValue') ],
+          ]),
+        ];
+
+        await expect(bindings).toEqualBindingsStream(expectedResult);
+      });
+
       it('should not overwrite initialbindings', async() => {
         const context: QueryStringContext = {
           sources: [

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -923,13 +923,13 @@ SELECT ?obsId {
           initialBindings,
         };
 
-        const expectedResult = [
-          [
+        const expectedResult: Bindings[] = [
+          BF.bindings([
             [ DF.variable('a'), DF.namedNode('http://example.org/test#testBinding') ],
-          ],
+          ]),
         ];
 
-        const bindings = (await arrayifyStream(await engine.queryBindings(`
+        const bindings = (await engine.queryBindings(`
         PREFIX ex: <http://example.org/test#>
         
         SELECT $a WHERE {
@@ -939,9 +939,9 @@ SELECT ?obsId {
           $a ex:property "testProperty" .
           FILTER (bound($a)) .
         }
-          `, context))).map(binding => [ ...binding ].sort(([ var1, _c1 ], [ var2, _c2 ]) => var1.value.localeCompare(var2.value)));
+          `, context));
 
-        expect(bindings).toMatchObject(expectedResult);
+        await expect(bindings).toEqualBindingsStream(expectedResult);
       });
 
       it('should consider the initialbindings in the filter function', async() => {
@@ -956,13 +956,13 @@ SELECT ?obsId {
           initialBindings,
         };
 
-        const expectedResult = [
-          [
+        const expectedResult: Bindings[] = [
+          BF.bindings([
             [ DF.variable('a'), DF.namedNode('http://example.org/test#testBinding') ],
-          ],
+          ]),
         ];
 
-        const bindings = (await arrayifyStream(await engine.queryBindings(`
+        const bindings = (await engine.queryBindings(`
         PREFIX ex: <http://example.org/test#>
       
         SELECT $a WHERE {
@@ -972,9 +972,9 @@ SELECT ?obsId {
             }
           }
         }
-        `, context))).map(binding => [ ...binding ].sort(([ var1, _c1 ], [ var2, _c2 ]) => var1.value.localeCompare(var2.value)));
+        `, context));
 
-        expect(bindings).toMatchObject(expectedResult);
+        await expect(bindings).toEqualBindingsStream(expectedResult);
       });
 
       it('should consider the initialbindings in the filter function 2', async() => {
@@ -989,13 +989,13 @@ SELECT ?obsId {
           initialBindings,
         };
 
-        const expectedResult = [
-          [
+        const expectedResult: Bindings[] = [
+          BF.bindings([
             [ DF.variable('a'), DF.namedNode('http://example.org/test#testBinding') ],
-          ],
+          ]),
         ];
 
-        const bindings = (await arrayifyStream(await engine.queryBindings(`
+        const bindings = (await engine.queryBindings(`
         PREFIX ex: <http://example.org/test#>
       
         SELECT $a WHERE {
@@ -1005,9 +1005,9 @@ SELECT ?obsId {
             }
           }
         }
-        `, context))).map(binding => [ ...binding ].sort(([ var1, _c1 ], [ var2, _c2 ]) => var1.value.localeCompare(var2.value)));
+        `, context));
 
-        expect(bindings).toMatchObject(expectedResult);
+        await expect(bindings).toEqualBindingsStream(expectedResult);
       });
 
       it('should consider initialbindings which are not projected', async() => {
@@ -1034,13 +1034,13 @@ SELECT ?obsId {
           initialBindings,
         };
 
-        const bindings = (await arrayifyStream(await engine.queryBindings(`
+        const bindings = (await engine.queryBindings(`
         SELECT $subject ?value WHERE {
           $subject $predicate ?value .
           FILTER (!isLiteral(?value) || !langMatches(lang(?value), "de"))
-        }`, context))).map(binding => [ ...binding ].sort(([ var1, _c1 ], [ var2, _c2 ]) => var1.value.localeCompare(var2.value)));
+        }`, context));
 
-        expect(bindings).toMatchObject([]);
+        await expect(bindings).toEqualBindingsStream([]);
       });
 
       it('should not overwrite initialbindings', async() => {

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -895,7 +895,7 @@ SELECT ?obsId {
       });
     });
 
-    describe('initialbindings', () => {
+    describe('initialBindings', () => {
       let initialBindings: Bindings;
       let sourcesValue1: string;
 

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -107,10 +107,20 @@ export function materializeOperation(
         }
       }
       const values: Algebra.Operation[] =
-      createValuesFromBindings(factory, <Bindings> options.originalBindings, op.variables);
+        createValuesFromBindings(factory, <Bindings> options.originalBindings, op.variables);
+      
+      let recursionResult: Algebra.Operation = materializeOperation(
+        op.input,
+        bindings,
+        bindingsFactory,
+        options,
+      );
+      if (values.length > 0) {
+        recursionResult = factory.createJoin([ ...values, recursionResult ]);
+      }
       return {
         recurse: true,
-        result: factory.createExtend(factory.createJoin([ ...values, op.input ]), op.variable, op.expression),
+        result: factory.createExtend(recursionResult, op.variable, op.expression),
       };
     },
     group(op: Algebra.Group, factory: Factory) {

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -4,7 +4,8 @@ import type * as RDF from '@rdfjs/types';
 import type { Variable } from 'rdf-data-factory';
 import { termToString } from 'rdf-string';
 import { mapTermsNested, someTermsNested } from 'rdf-terms';
-import { Algebra, Factory } from 'sparqlalgebrajs';
+import { Algebra } from 'sparqlalgebrajs';
+import type { Factory } from 'sparqlalgebrajs';
 import { Util } from 'sparqlalgebrajs';
 
 /**
@@ -125,8 +126,15 @@ export function materializeOperation(
         recursionResult = factory.createJoin([ ...values, recursionResult ]);
       }
       return {
-        recurse: true,
-        result: factory.createExtend(recursionResult, op.variable, op.expression),
+        recurse: false,
+        result: factory.createExtend(recursionResult,
+          op.variable,
+          <Algebra.Expression> materializeOperation(
+            op.expression,
+            bindings,
+            bindingsFactory,
+            options
+          )),
       };
     },
     group(op: Algebra.Group, factory: Factory) {

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -92,7 +92,7 @@ export function materializeOperation(
         ), { metadata: op.metadata }),
       };
     },
-    extend(op: Algebra.Extend) {
+    extend(op: Algebra.Extend, factory: Factory) {
       // Materialize an extend operation.
       // If strictTargetVariables is true, we throw if the extension target variable is attempted to be bound.
       // Otherwise, we remove the extend operation.
@@ -106,9 +106,11 @@ export function materializeOperation(
           };
         }
       }
+      const values: Algebra.Operation[] =
+      createValuesFromBindings(factory, <Bindings> options.originalBindings, op.variables);
       return {
         recurse: true,
-        result: op,
+        result: factory.createExtend(factory.createJoin([ ...values, op.input ]), op.variable, op.expression),
       };
     },
     group(op: Algebra.Group, factory: Factory) {

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -106,8 +106,6 @@ export function materializeOperation(
           };
         }
       }
-      const values: Algebra.Operation[] =
-        createValuesFromBindings(factory, <Bindings> options.originalBindings, op.variables);
       
       let recursionResult: Algebra.Operation = materializeOperation(
         op.input,
@@ -115,9 +113,13 @@ export function materializeOperation(
         bindingsFactory,
         options,
       );
+      
+      const values: Algebra.Operation[] =
+        createValuesFromBindings(factory, <Bindings> options.originalBindings, Util.inScopeVariables(op));
       if (values.length > 0) {
         recursionResult = factory.createJoin([ ...values, recursionResult ]);
       }
+
       return {
         recurse: true,
         result: factory.createExtend(recursionResult, op.variable, op.expression),

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -4,9 +4,8 @@ import type * as RDF from '@rdfjs/types';
 import type { Variable } from 'rdf-data-factory';
 import { termToString } from 'rdf-string';
 import { mapTermsNested, someTermsNested } from 'rdf-terms';
-import { Algebra } from 'sparqlalgebrajs';
 import type { Factory } from 'sparqlalgebrajs';
-import { Util } from 'sparqlalgebrajs';
+import { Algebra, Util } from 'sparqlalgebrajs';
 
 /**
  * Materialize a term with the given binding.
@@ -114,11 +113,11 @@ export function materializeOperation(
         bindingsFactory,
         options,
       );
-      
+
       // Join op.input with a values clause containing the variables that are in InitialBindings and
       // are used in the current extend operation.
-      let inScopeVariables = [op.variable];
-      if (op.expression.expressionType == Algebra.expressionTypes.TERM && op.expression.term.termType == 'Variable') {
+      const inScopeVariables = [ op.variable ];
+      if (op.expression.expressionType === Algebra.expressionTypes.TERM && op.expression.term.termType === 'Variable') {
         inScopeVariables.push(op.expression.term);
       }
       const values: Algebra.Operation[] =
@@ -128,15 +127,8 @@ export function materializeOperation(
       }
       return {
         recurse: false,
-        result: factory.createExtend(recursionResult,
-          op.variable,
-          <Algebra.Expression> materializeOperation(
-            op.expression,
-            bindings,
-            algebraFactory,
-            bindingsFactory,
-            options
-          )),
+        result: factory.createExtend(recursionResult, op.variable, <Algebra.Expression>
+          materializeOperation(op.expression, bindings, algebraFactory, bindingsFactory, options)),
       };
     },
     group(op: Algebra.Group, factory: Factory) {

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -110,6 +110,7 @@ export function materializeOperation(
       let recursionResult: Algebra.Operation = materializeOperation(
         op.input,
         bindings,
+        algebraFactory,
         bindingsFactory,
         options,
       );
@@ -132,6 +133,7 @@ export function materializeOperation(
           <Algebra.Expression> materializeOperation(
             op.expression,
             bindings,
+            algebraFactory,
             bindingsFactory,
             options
           )),

--- a/packages/utils-query-operation/test/MaterializeBindings-test.ts
+++ b/packages/utils-query-operation/test/MaterializeBindings-test.ts
@@ -295,10 +295,14 @@ describe('materializeOperation', () => {
       BF,
     ))
       .toEqual(AF.createExtend(
-        AF.createPattern(valueA, termNamedNode, termVariableC, termNamedNode),
+        AF.createJoin([
+          AF.createValues([ termVariableA ], [ valuesBindingsA ]),
+          AF.createPattern(valueA, termNamedNode, termVariableC, termNamedNode),
+        ]),
         termVariableB,
         AF.createTermExpression(valueA),
-      ));
+      )
+    );
   });
 
   it('should error on an extend operation with ' +

--- a/packages/utils-query-operation/test/MaterializeBindings-test.ts
+++ b/packages/utils-query-operation/test/MaterializeBindings-test.ts
@@ -301,8 +301,7 @@ describe('materializeOperation', () => {
         ]),
         termVariableB,
         AF.createTermExpression(valueA),
-      )
-    );
+      ));
   });
 
   it('should error on an extend operation with ' +


### PR DESCRIPTION
In response to #1433 this PR uses a `VALUES` clause to represent variables in `BIND` operations that also appear in initialbindings. It replaces the input of the `BIND` operation with a join of the input and a values clause containing the values from initialbindings. The principle is the same as in the original PR #1385.

This PR currently only takes into account the case where the BIND expression is a variable.

I've added full engine tests from the issue #1433 and from the original issue #1298.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new test suite for validating initial bindings in SPARQL queries.
	- Enhanced handling of various operations (extend, group, project, values) in the materialization process.

- **Bug Fixes**
	- Improved logic for handling variable bindings and transformations, ensuring correct behavior in strict target variable scenarios.

- **Tests**
	- Expanded test coverage for initial bindings and various operations to ensure robustness and accuracy.
	- Updated tests to reflect new logic for extend operations and variable matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->