### PR TITLE
Changes to ActorQuerySourceIdentifyHypermediaSparql

### DIFF
--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
@@ -26,7 +26,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
   public readonly checkUrlSuffix: boolean;
   public readonly forceHttpGet: boolean;
   public readonly cacheSize: number;
-  public readonly forceSourceType: string;
+  public readonly forceSourceType: boolean;
   public readonly bindMethod: BindMethod;
   public readonly countTimeout: number;
 

--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
@@ -26,6 +26,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
   public readonly checkUrlSuffix: boolean;
   public readonly forceHttpGet: boolean;
   public readonly cacheSize: number;
+  public readonly forceSourceType: string;
   public readonly bindMethod: BindMethod;
   public readonly countTimeout: number;
 
@@ -36,7 +37,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
   public async testMetadata(
     action: IActionQuerySourceIdentifyHypermedia,
   ): Promise<TestResult<IActorQuerySourceIdentifyHypermediaTest>> {
-    if (!action.forceSourceType && !action.metadata.sparqlService &&
+    if (!action.forceSourceType && !this.forceSourceType && !action.metadata.sparqlService &&
       !(this.checkUrlSuffix && action.url.endsWith('/sparql'))) {
       return failTest(`Actor ${this.name} could not detect a SPARQL service description or URL ending on /sparql.`);
     }
@@ -49,7 +50,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
     const dataFactory: ComunicaDataFactory = action.context.getSafe(KeysInitQuery.dataFactory);
     const algebraFactory = new Factory(dataFactory);
     const source = new QuerySourceSparql(
-      action.forceSourceType ? action.url : action.metadata.sparqlService || action.url,
+      (action.forceSourceType ?? this.forceSourceType) ? action.url : action.metadata.sparqlService || action.url,
       action.context,
       this.mediatorHttp,
       this.bindMethod,
@@ -92,6 +93,11 @@ export interface IActorQuerySourceIdentifyHypermediaSparqlArgs extends IActorQue
    * @default {1024}
    */
   cacheSize?: number;
+  /**
+   * If provided, forces the source type of a source
+   * @default {false}
+   */
+  forceSourceType?: boolean;
   /**
    * The query operation for communicating bindings.
    * @default {values}

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
@@ -131,6 +131,48 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           .test({ url: 'URL/sparql', metadata: {}, quads: <any> null, forceSourceType: 'file', context }))
           .resolves.toFailTest('Actor actor is not able to handle source type file.');
       });
+
+      // Added tests
+      it('should test with a forced sparql source type via actor parameter', async() => {
+        actor = new ActorQuerySourceIdentifyHypermediaSparql({
+          name: 'actor',
+          bus,
+          mediatorHttp: <any>'mediator',
+          checkUrlSuffix: false,
+          forceHttpGet: false,
+          forceSourceType: true,
+          bindMethod: 'values',
+          countTimeout: 3_000,
+          mediatorMergeBindingsContext,
+        });
+        await expect(actor.test({
+          url: 'URL',
+          metadata: {},
+          quads: <any> null,
+          context,
+        })).resolves
+          .toPassTest({ filterFactor: 1 });
+      });
+
+      it('should not test without a forced sparql source type via actor parameter', async() => {
+        actor = new ActorQuerySourceIdentifyHypermediaSparql({
+          name: 'actor',
+          bus,
+          mediatorHttp: <any>'mediator',
+          checkUrlSuffix: false,
+          forceHttpGet: false,
+          bindMethod: 'values',
+          countTimeout: 3_000,
+          mediatorMergeBindingsContext,
+        });
+        await expect(actor.test({
+          url: 'URL',
+          metadata: {},
+          quads: <any> null,
+          context,
+        })).resolves
+          .toFailTest('Actor actor could not detect a SPARQL service description or URL ending on /sparql.');
+      });
     });
 
     describe('#run', () => {

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
@@ -131,8 +131,6 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           .test({ url: 'URL/sparql', metadata: {}, quads: <any> null, forceSourceType: 'file', context }))
           .resolves.toFailTest('Actor actor is not able to handle source type file.');
       });
-
-      // Added tests
       it('should test with a forced sparql source type via actor parameter', async() => {
         actor = new ActorQuerySourceIdentifyHypermediaSparql({
           name: 'actor',


### PR DESCRIPTION
Added the `forceSourceType?: boolean` arg to the `ActorQuerySourceIdentifyHypermediaSparql` actor. 

This arg allows the passing of a `Boolean` value to force all sources to be interpreted as SPARQL Endpoints. 

Along with the addition of this argument, also added unit tests to extend 100% test coverage. 