### PR TITLE
Avoid flattening joins with input-specific metadata

### DIFF
--- a/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
@@ -147,7 +147,8 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
         // Send the materialized patterns to the mediator for recursive join evaluation.
         const operation = operations.length === 1 ?
           operations[0] :
-          algebraFactory.createJoin(operations);
+          // Flattening should only take place if none of the input operations have associated metadata
+          algebraFactory.createJoin(operations, operations.every(op => !op.metadata));
         const output = getSafeBindings(await this.mediatorQueryOperation.mediate(
           { operation, context: subContext?.set(KeysQueryOperation.joinBindings, operationBindings) },
         ));

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -92,6 +92,20 @@ export function materializeOperation(
         ), { metadata: op.metadata }),
       };
     },
+    join(op: Algebra.Join, factory: Factory) {
+      // Materialize join operation, and ensure metadata is taken into account.
+      // Join entries with metadata should not be flattened.
+      return {
+        recurse: false,
+        result: factory.createJoin(op.input.map(input => materializeOperation(
+          input,
+          bindings,
+          algebraFactory,
+          bindingsFactory,
+          options,
+        )), op.input.every(input => !input.metadata)),
+      };
+    },
     extend(op: Algebra.Extend) {
       // Materialize an extend operation.
       // If strictTargetVariables is true, we throw if the extension target variable is attempted to be bound.

--- a/packages/utils-query-operation/test/MaterializeBindings-test.ts
+++ b/packages/utils-query-operation/test/MaterializeBindings-test.ts
@@ -202,6 +202,107 @@ describe('materializeOperation', () => {
       .toEqual(Object.assign(AF.createPattern(valueA, termNamedNode, termVariableC, termNamedNode), { metadata }));
   });
 
+  it('should materialize a join with empty bindings', () => {
+    expect(materializeOperation(
+      AF.createJoin([
+        AF.createJoin([
+          AF.createPattern(termVariableA, termNamedNode, termVariableB, termNamedNode),
+          AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+        ]),
+        AF.createJoin([
+          AF.createPattern(termVariableA, termNamedNode, termVariableD, termNamedNode),
+          AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
+        ]),
+      ], false),
+      bindingsEmpty,
+      AF,
+      BF,
+    ))
+      .toEqual(AF.createJoin([
+        AF.createPattern(termVariableA, termNamedNode, termVariableB, termNamedNode),
+        AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+        AF.createPattern(termVariableA, termNamedNode, termVariableD, termNamedNode),
+        AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
+      ]));
+  });
+
+  it('should materialize a join with non-empty bindings', () => {
+    expect(materializeOperation(
+      AF.createJoin([
+        AF.createJoin([
+          AF.createPattern(termVariableA, termNamedNode, termVariableB, termNamedNode),
+          AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+        ]),
+        AF.createJoin([
+          AF.createPattern(termVariableA, termNamedNode, termVariableD, termNamedNode),
+          AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
+        ]),
+      ], false),
+      bindingsA,
+      AF,
+      BF,
+    ))
+      .toEqual(AF.createJoin([
+        Object.assign(
+          AF.createPattern(valueA, termNamedNode, termVariableB, termNamedNode),
+          { metadata: undefined },
+        ),
+        Object.assign(
+          AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+          { metadata: undefined },
+        ),
+        Object.assign(
+          AF.createPattern(valueA, termNamedNode, termVariableD, termNamedNode),
+          { metadata: undefined },
+        ),
+        Object.assign(
+          AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
+          { metadata: undefined },
+        ),
+      ]));
+  });
+
+  it('should materialize a join with non-empty bindings and keep metadata', () => {
+    const metadata = { a: 'b' };
+    expect(materializeOperation(
+      AF.createJoin([
+        Object.assign(AF.createJoin([
+          AF.createPattern(termVariableA, termNamedNode, termVariableB, termNamedNode),
+          AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+        ]), { metadata }),
+        AF.createJoin([
+          AF.createPattern(termVariableA, termNamedNode, termVariableD, termNamedNode),
+          AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
+        ]),
+      ], false),
+      bindingsA,
+      AF,
+      BF,
+    ))
+      .toEqual(AF.createJoin([
+        Object.assign(AF.createJoin([
+          Object.assign(
+            AF.createPattern(valueA, termNamedNode, termVariableB, termNamedNode),
+            { metadata: undefined },
+          ),
+          Object.assign(
+            AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+            { metadata: undefined },
+          ),
+        ]), { metadata }),
+        AF.createJoin([
+          Object.assign(
+            AF.createPattern(valueA, termNamedNode, termVariableD, termNamedNode),
+            { metadata: undefined },
+          ),
+          Object.assign(
+            AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
+            { metadata: undefined },
+          ),
+        ]),
+      ], false));
+  });
+
   it('should materialize a BGP with non-empty bindings', () => {
     expect(materializeOperation(
       AF.createBgp([


### PR DESCRIPTION
After a lot of debugging, it turned out the source assignment error in #1519 is most likely caused by the flattening of joins, when using the `createJoin` function from `sparqlalgebrajs`, as it seems to strip out the metadata from join entries when it performs the flattening step.

Disabling flattening seems to fix it, so I changed the parts of the code where I ran into this issue to not do flattening when any of the join entries have metadata associated with them.

After this change, the query in #1519, as well as another consistently reproducible query (`020_ns` from @ecrum19's example collection) no longer crash due to source assignment issues. Neither of them seem to complete within a reasonable amount of time, either, but at least the error is gone.

Any feedback would be welcome, though, because I am not sure if this is the correct way to fix this.