### PR TITLE
Fix traversal flag extraction for operation pruning 

### DIFF
--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
@@ -196,7 +196,7 @@ export class ActorOptimizeQueryOperationPruneEmptySourceOperations extends Actor
     context: IActionContext,
   ): Promise<boolean> {
     // Traversal sources should never be considered empty at optimization time.
-    if (source.context?.get(KeysQuerySourceIdentify.traverse)) {
+    if (source.context?.get(KeysQuerySourceIdentify.traverse) ?? context.get(KeysQuerySourceIdentify.traverse)) {
       return true;
     }
 

--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
@@ -790,7 +790,7 @@ describe('ActorOptimizeQueryOperationPruneEmptySourceOperations', () => {
           expect(source1.source.queryBindings).toHaveBeenCalledWith(AF.createNop(), ctx);
         });
 
-        it('should be true for cardinality = 0 on a traversal source', async() => {
+        it('should be true for 0 cardinality on source with traversal enabled', async() => {
           source1.context = new ActionContext().set(KeysQuerySourceIdentify.traverse, true);
           source1.source.queryBindings = () => {
             const bindingsStream = new ArrayIterator<RDF.Bindings>([], { autoStart: false });
@@ -798,6 +798,17 @@ describe('ActorOptimizeQueryOperationPruneEmptySourceOperations', () => {
             return bindingsStream;
           };
           await expect(actor.hasSourceResults(AF, source1, AF.createNop(), ctx)).resolves.toBeTruthy();
+        });
+
+        it('should be true for 0 cardinality on source with traversal enabled via action context', async() => {
+          const actionContext = new ActionContext({ [KeysQuerySourceIdentify.traverse.name]: true });
+          source1.context = new ActionContext();
+          source1.source.queryBindings = () => {
+            const bindingsStream = new ArrayIterator<RDF.Bindings>([], { autoStart: false });
+            bindingsStream.setProperty('metadata', { cardinality: { value: 0 }});
+            return bindingsStream;
+          };
+          await expect(actor.hasSourceResults(AF, source1, AF.createNop(), actionContext)).resolves.toBeTruthy();
         });
       });
 


### PR DESCRIPTION
This is a fix for an issue where the `traverse` key was being extracted from the source context by `ActorOptimizeQueryOperationPruneEmptySourceOperations` but not from the action context. When the source context does not have the traversal key, and the pruning logic is run, this would result in the pruning of all operations assigned to that source, even when the action context itself would have the traversal flag in it.

This should fix #1498 