### PR TITLE
Fix sd:defaultGraph parsing with QPF endpoints

### DIFF
--- a/packages/actor-rdf-metadata-extract-sparql-service/test/ActorRdfMetadataExtractSparqlService-test.ts
+++ b/packages/actor-rdf-metadata-extract-sparql-service/test/ActorRdfMetadataExtractSparqlService-test.ts
@@ -25,15 +25,18 @@ describe('ActorRdfMetadataExtractSparqlService', () => {
     });
 
     it('should test successfully', async() => {
-      await expect(actor.test({ url: 'http://example.org/', metadata: <any> undefined, requestTime, context })).resolves.toBeTruthy();
+      await expect(actor.test({ url: 'http://localhost/', metadata: <any> undefined, requestTime, context })).resolves.toBeTruthy();
     });
   });
 
   describe('run', () => {
-    const sparqlIri = DF.namedNode('http://example.org/sparql');
-    const sparqlService = DF.namedNode('http://example.org/endpoint');
-    const sparqlDefaultDataset = DF.namedNode('http://example.org/dataset');
-    const sparqlDefaultGraph = DF.namedNode('http://example.org/graph');
+    const voidSubset = DF.namedNode('http://rdfs.org/ns/void#subset');
+
+    const endpointIri = DF.namedNode('http://localhost/sparql');
+    const endpointService = DF.namedNode('http://localhost/endpoint');
+    const endpointDefaultDataset = DF.namedNode('http://localhost/dataset');
+    const endpointDefaultGraph = DF.namedNode('http://localhost/graph');
+
     const sparqlResultsJson = DF.namedNode('http://www.w3.org/ns/formats/SPARQL_Results_JSON');
     const sparqlResultsXml = DF.namedNode('http://www.w3.org/ns/formats/SPARQL_Results_XML');
     const sparql11Query = DF.namedNode('http://www.w3.org/ns/sparql-service-description#SPARQL11Query');
@@ -53,26 +56,26 @@ describe('ActorRdfMetadataExtractSparqlService', () => {
     });
 
     it.each([
-      [ 'iri', sparqlIri ],
+      [ 'iri', endpointIri ],
       [ 'blank node', DF.blankNode() ],
-    ])('should parse service description when available with %s', async(type, serviceDescriptionIri) => {
+    ])('should parse service description identified by %s', async(_, serviceDescriptionIri) => {
       const input = streamifyArray([
-        DF.quad(serviceDescriptionIri, serviceDescriptionEndpoint, sparqlService),
+        DF.quad(serviceDescriptionIri, serviceDescriptionEndpoint, endpointService),
         DF.quad(serviceDescriptionIri, serviceDescriptionFeature, serviceDescriptionBasicFederatedQuery),
         DF.quad(serviceDescriptionIri, serviceDescriptionFeature, serviceDescriptionUnionDefaultGraph),
         DF.quad(serviceDescriptionIri, serviceDescriptionSupportedLanguage, sparql11Query),
         DF.quad(serviceDescriptionIri, serviceDescriptionInputFormat, sparqlResultsJson),
         DF.quad(serviceDescriptionIri, serviceDescriptionResultFormat, sparqlResultsXml),
-        DF.quad(serviceDescriptionIri, serviceDescriptionDefaultDataset, sparqlDefaultDataset),
-        DF.quad(sparqlDefaultDataset, serviceDescriptionDefaultGraph, sparqlDefaultGraph),
+        DF.quad(serviceDescriptionIri, serviceDescriptionDefaultDataset, endpointDefaultDataset),
+        DF.quad(endpointDefaultDataset, serviceDescriptionDefaultGraph, endpointDefaultGraph),
       ]);
-      await expect(actor.run({ url: sparqlIri.value, metadata: input, context, requestTime })).resolves.toEqual({
+      await expect(actor.run({ url: endpointIri.value, metadata: input, context, requestTime })).resolves.toEqual({
         metadata: {
-          sparqlService: sparqlService.value,
+          sparqlService: endpointService.value,
           basicFederatedQuery: true,
           unionDefaultGraph: true,
-          defaultDataset: sparqlDefaultDataset.value,
-          defaultGraph: sparqlDefaultGraph.value,
+          defaultDataset: endpointDefaultDataset.value,
+          defaultGraph: endpointDefaultGraph.value,
           inputFormats: [ sparqlResultsJson.value ],
           resultFormats: [ sparqlResultsXml.value ],
           supportedLanguages: [ sparql11Query.value ],
@@ -80,42 +83,50 @@ describe('ActorRdfMetadataExtractSparqlService', () => {
       });
     });
 
-    it('should parse relative endpoint from literal when available', async() => {
-      const input = streamifyArray([ DF.quad(sparqlIri, serviceDescriptionEndpoint, DF.literal('/abc/../endpoint')) ]);
-      await expect(actor.run({ url: sparqlIri.value, metadata: input, context, requestTime })).resolves.toEqual({
-        metadata: { sparqlService: sparqlService.value },
-      });
-    });
-
-    it('should infer HTTPS endpoint when instructed to', async() => {
-      actor = new ActorRdfMetadataExtractSparqlService({ name: 'actor', bus, inferHttpsEndpoint: true });
-      const httpsIri = sparqlIri.value.replace(/^http:/u, 'https:');
-      const input = streamifyArray([ DF.quad(DF.namedNode(httpsIri), serviceDescriptionEndpoint, sparqlService) ]);
-      await expect(actor.run({ url: httpsIri, metadata: input, context, requestTime })).resolves.toEqual({
-        metadata: { sparqlService: sparqlService.value.replace(/^http:/u, 'https:') },
-      });
-    });
-
-    it('should parse endpoint, defaultDataset and the correct defaultGraph when available', async() => {
+    it('should parse sd:defaultGraph when available via QPF metadata graph', async() => {
+      const qpfEndpointUri = DF.namedNode('http://localhost/qpf');
       const input = streamifyArray([
-        DF.quad(sparqlIri, serviceDescriptionEndpoint, sparqlService),
-        DF.quad(sparqlIri, serviceDescriptionDefaultDataset, sparqlDefaultDataset),
-        DF.quad(sparqlDefaultDataset, serviceDescriptionDefaultGraph, sparqlDefaultGraph),
+        DF.quad(endpointDefaultDataset, voidSubset, qpfEndpointUri),
+        DF.quad(endpointDefaultDataset, serviceDescriptionDefaultGraph, endpointDefaultGraph),
+      ]);
+      await expect(actor.run({ url: qpfEndpointUri.value, metadata: input, context, requestTime })).resolves.toEqual({
+        metadata: { defaultGraph: endpointDefaultGraph.value },
+      });
+    });
+
+    it('should parse relative sd:endpoint from xsd:Literal when available', async() => {
+      const input = streamifyArray([
+        DF.quad(endpointIri, serviceDescriptionEndpoint, DF.literal('/abc/../endpoint')),
+      ]);
+      await expect(actor.run({ url: endpointIri.value, metadata: input, context, requestTime })).resolves.toEqual({
+        metadata: { sparqlService: endpointService.value },
+      });
+    });
+
+    it('should force sd:endpoint to HTTPS when instructed to', async() => {
+      actor = new ActorRdfMetadataExtractSparqlService({ name: 'actor', bus, inferHttpsEndpoint: true });
+      const httpsIri = endpointIri.value.replace(/^http:/u, 'https:');
+      const input = streamifyArray([
+        DF.quad(DF.namedNode(httpsIri), serviceDescriptionEndpoint, endpointService),
+      ]);
+      await expect(actor.run({ url: httpsIri, metadata: input, context, requestTime })).resolves.toEqual({
+        metadata: { sparqlService: endpointService.value.replace(/^http:/u, 'https:') },
+      });
+    });
+
+    it('should parse sd:endpoint, sd:defaultDataset and the correct sd:defaultGraph when available', async() => {
+      const input = streamifyArray([
+        DF.quad(endpointIri, serviceDescriptionEndpoint, endpointService),
+        DF.quad(endpointIri, serviceDescriptionDefaultDataset, endpointDefaultDataset),
+        DF.quad(endpointDefaultDataset, serviceDescriptionDefaultGraph, endpointDefaultGraph),
         DF.quad(DF.namedNode('http://example.org/dataset2'), serviceDescriptionDefaultGraph, DF.namedNode('http://example.org/graph2')),
       ]);
-      await expect(actor.run({ url: sparqlIri.value, metadata: input, context, requestTime })).resolves.toEqual({
+      await expect(actor.run({ url: endpointIri.value, metadata: input, context, requestTime })).resolves.toEqual({
         metadata: {
-          sparqlService: sparqlService.value,
-          defaultDataset: sparqlDefaultDataset.value,
-          defaultGraph: sparqlDefaultGraph.value,
+          sparqlService: endpointService.value,
+          defaultDataset: endpointDefaultDataset.value,
+          defaultGraph: endpointDefaultGraph.value,
         },
-      });
-    });
-
-    it('should return empty result without endpoint defined', async() => {
-      const input = streamifyArray([ DF.quad(sparqlIri, serviceDescriptionInputFormat, sparqlResultsJson) ]);
-      await expect(actor.run({ url: sparqlIri.value, metadata: input, context, requestTime })).resolves.toEqual({
-        metadata: {},
       });
     });
   });


### PR DESCRIPTION
This should fix the parsing of `sd:defaultGraph` on QPF endpoints, without causing the parser to register unrelated triples with that predicate. The fix relies on a whitelist of subjects that can be used to extract the predicate values from, which is not perfect, but is better than ignoring the subject entirely.

The parsing of the default graph with QPF broke due to the changes in 2c0af9eb76b7763afe39d07900f3320a061d94a4.

There is an added unit test for the QPF defaultGraph case, as well as the existing test for ignoring unrelated `sd:defaultGraph` entries. I removed the test for returning empty results without an `sd:endpoint` since that behaviour is not intended with QPF.

Manually testing against the linkeddatafragments.org TPF and QPF servers worked, with a simple spo query.

Any feedback would be welcome! :slightly_smiling_face: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined metadata extraction logic for SPARQL services
	- Improved subject URI filtering mechanism

- **Tests**
	- Updated test cases to use localhost URLs
	- Added new test for parsing default graph metadata
	- Improved test coverage for endpoint and dataset parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->