### PR TITLE
Fix Coveralls result key to avoid false duplicates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.node-version }}
+          flag-name: ${{ matrix.os }}-${{ matrix.node-version }}
           parallel: true
           fail-on-error: false
 


### PR DESCRIPTION
This fixes the false duplicates in Coveralls reports, where the same lines would be reported multiple times. It turns out this issue was caused by the OS not being taken into account for the generation of the identifier.