### PR TITLE
Bump lru-cache version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
       - name: Build TypeScript with esModuleInterop flag
         run: yarn run build:ts --esModuleInterop true
       - name: Run linter
@@ -76,7 +76,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies and build
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
       - name: Run tests
         run: yarn run test:ci
       - name: Submit coverage results
@@ -117,7 +117,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies and build
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
       - name: Load RDF test suite cache
         uses: actions/cache@v4
         with:
@@ -156,7 +156,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies and build
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
       - name: Install ${{ matrix.browser }} via Playwright
         if: startsWith(matrix.browser, 'Webkit')
         # The @L will convert 'Webkit' into lowercase 'webkit' which is the name Playwright expects.
@@ -207,7 +207,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies and build
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
       - name: Build browser bundles
         run: yarn run build:browser
       - name: Deploy browser builds
@@ -243,7 +243,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies and build monorepo
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
       - name: Install Lerna Docker
         run: sh -c "`curl -fsSl https://raw.githubusercontent.com/rubensworks/lerna-docker/master/install.sh`"
       - name: Build Docker images
@@ -292,7 +292,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies and build monorepo
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-engines
       - name: Run benchmarks
         run: cd performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
       - uses: actions/upload-artifact@v4
@@ -404,7 +404,7 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-modules-${{ secrets.CACHE_VERSION }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
-        run: yarn install --ignore-scripts --frozen-lockfile
+        run: yarn install --ignore-scripts --ignore-engines --frozen-lockfile
       - name: Build documentation
         run: yarn run doc
       - name: Prepare artifact

--- a/packages/actor-context-preprocess-query-source-identify/package.json
+++ b/packages/actor-context-preprocess-query-source-identify/package.json
@@ -47,6 +47,6 @@
     "@comunica/context-entries": "^4.1.0",
     "@comunica/core": "^4.1.0",
     "@comunica/types": "^4.1.0",
-    "lru-cache": "^10.0.0"
+    "lru-cache": "^11.0.0"
   }
 }

--- a/packages/actor-query-operation-reduced-hash/package.json
+++ b/packages/actor-query-operation-reduced-hash/package.json
@@ -47,7 +47,7 @@
     "@comunica/types": "^4.1.0",
     "@comunica/utils-query-operation": "^4.1.0",
     "@rdfjs/types": "*",
-    "lru-cache": "^10.0.0",
+    "lru-cache": "^11.0.0",
     "sparqlalgebrajs": "^4.3.8"
   }
 }

--- a/packages/actor-query-source-identify-hypermedia-sparql/package.json
+++ b/packages/actor-query-source-identify-hypermedia-sparql/package.json
@@ -52,7 +52,7 @@
     "@rdfjs/types": "*",
     "asynciterator": "^3.9.0",
     "fetch-sparql-endpoint": "^5.1.0",
-    "lru-cache": "^10.0.0",
+    "lru-cache": "^11.0.0",
     "rdf-terms": "^1.11.0",
     "sparqlalgebrajs": "^4.3.8"
   }

--- a/packages/actor-query-source-identify-hypermedia/package.json
+++ b/packages/actor-query-source-identify-hypermedia/package.json
@@ -59,7 +59,7 @@
     "@comunica/utils-metadata": "^4.1.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.9.0",
-    "lru-cache": "^10.0.0",
+    "lru-cache": "^11.0.0",
     "rdf-streaming-store": "^1.1.4",
     "readable-stream": "^4.5.2",
     "sparqlalgebrajs": "^4.3.8"

--- a/packages/actor-rdf-update-quads-hypermedia/package.json
+++ b/packages/actor-rdf-update-quads-hypermedia/package.json
@@ -49,6 +49,6 @@
     "@comunica/bus-rdf-update-quads": "^4.1.0",
     "@comunica/core": "^4.1.0",
     "@comunica/types": "^4.1.0",
-    "lru-cache": "^10.0.0"
+    "lru-cache": "^11.0.0"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -45,7 +45,7 @@
     "@rdfjs/types": "*",
     "@types/yargs": "^17.0.24",
     "asynciterator": "^3.9.0",
-    "lru-cache": "^10.0.1",
+    "lru-cache": "^11.0.0",
     "sparqlalgebrajs": "^4.3.8"
   }
 }

--- a/packages/utils-expression-evaluator/package.json
+++ b/packages/utils-expression-evaluator/package.json
@@ -41,7 +41,7 @@
     "@comunica/context-entries": "^4.1.0",
     "@comunica/types": "^4.1.0",
     "@rdfjs/types": "*",
-    "lru-cache": "^10.0.0",
+    "lru-cache": "^11.0.0",
     "rdf-data-factory": "^1.1.2",
     "rdf-string": "^1.6.3",
     "sparqlalgebrajs": "^4.3.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8785,10 +8785,15 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lru-cache@^10.0.0, lru-cache@^10.0.1, lru-cache@^10.2.0:
+lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.2.0"
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz"
   integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
+
+lru-cache@^11.0.0:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.0.2.tgz#fbd8e7cf8211f5e7e5d91905c415a3f55755ca39"
+  integrity sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==
 
 lru-cache@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This bumps the `lru-cache` version to 11, and also adds the `--ignore-engines` flags to the CI install steps, because the new version does not officially claim to spport Node 18.

The Node [release schedule](https://nodejs.org/en/about/previous-releases#release-schedule) makes it look like Node 18 will also reach EOL at the end of April, so maybe dropping it would make sense soon.

Any feedback would be welcome, though. 