### PR TITLE
Add workaround for DBPedia SPARQL HTTP status 405 with Retry-After

### DIFF
--- a/packages/actor-http-retry/test/ActorHttpRetry-test.ts
+++ b/packages/actor-http-retry/test/ActorHttpRetry-test.ts
@@ -75,8 +75,8 @@ describe('ActorHttpRetry', () => {
 
     it('should handle request that succeeds after retries', async() => {
       const mediatorResponseQueue: IActorHttpOutput[] = [
-        <any> { ok: false, status: 999, statusText: 'Dummy Failure' },
-        <any> { ok: false, status: 504, statusText: 'Gateway Timeout' },
+        <any> { ok: false, status: 999, statusText: 'Dummy Failure', headers: new Map() },
+        <any> { ok: false, status: 504, statusText: 'Gateway Timeout', headers: new Map() },
         <any> { ok: true },
       ];
       // eslint-disable-next-line jest/prefer-mock-promise-shorthand
@@ -94,7 +94,7 @@ describe('ActorHttpRetry', () => {
     });
 
     it('should handle error codes in the 400 range', async() => {
-      const response: Response = <any> { ok: false, status: 400 };
+      const response: Response = <any> { ok: false, status: 400, headers: new Map() };
       jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(response);
       expect(ActorHttpRetry.sleep).not.toHaveBeenCalled();
       expect(ActorHttpRetry.parseRetryAfterHeader).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ describe('ActorHttpRetry', () => {
     });
 
     it('should handle error codes in the 500 range', async() => {
-      const response: Response = <any> { ok: false, status: 500 };
+      const response: Response = <any> { ok: false, status: 500, headers: new Map() };
       jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(response);
       expect(ActorHttpRetry.sleep).not.toHaveBeenCalled();
       expect(ActorHttpRetry.parseRetryAfterHeader).not.toHaveBeenCalled();
@@ -118,7 +118,7 @@ describe('ActorHttpRetry', () => {
     });
 
     it('should handle error codes in force retry list', async() => {
-      const response: Response = <any> { ok: false, status: 500 };
+      const response: Response = <any> { ok: false, status: 500, headers: new Map() };
       jest.spyOn(mediatorHttp, 'mediate').mockResolvedValue(response);
       expect(ActorHttpRetry.sleep).not.toHaveBeenCalled();
       expect(ActorHttpRetry.parseRetryAfterHeader).not.toHaveBeenCalled();
@@ -132,11 +132,15 @@ describe('ActorHttpRetry', () => {
       expect(mediatorHttp.mediate).toHaveBeenCalledTimes(2);
     });
 
-    it('should handle server-side delay requests via Retry-After header', async() => {
+    it.each([
+      405,
+      429,
+      503,
+    ])('should handle server-side delay requests via Retry-After header with status code %d', async(status) => {
       const retryAfterDate = new Date(1_000);
       const response: Response = <any> {
         ok: false,
-        status: 429,
+        status,
         headers: new Headers({ 'retry-after': retryAfterDate.getTime().toString(10) }),
       };
       jest.spyOn(Date, 'now').mockReturnValue(0);


### PR DESCRIPTION
This is a workaround for DBPedia SPARQL endpoint sending a 405 instead of 429 for rate limiting, which should be considered 429 by the client for retry purposes. Assuming the same software could be used in other SPARQL endpoints, as well, there is no URI-specific handling, but instead just a check for 405 with `Retry-After`, which should be sufficient.

This also fixes a small bug with the timeout calculation for clearing up old delays.