### PR TITLE
Enable local cardinality estimation for `ASK` and `UNION` using VoID metadata

### DIFF
--- a/packages/actor-rdf-metadata-extract-void/lib/Estimators.ts
+++ b/packages/actor-rdf-metadata-extract-void/lib/Estimators.ts
@@ -14,6 +14,7 @@ export function getCardinality(dataset: IVoidDataset, operation: Algebra.Operati
     case Algebra.types.ORDER_BY:
     case Algebra.types.GROUP:
     case Algebra.types.CONSTRUCT:
+    case Algebra.types.ASK:
       return getCardinality(dataset, operation.input);
     case Algebra.types.PATTERN:
       return getPatternCardinality(dataset, operation);

--- a/packages/actor-rdf-metadata-extract-void/lib/Estimators.ts
+++ b/packages/actor-rdf-metadata-extract-void/lib/Estimators.ts
@@ -19,9 +19,10 @@ export function getCardinality(dataset: IVoidDataset, operation: Algebra.Operati
     case Algebra.types.PATTERN:
       return getPatternCardinality(dataset, operation);
     case Algebra.types.BGP:
-      return getJoinCardinality(dataset, operation.patterns);
+      return getUnionCardinality(dataset, operation.patterns);
     case Algebra.types.JOIN:
-      return getJoinCardinality(dataset, operation.input);
+    case Algebra.types.UNION:
+      return getUnionCardinality(dataset, operation.input);
     case Algebra.types.GRAPH:
       return getGraphCardinality(dataset, operation);
     case Algebra.types.FROM:
@@ -101,14 +102,12 @@ export function getGraphCardinality(dataset: IVoidDataset, graph: Algebra.Graph)
 }
 
 /**
- * Estimate the cardinality of a join, using a sum of the individual input cardinalities.
- * This should result in a somewhat acceptable estimate that will likely be above the probable join plan,
- * but still below an unreasonably high and unlikely cartesian estimate.
+ * Estimate the cardinality of a union, using a sum of the individual input cardinalities.
  */
-export function getJoinCardinality(dataset: IVoidDataset, operations: Algebra.Operation[]): RDF.QueryResultCardinality {
+export function getUnionCardinality(dataset: IVoidDataset, input: Algebra.Operation[]): RDF.QueryResultCardinality {
   const estimate: RDF.QueryResultCardinality = { type: 'exact', value: 0 };
-  for (const input of operations) {
-    const cardinality = getCardinality(dataset, input);
+  for (const operation of input) {
+    const cardinality = getCardinality(dataset, operation);
     if (cardinality.value > 0) {
       estimate.type = 'estimate';
       estimate.value += cardinality.value;

--- a/packages/actor-rdf-metadata-extract-void/test/Estimators-test.ts
+++ b/packages/actor-rdf-metadata-extract-void/test/Estimators-test.ts
@@ -103,6 +103,7 @@ describe('estimators', () => {
       Algebra.types.ORDER_BY,
       Algebra.types.GROUP,
       Algebra.types.CONSTRUCT,
+      Algebra.types.ASK,
     ])('should estimate cardinality for %s', (type) => {
       const operation = <Algebra.Operation>{ type, input: { type: 'fallback' }};
       expect(getCardinality(dataset, operation)).toEqual({

--- a/packages/actor-rdf-metadata-extract-void/test/Estimators-test.ts
+++ b/packages/actor-rdf-metadata-extract-void/test/Estimators-test.ts
@@ -12,7 +12,7 @@ import {
   getDistinctObjects,
   matchPatternVocabularies,
   matchPatternResourceUris,
-  getJoinCardinality,
+  getUnionCardinality,
   getGraphCardinality,
   getFromCardinality,
   getPatternCardinalityRaw,
@@ -200,14 +200,14 @@ describe('estimators', () => {
     });
   });
 
-  describe('getJoinCardinality', () => {
+  describe('getUnionCardinality', () => {
     it('should return 0 without any input', () => {
-      expect(getJoinCardinality(<any>'dataset', [])).toEqual({ type: 'exact', value: 0 });
+      expect(getUnionCardinality(<any>'dataset', [])).toEqual({ type: 'exact', value: 0 });
     });
 
     it('should return the sum of input', () => {
       const pattern = AF.createPattern(DF.variable('s'), DF.variable('p'), DF.variable('o'));
-      expect(getJoinCardinality(dataset, [ pattern ])).toEqual({ type: 'estimate', value: datasetTripleCount });
+      expect(getUnionCardinality(dataset, [ pattern ])).toEqual({ type: 'estimate', value: datasetTripleCount });
     });
   });
 


### PR DESCRIPTION
This is a small addition to the cardinality estimation functionality that allows the estimator to produce non-infinite values for `ASK` and `UNION`.