### PR TITLE
Fix Query Termination for Triple Patterns with Zero Estimated Cardinality

### DIFF
--- a/packages/actor-query-operation-join/lib/ActorQueryOperationJoin.ts
+++ b/packages/actor-query-operation-join/lib/ActorQueryOperationJoin.ts
@@ -44,7 +44,7 @@ export class ActorQueryOperationJoin extends ActorQueryOperationTypedMediated<Al
 
     // Return immediately if one of the join entries has cardinality zero, to avoid actor testing overhead.
     if ((await Promise.all(entries.map(entry => entry.output.metadata())))
-      .some(entry => entry.cardinality.value === 0)) {
+      .some(entry => (entry.cardinality.value === 0 && entry.cardinality.type === 'exact'))) {
       for (const entry of entries) {
         entry.output.bindingsStream.close();
       }


### PR DESCRIPTION
This fix ensures that the query does not terminate when a triple pattern is estimated to have zero cardinality. This issue occurs when the estimation is incorrect or during link traversal, where triple patterns often have an estimated cardinality of zero due to the lack of prior knowledge.

Queries will still terminate as expected when the cardinality estimation is accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved join operation logic to handle edge cases with zero cardinality entries more precisely
	- Enhanced test coverage for join operations with estimated zero cardinality

- **Tests**
	- Added new test case to validate join operation behavior with zero-cardinality entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->