### PR TITLE
Avoid printing all metadata in join logging

### DIFF
--- a/packages/actor-rdf-join-inner-multi-bind-source/lib/ActorRdfJoinMultiBindSource.ts
+++ b/packages/actor-rdf-join-inner-multi-bind-source/lib/ActorRdfJoinMultiBindSource.ts
@@ -53,7 +53,12 @@ export class ActorRdfJoinMultiBindSource extends ActorRdfJoin<IActorRdfJoinMulti
     this.logDebug(
       action.context,
       'First entry for Bind Join Source: ',
-      () => ({ entry: entries[0].operation, metadata: entries[0].metadata }),
+      () => ({
+        entry: entries[0].operation,
+        cardinality: entries[0].metadata.cardinality,
+        order: entries[0].metadata.order,
+        availableOrders: entries[0].metadata.availableOrders,
+      }),
     );
 
     // Close the non-smallest streams

--- a/packages/actor-rdf-join-inner-multi-bind-source/test/ActorRdfJoinMultiBindSource-test.ts
+++ b/packages/actor-rdf-join-inner-multi-bind-source/test/ActorRdfJoinMultiBindSource-test.ts
@@ -232,14 +232,7 @@ describe('ActorRdfJoinMultiBindSource', () => {
         expect(logSpy).toHaveBeenCalledWith(context, 'First entry for Bind Join Source: ', expect.any(Function));
         expect(logSpy.mock.calls[0][2]()).toEqual({
           entry: action.entries[1].operation,
-          metadata: {
-            state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 3 },
-
-            variables: [
-              { variable: DF.variable('a'), canBeUndef: false },
-            ],
-          },
+          cardinality: { type: 'estimate', value: 3 },
         });
         expect(source1.source.queryBindings).toHaveBeenCalledTimes(2);
         expect(source1.source.queryBindings).toHaveBeenNthCalledWith(
@@ -356,14 +349,7 @@ describe('ActorRdfJoinMultiBindSource', () => {
         expect(logSpy).toHaveBeenCalledWith(context, 'First entry for Bind Join Source: ', expect.any(Function));
         expect(logSpy.mock.calls[0][2]()).toEqual({
           entry: action.entries[1].operation,
-          metadata: {
-            state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 3 },
-
-            variables: [
-              { variable: DF.variable('a'), canBeUndef: false },
-            ],
-          },
+          cardinality: { type: 'estimate', value: 3 },
         });
         expect(source4Context.source.queryBindings).toHaveBeenCalledTimes(2);
         expect(source4Context.source.queryBindings).toHaveBeenNthCalledWith(

--- a/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
@@ -115,7 +115,12 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
     this.logDebug(
       action.context,
       'First entry for Bind Join: ',
-      () => ({ entry: entries[0].operation, metadata: entries[0].metadata }),
+      () => ({
+        entry: entries[0].operation,
+        cardinality: entries[0].metadata.cardinality,
+        order: entries[0].metadata.order,
+        availableOrders: entries[0].metadata.availableOrders,
+      }),
     );
 
     // Close the non-smallest streams

--- a/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
@@ -1098,14 +1098,7 @@ IQueryOperationResultBindings
         expect(logSpy).toHaveBeenCalledWith(context, 'First entry for Bind Join: ', expect.any(Function));
         expect(logSpy.mock.calls[0][2]()).toEqual({
           entry: action.entries[1].operation,
-          metadata: {
-            state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 1 },
-
-            variables: [
-              { variable: DF.variable('a'), canBeUndef: false },
-            ],
-          },
+          cardinality: { type: 'estimate', value: 1 },
         });
         expect(mediatorQueryOperation.mediate).toHaveBeenCalledTimes(2);
         expect(mediatorQueryOperation.mediate).toHaveBeenNthCalledWith(1, {
@@ -1494,14 +1487,7 @@ IQueryOperationResultBindings
         expect(logSpy).toHaveBeenCalledWith(context, 'First entry for Bind Join: ', expect.any(Function));
         expect(logSpy.mock.calls[0][2]()).toEqual({
           entry: action.entries[2].operation,
-          metadata: {
-            state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 1 },
-
-            variables: [
-              { variable: DF.variable('a'), canBeUndef: false },
-            ],
-          },
+          cardinality: { type: 'estimate', value: 1 },
         });
         expect(mediatorQueryOperation.mediate).toHaveBeenCalledTimes(2);
         expect(mediatorQueryOperation.mediate).toHaveBeenNthCalledWith(1, {


### PR DESCRIPTION
This should fix the issue with extremely verbose debug logging after VoID descriptions are discovered.