### PR TITLE
Fixes to dereference error handling

### DIFF
--- a/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
+++ b/packages/actor-dereference-http/test/ActorDereferenceHttp-test.ts
@@ -276,14 +276,16 @@ describe('ActorDereferenceHttp', () => {
     it('should run and ignore http rejects in lenient mode and log them', async() => {
       const logger = new LoggerVoid();
       const spy = jest.spyOn(logger, 'warn');
+      const url = 'https://www.google.com/';
       context = new ActionContext({
         httpReject: true,
         [KeysInitQuery.lenient.name]: true,
         [KeysCore.log.name]: logger,
       });
-      await actor.run({ url: 'https://www.google.com/', context });
+      await actor.run({ url, context });
       expect(spy).toHaveBeenCalledWith('Http reject error', {
         actor: 'actor',
+        url,
       });
     });
   });

--- a/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
+++ b/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
@@ -163,14 +163,16 @@ describe('ActorAbstractDereferenceParse', () => {
   it('should run and ignore parse rejects in lenient mode and log them', async() => {
     const logger = new LoggerVoid();
     const spy = jest.spyOn(logger, 'warn');
+    const url = 'https://www.google.com/';
     context = new ActionContext({
       parseReject: true,
       [KeysInitQuery.lenient.name]: true,
       [KeysCore.log.name]: logger,
     });
-    await actor.run({ url: 'https://www.google.com/', context });
+    await actor.run({ url, context });
     expect(spy).toHaveBeenCalledWith('Parse reject error', {
       actor: 'actor',
+      url,
     });
   });
 });

--- a/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
+++ b/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
@@ -76,7 +76,7 @@ describe('ActorAbstractDereferenceParse', () => {
     expect(actor.mediatorParse.mediate).toHaveBeenCalledWith({
       context,
       handle: expect.anything(),
-      handleMediaType: undefined,
+      handleMediaType: '',
     });
   });
 

--- a/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
+++ b/packages/actor-dereference-rdf-parse/test/ActorDereferenceRdfParse-test.ts
@@ -31,7 +31,7 @@ describe('ActorAbstractDereferenceParse', () => {
             data: emptyReadable(),
             url: `${action.url}${ext}`,
             requestTime: 0,
-            exists: true,
+            exists: !(<any>action.context).hasRaw('doesNotExist'),
             mediaType: (<any> action).mediaType,
           };
         }),
@@ -143,6 +143,13 @@ describe('ActorAbstractDereferenceParse', () => {
       actor: 'actor',
       url: 'https://www.google.com/',
     });
+  });
+
+  it('should run and ignore non-existing dereferenced urls', async() => {
+    context = new ActionContext({ doesNotExist: true });
+    const output = await actor.run({ url: 'https://www.google.com/', context });
+    expect(output.url).toBe('https://www.google.com/index.html');
+    await expect(arrayifyStream(output.data)).resolves.toEqual([]);
   });
 
   it('should not run on parse rejects', async() => {

--- a/packages/bus-dereference/lib/ActorDereferenceBase.ts
+++ b/packages/bus-dereference/lib/ActorDereferenceBase.ts
@@ -1,9 +1,9 @@
 import { KeysInitQuery } from '@comunica/context-entries';
-import type { IAction, IActorArgs, IActorTest } from '@comunica/core';
+import type { IActorArgs, IActorTest } from '@comunica/core';
 import { Actor } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
 import { Readable } from 'readable-stream';
-import type { IActorDereferenceOutput } from '.';
+import type { IActorDereferenceOutput, IActionDereference } from './ActorDereference';
 
 export function emptyReadable<S extends Readable>(): S {
   const data = new Readable();
@@ -32,7 +32,7 @@ export function isHardError(context: IActionContext): boolean {
  * @see IActorDereferenceOutput
  */
 export abstract class ActorDereferenceBase<
-  I extends IAction,
+  I extends IActionDereference,
 T extends IActorTest,
 O extends IActorDereferenceOutput,
 TS = undefined,
@@ -57,7 +57,7 @@ TS = undefined,
     if (isHardError(action.context)) {
       throw error;
     }
-    this.logWarn(action.context, (<Error> error).message);
+    this.logWarn(action.context, (<Error> error).message, () => ({ url: action.url }));
     return { ...output, data: emptyReadable<M>() };
   }
 }

--- a/packages/bus-dereference/lib/ActorDereferenceParse.ts
+++ b/packages/bus-dereference/lib/ActorDereferenceParse.ts
@@ -103,9 +103,8 @@ export abstract class ActorDereferenceParse<
           context,
           handle: { context, ...dereference, metadata: await this.getMetadata(dereference) },
           // eslint-disable-next-line ts/prefer-nullish-coalescing
-          handleMediaType: (dereference.mediaType ||
-            getMediaTypeFromExtension(dereference.url, this.mediaMappings)) ||
-            action.mediaType,
+          handleMediaType: dereference.mediaType || action.mediaType ||
+            getMediaTypeFromExtension(dereference.url, this.mediaMappings),
         })).handle;
         result.data = this.handleDereferenceStreamErrors(action, result.data);
       } catch (error: unknown) {

--- a/packages/bus-dereference/lib/ActorDereferenceParse.ts
+++ b/packages/bus-dereference/lib/ActorDereferenceParse.ts
@@ -5,7 +5,7 @@ import { passTestVoid } from '@comunica/core';
 import type { Readable } from 'readable-stream';
 import { PassThrough } from 'readable-stream';
 import type { IActionDereference, IActorDereferenceOutput, MediatorDereference } from './ActorDereference';
-import { ActorDereferenceBase, isHardError } from './ActorDereferenceBase';
+import { ActorDereferenceBase, isHardError, emptyReadable } from './ActorDereferenceBase';
 
 /**
  * Get the media type based on the extension of the given path,
@@ -96,20 +96,28 @@ export abstract class ActorDereferenceParse<
     });
 
     let result: IActorParseOutput<S, M>;
-    try {
-      result = (await this.mediatorParse.mediate({
-        context,
-        handle: { context, ...dereference, metadata: await this.getMetadata(dereference) },
-        // eslint-disable-next-line ts/prefer-nullish-coalescing
-        handleMediaType: (dereference.mediaType ||
-          getMediaTypeFromExtension(dereference.url, this.mediaMappings)) ||
-          action.mediaType,
-      })).handle;
-      result.data = this.handleDereferenceStreamErrors(action, result.data);
-    } catch (error: unknown) {
-      // Close the body, to avoid process to hang
+
+    if (dereference.exists) {
+      try {
+        result = (await this.mediatorParse.mediate({
+          context,
+          handle: { context, ...dereference, metadata: await this.getMetadata(dereference) },
+          // eslint-disable-next-line ts/prefer-nullish-coalescing
+          handleMediaType: (dereference.mediaType ||
+            getMediaTypeFromExtension(dereference.url, this.mediaMappings)) ||
+            action.mediaType,
+        })).handle;
+        result.data = this.handleDereferenceStreamErrors(action, result.data);
+      } catch (error: unknown) {
+        // Close the body, to avoid process to hang
+        await dereference.data.close?.();
+        result = await this.dereferenceErrorHandler(action, error, {});
+      }
+    } else {
+      // Close the dereference stream and return an empty response directly to avoid unnecessary processing.
+      // This code is equivalent to the error handler above in the catch clause, but avoids redundant processing.
       await dereference.data.close?.();
-      result = await this.dereferenceErrorHandler(action, error, {});
+      result = { data: emptyReadable() };
     }
 
     // Return the parsed stream and any metadata


### PR DESCRIPTION
This is a small PR to address three issues I discovered while testing out the master branch with link traversal:
1. The URL of a failed fetch request does not get reported, but the actor does. This makes the warning messages useless, so I added the URL as extra data to the error message.
2. The media type cascade logic seemed off, so I changed it to prefer the variables, and only fall back to a function call as last resort. This seems to have changed nothing in my tests, but should avoid a function call if one of the variables does have a non-empty value.
3. The entire RDF parse operation was being attempted on sources that failed to be dereferenced, so I added that part of the code behind an if statement to avoid the redundant parse error messages when dereferencing fails. The error message about a failed fetch is more accurate, and the parse error was just a byproduct of a missing check.

Any feedback would be welcome. :slightly_smiling_face: None of these is a breaking change in my opinion.