### PR TITLE
Update SPARQL endpoint code to support default-graph-uri

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,7 @@ module.exports = config([
       '**/__mocks__/*.js',
       'packages/actor-dereference-file/**/*.ts',
       'packages/actor-http-native/**/*.ts',
+      'packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts',
       'packages/logger-bunyan/**/*.ts',
       'packages/packager/**/*.ts',
     ],

--- a/packages/actor-context-preprocess-convert-shortcuts/lib/ActorContextPreprocessConvertShortcuts.ts
+++ b/packages/actor-context-preprocess-convert-shortcuts/lib/ActorContextPreprocessConvertShortcuts.ts
@@ -70,7 +70,11 @@ export interface IActorContextPreprocessConvertShortcutsArgs extends IActorConte
    *   "traverse": "@comunica/bus-query-source-identify:traverse",
    *   "invalidateCache": "@comunica/actor-init-query:invalidateCache",
    *   "dataFactory": "@comunica/actor-init-query:dataFactory",
-   *   "distinctConstruct": "@comunica/actor-init-query:distinctConstruct"
+   *   "distinctConstruct": "@comunica/actor-init-query:distinctConstruct",
+   *   "defaultGraphUris": "@comunica/actor-init-query:defaultGraphUris",
+   *   "namedGraphUris": "@comunica/actor-init-query:namedGraphUris",
+   *   "usingGraphUris": "@comunica/actor-init-query:usingGraphUris",
+   *   "usingNamedGraphUris": "@comunica/actor-init-query:usingNamedGraphUris"
    * }}
    */
   contextKeyShortcuts: Record<string, string>;

--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -547,7 +547,7 @@ export class HttpServiceSparqlEndpoint {
     // Create the server with the request handler function, that has to be synchronous
     const server = createServer((request: IncomingMessage, response: ServerResponse) => {
       openResponses.add(response);
-      response.on('close', () => {
+      response.on('end', () => {
         // Inform the primary process that the worker has finished
         process.send!('end');
         // Remove the connection from the tracked open list, and kill the worker if we want fresh workers per query.

--- a/packages/actor-init-query/package.json
+++ b/packages/actor-init-query/package.json
@@ -56,7 +56,7 @@
     "asynciterator": "^3.9.0",
     "negotiate": "^1.0.1",
     "process": "^0.11.10",
-    "rdf-quad": "^1.5.0",
+    "rdf-data-factory": "^1.1.2",
     "readable-stream": "^4.5.2",
     "yargs": "^17.7.2"
   },

--- a/packages/actor-init-query/test/cli/CliArgsHandlerHttp-test.ts
+++ b/packages/actor-init-query/test/cli/CliArgsHandlerHttp-test.ts
@@ -1,0 +1,72 @@
+import type { Argv } from 'yargs';
+import { CliArgsHandlerHttp } from '../../lib/cli/CliArgsHandlerHttp';
+
+describe('CliArgsHandlerHttp', () => {
+  let handler: CliArgsHandlerHttp;
+  let argumentsBuilder: Argv<any>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    handler = new CliArgsHandlerHttp();
+    argumentsBuilder = <any>{
+      usage: jest.fn().mockReturnThis(),
+      example: jest.fn().mockReturnThis(),
+      options: jest.fn().mockReturnThis(),
+      check: jest.fn().mockReturnThis(),
+    };
+  });
+
+  describe('populateYargs', () => {
+    it.each([
+      'port',
+      'workers',
+      'timeout',
+      'update',
+      'invalidateCache',
+      'freshWorker',
+      'contextOverride',
+    ])('adds %s as option to argumentsBuilder', async(option) => {
+      expect(() => handler.populateYargs(argumentsBuilder)).not.toThrow();
+      expect(argumentsBuilder.usage).toHaveBeenCalledTimes(1);
+      expect(argumentsBuilder.example).toHaveBeenCalledTimes(1);
+      expect(argumentsBuilder.options).toHaveBeenCalledTimes(1);
+      expect(argumentsBuilder.options).toHaveBeenCalledWith(expect.objectContaining({ [option]: expect.any(Object) }));
+      expect(argumentsBuilder.check).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts version arg on its own', async() => {
+      let check: (args: Record<string, any>) => void;
+      jest.spyOn(argumentsBuilder, 'check').mockImplementation((checkFn: any): Argv<any> => {
+        check = checkFn;
+        return argumentsBuilder;
+      });
+      expect(() => handler.populateYargs(argumentsBuilder)).not.toThrow();
+      expect(() => check({ version: true })).not.toThrow();
+    });
+
+    it('disallows sources with context', async() => {
+      let check: (args: Record<string, any>) => void;
+      jest.spyOn(argumentsBuilder, 'check').mockImplementation((checkFn: any): Argv<any> => {
+        check = checkFn;
+        return argumentsBuilder;
+      });
+      const errorMessage = 'At least one source must be provided';
+      expect(() => handler.populateYargs(argumentsBuilder)).not.toThrow();
+      expect(() => check({ context: false, sources: []})).toThrow(errorMessage);
+      expect(() => check({ context: false, sources: [ 's' ]})).not.toThrow();
+      expect(() => check({ context: true, sources: []})).not.toThrow();
+      expect(() => check({ context: true, sources: [ 's' ]})).toThrow(errorMessage);
+    });
+  });
+
+  describe('handleArgs', () => {
+    it('does nothing', async() => {
+      const args = {};
+      const context = {};
+      jest.spyOn(handler, 'populateYargs').mockImplementation();
+      await expect(handler.handleArgs(args, context)).resolves.toBeUndefined();
+      expect(args).toEqual({});
+      expect(context).toEqual({});
+    });
+  });
+});

--- a/packages/actor-query-parse-sparql/package.json
+++ b/packages/actor-query-parse-sparql/package.json
@@ -45,6 +45,7 @@
     "@comunica/context-entries": "^4.1.0",
     "@comunica/core": "^4.1.0",
     "@comunica/types": "^4.1.0",
+    "@rdfjs/types": "*",
     "@types/sparqljs": "^3.1.3",
     "sparqlalgebrajs": "^4.3.8",
     "sparqljs": "^3.7.1"

--- a/packages/actor-query-parse-sparql/test/ActorQueryParseSparql-test.ts
+++ b/packages/actor-query-parse-sparql/test/ActorQueryParseSparql-test.ts
@@ -1,9 +1,10 @@
 import { ActorQueryParse } from '@comunica/bus-query-parse';
 import { KeysInitQuery } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
-import type { IActionContext } from '@comunica/types';
+import type { IActionContext, IActionContextKey } from '@comunica/types';
+import type * as RDF from '@rdfjs/types';
 import { DataFactory } from 'rdf-data-factory';
-import { ActorQueryParseSparql } from '..';
+import { ActorQueryParseSparql } from '../lib/ActorQueryParseSparql';
 import '@comunica/utils-jest';
 
 const DF = new DataFactory();
@@ -146,6 +147,150 @@ describe('ActorQueryParseSparql', () => {
               value: 'b',
             },
           ],
+        },
+      });
+    });
+
+    it('should run with an additional default graph URI', async() => {
+      const key: IActionContextKey<RDF.NamedNode[]> = {
+        name: '@comunica/actor-init-query:defaultGraphUris',
+        dummy: undefined,
+      };
+      const uri: RDF.NamedNode = { value: 'http://example.org/book/', equals: () => true, termType: 'NamedNode' };
+      const result = await actor.run({ query: 'SELECT * WHERE { ?a a ?b }', context: context.set(key, [ uri ]) });
+      expect(result).toMatchObject({
+        operation: {
+          type: 'from',
+          default: [ uri ],
+          named: [],
+          input: {
+            input: { patterns: [
+              {
+                graph: { value: '' },
+                object: { value: 'b' },
+                predicate: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
+                subject: { value: 'a' },
+                type: 'pattern',
+              },
+            ], type: 'bgp' },
+            type: 'project',
+            variables: [
+              {
+                value: 'a',
+              },
+              {
+                value: 'b',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it('should run with an overridden default graph URI', async() => {
+      const key: IActionContextKey<RDF.NamedNode[]> = {
+        name: '@comunica/actor-init-query:defaultGraphUris',
+        dummy: undefined,
+      };
+      const uri: RDF.NamedNode = { value: 'http://example.org/book/', equals: () => true, termType: 'NamedNode' };
+      const result = await actor.run({ query: 'SELECT * FROM <http://example.org/song/> WHERE { ?a a ?b }', context: context.set(key, [ uri ]) });
+      expect(result).toMatchObject({
+        operation: {
+          type: 'from',
+          default: [ uri ],
+          named: [],
+          input: {
+            input: { patterns: [
+              {
+                graph: { value: '' },
+                object: { value: 'b' },
+                predicate: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
+                subject: { value: 'a' },
+                type: 'pattern',
+              },
+            ], type: 'bgp' },
+            type: 'project',
+            variables: [
+              {
+                value: 'a',
+              },
+              {
+                value: 'b',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it('should run with an additional named graph URI', async() => {
+      const key: IActionContextKey<RDF.NamedNode[]> = {
+        name: '@comunica/actor-init-query:namedGraphUris',
+        dummy: undefined,
+      };
+      const uri: RDF.NamedNode = { value: 'http://example.org/book/', equals: () => true, termType: 'NamedNode' };
+      const result = await actor.run({ query: 'SELECT * WHERE { ?a a ?b }', context: context.set(key, [ uri ]) });
+      expect(result).toMatchObject({
+        operation: {
+          type: 'from',
+          default: [],
+          named: [ uri ],
+          input: {
+            input: { patterns: [
+              {
+                graph: { value: '' },
+                object: { value: 'b' },
+                predicate: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
+                subject: { value: 'a' },
+                type: 'pattern',
+              },
+            ], type: 'bgp' },
+            type: 'project',
+            variables: [
+              {
+                value: 'a',
+              },
+              {
+                value: 'b',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it('should run with an overridden named graph URI', async() => {
+      const key: IActionContextKey<RDF.NamedNode[]> = {
+        name: '@comunica/actor-init-query:namedGraphUris',
+        dummy: undefined,
+      };
+      const uri: RDF.NamedNode = { value: 'http://example.org/book/', equals: () => true, termType: 'NamedNode' };
+      const result = await actor.run({ query: 'SELECT * FROM NAMED <http://example.org/song/> WHERE { ?a a ?b }', context: context.set(key, [ uri ]) });
+      expect(result).toMatchObject({
+        operation: {
+          type: 'from',
+          default: [],
+          named: [ uri ],
+          input: {
+            input: { patterns: [
+              {
+                graph: { value: '' },
+                object: { value: 'b' },
+                predicate: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
+                subject: { value: 'a' },
+                type: 'pattern',
+              },
+            ], type: 'bgp' },
+            type: 'project',
+            variables: [
+              {
+                value: 'a',
+              },
+              {
+                value: 'b',
+              },
+            ],
+          },
         },
       });
     });

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -216,6 +216,22 @@ export const KeysInitQuery = {
    * A boolean value denoting whether results should be deduplicated or not.
    */
   distinctConstruct: new ActionContextKey<boolean>('@comunica/actor-init-query:distinctConstruct'),
+  /**
+   * Values received for default-graph-uri when acting as a SPARQL endpoint.
+   */
+  defaultGraphUris: new ActionContextKey<RDF.NamedNode[]>('@comunica/actor-init-query:defaultGraphUris'),
+  /**
+   * Values received for named-graph-uri when acting as a SPARQL endpoint.
+   */
+  namedGraphUris: new ActionContextKey<RDF.NamedNode[]>('@comunica/actor-init-query:namedGraphUris'),
+  /**
+   * Values received for using-graph-uri when acting as a SPARQL endpoint.
+   */
+  usingGraphUris: new ActionContextKey<RDF.NamedNode[]>('@comunica/actor-init-query:usingGraphUris'),
+  /**
+   * Values received for using-named-graph-uri when acting as a SPARQL endpoint.
+   */
+  usingNamedGraphUris: new ActionContextKey<RDF.NamedNode[]>('@comunica/actor-init-query:usingNamedGraphUris'),
 };
 
 export const KeysExpressionEvaluator = {


### PR DESCRIPTION
This is a collection of the work to support `default-graph-uri` with `HttpServiceSparqlEndpoint`, along with various adjustments to the way requests are handled to make it easier to implement the different cases. The SPARQL endpoint actor parses the `default-graph-uri` into the context, and `ActorQueryParseSparql` handles the wrapping of the query into a corresponding `Algebra.FROM` (or overrides the graph URIs in an existing one).

The motivation for this work is the need to be able to use Comunica as a SPARQL endpoint over multiple named graphs.

Any feedback would be welcome. I need to see if the CI passes, but the code itself works for the purpose it is meant for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced SPARQL endpoint functionality with new graph URI handling.
  - Added support for more flexible context configuration in query processing.

- **Dependency Changes**
  - Replaced `rdf-quad` with `rdf-data-factory` in the actor-init-query package.
  - Added `@rdfjs/types` dependency in the actor-query-parse-sparql package.

- **Improvements**
  - Refined HTTP service request handling.
  - Improved error management in SPARQL query parsing.
  - Extended context key management for graph URIs.

- **Testing**
  - Expanded test coverage for SPARQL endpoint and query parsing functionality.
  - Established comprehensive testing framework for CLI argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->