### PR TITLE
Add distinctConstruct key to IQueryContextCommon

### DIFF
--- a/packages/types/lib/IQueryContext.ts
+++ b/packages/types/lib/IQueryContext.ts
@@ -47,4 +47,5 @@ export interface IQueryContextCommon {
   extensionFunctions?: Record<string, (args: RDF.Term[]) => Promise<RDF.Term>>;
   explain?: QueryExplainMode;
   recoverBrokenLinks?: boolean;
+  distinctConstruct?: boolean;
 }


### PR DESCRIPTION
This PR adds the `distinctConstruct` key to the `IQueryContextCommon` interface.

Related to #1510.