### PR TITLE
Remove Jest maxWorkers as redundant

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "yarn run test:node",
     "test:browser": "karma start --single-run",
     "test:changed": "lerna run test --since HEAD",
-    "test:ci": "yarn run test:node --ci --maxWorkers=4",
+    "test:ci": "yarn run test:node --ci",
     "test:integration": "lerna run integration --concurrency 1",
     "test:node": "jest",
     "test:spec": "lerna run spec --concurrency 1",


### PR DESCRIPTION
After some local experimentation, it seems that limiting the worker count can make the tests go faster, and consume a lot less memory. This is probably also the reason why the worker count has been limited in the CI originally.

However, a fixed limit of 4 translates to no limit at all for the MacOS runner, that has [3 cores](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) and considerably less memory than the other ones. I think this is the reason why the tests fail so often on MacOS.

This PR changes the static limit of 4 workers to a relative limit of 50%.