### PR TITLE
Update README.md of actor-query-source-identify-hypermedia-annotate-source

### DIFF
--- a/packages/actor-query-source-identify-hypermedia-annotate-source/README.md
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/README.md
@@ -2,8 +2,10 @@
 
 [![npm version](https://badge.fury.io/js/%40comunica%2Factor-query-source-identify-hypermedia-annotate-source.svg)](https://www.npmjs.com/package/@comunica/actor-query-source-identify-hypermedia-annotate-source)
 
-A comunica Annotate Source Query Source Identify Hypermedia Actor. This actor wraps around other hypermedia sources and adds the
+A Comunica Annotate Source Query Source Identify Hypermedia Actor. This actor wraps around other hypermedia sources and adds the
 URL from which the bindings are derived to the binding's context.
+
+This actor does _not_ work when the `aggregateTraversalStore` is enabled in `ActorQuerySourceIdentifyHypermedia`.
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).

--- a/packages/actor-query-source-identify-hypermedia-annotate-source/README.md
+++ b/packages/actor-query-source-identify-hypermedia-annotate-source/README.md
@@ -5,7 +5,7 @@
 A Comunica Annotate Source Query Source Identify Hypermedia Actor. This actor wraps around other hypermedia sources and adds the
 URL from which the bindings are derived to the binding's context.
 
-This actor does _not_ work when the `aggregateTraversalStore` is enabled in `ActorQuerySourceIdentifyHypermedia`.
+**Warning**: This actor does _not_ work when the `aggregateTraversalStore` is enabled in `ActorQuerySourceIdentifyHypermedia`.
 
 This module is part of the [Comunica framework](https://github.com/comunica/comunica),
 and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).


### PR DESCRIPTION
The `ActorQuerySourceIdentifyHypermediaAnnotateSource` actor produces incomplete why-provenance annotations when the `aggregateStore` is enabled. To reflect this limitation I've updated the README.md