### PR TITLE
Rework SPARQL source cardinality estimation to cache pattern counts

### DIFF
--- a/packages/actor-query-source-identify-hypermedia-sparql/README.md
+++ b/packages/actor-query-source-identify-hypermedia-sparql/README.md
@@ -46,4 +46,4 @@ After installing, this package can be added to your engine's configuration as fo
 * `bindMethod`: The query operation for communicating bindings, defaults to `'values'`, alt: `'union'` or `'filter'`.
 * `countTimeout`: Timeout in ms of how long count queries are allowed to take. If the timeout is reached, an infinity cardinality is returned. Defaults to `3000`.
 * `cardinalityCountQueries`: If count queries should be sent to obtain the cardinality of (sub)queries. If set to false, resulting cardinalities will always be considered infinity. Defaults to `true`
-* `cardinalityEstimateConstruction`: If cardinality estimates for larger queries should be constructed locally from (sub)query cardinalities when possible. Defaults to `false`. If set to false, count queries will be sent for every operation.
+* `cardinalityEstimateConstruction`: If cardinality estimates for larger queries should be constructed locally from (sub)query cardinalities when possible. Defaults to `false`. If set to false, count queries will be sent for every operation at all levels.

--- a/packages/actor-query-source-identify-hypermedia-sparql/README.md
+++ b/packages/actor-query-source-identify-hypermedia-sparql/README.md
@@ -46,3 +46,4 @@ After installing, this package can be added to your engine's configuration as fo
 * `bindMethod`: The query operation for communicating bindings, defaults to `'values'`, alt: `'union'` or `'filter'`.
 * `countTimeout`: Timeout in ms of how long count queries are allowed to take. If the timeout is reached, an infinity cardinality is returned. Defaults to `3000`.
 * `cardinalityCountQueries`: If count queries should be sent to obtain the cardinality of (sub)queries. If set to false, resulting cardinalities will always be considered infinity. Defaults to `true`
+* `cardinalityEstimateConstruction`: If cardinality estimates for larger queries should be constructed locally from (sub)query cardinalities when possible. Defaults to `false`. If set to false, count queries will be sent for every operation.

--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
@@ -30,6 +30,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
   public readonly bindMethod: BindMethod;
   public readonly countTimeout: number;
   public readonly cardinalityCountQueries: boolean;
+  public readonly cardinalityEstimateConstruction: boolean;
 
   public constructor(args: IActorQuerySourceIdentifyHypermediaSparqlArgs) {
     super(args, 'sparql');
@@ -62,6 +63,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
       this.cacheSize,
       this.countTimeout,
       this.cardinalityCountQueries,
+      this.cardinalityEstimateConstruction,
       action.metadata.defaultGraph,
       action.metadata.unionDefaultGraph,
       action.metadata.datasets,
@@ -117,6 +119,12 @@ export interface IActorQuerySourceIdentifyHypermediaSparqlArgs extends IActorQue
    * @default {true}
    */
   cardinalityCountQueries: boolean;
+  /**
+   * If estimates for queries should be constructed locally from sub-query cardinalities.
+   * If set to false, count queries will used for cardinality estimation at all levels.
+   * @default {false}
+   */
+  cardinalityEstimateConstruction: boolean;
 }
 
 export type BindMethod = 'values' | 'union' | 'filter';

--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
@@ -16,14 +16,15 @@ import type {
 } from '@comunica/types';
 import type { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { MetadataValidationState } from '@comunica/utils-metadata';
+import { estimateCardinality } from '@comunica/utils-query-operation';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { TransformIterator, wrap } from 'asynciterator';
 import { SparqlEndpointFetcher } from 'fetch-sparql-endpoint';
 import { LRUCache } from 'lru-cache';
 import { uniqTerms } from 'rdf-terms';
-import type { Factory, Algebra } from 'sparqlalgebrajs';
-import { toSparql, Util } from 'sparqlalgebrajs';
+import type { Factory } from 'sparqlalgebrajs';
+import { toSparql, Algebra, Util } from 'sparqlalgebrajs';
 import type { BindMethod } from './ActorQuerySourceIdentifyHypermediaSparql';
 
 export class QuerySourceSparql implements IQuerySource {
@@ -45,6 +46,7 @@ export class QuerySourceSparql implements IQuerySource {
   private readonly bindMethod: BindMethod;
   private readonly countTimeout: number;
   private readonly cardinalityCountQueries: boolean;
+  private readonly cardinalityEstimateConstruction: boolean;
   private readonly defaultGraph?: string;
   private readonly unionDefaultGraph: boolean;
   private readonly datasets?: IDataset[];
@@ -69,6 +71,7 @@ export class QuerySourceSparql implements IQuerySource {
     cacheSize: number,
     countTimeout: number,
     cardinalityCountQueries: boolean,
+    cardinalityEstimateConstruction: boolean,
     defaultGraph?: string,
     unionDefaultGraph?: boolean,
     datasets?: IDataset[],
@@ -94,6 +97,7 @@ export class QuerySourceSparql implements IQuerySource {
       undefined;
     this.countTimeout = countTimeout;
     this.cardinalityCountQueries = cardinalityCountQueries;
+    this.cardinalityEstimateConstruction = cardinalityEstimateConstruction;
     this.defaultGraph = defaultGraph;
     this.unionDefaultGraph = unionDefaultGraph ?? false;
     this.datasets = datasets;
@@ -179,12 +183,10 @@ export class QuerySourceSparql implements IQuerySource {
     let variablesCount: MetadataVariable[] = [];
     // eslint-disable-next-line no-async-promise-executor,ts/no-misused-promises
     new Promise<QueryResultCardinality>(async(resolve, reject) => {
-      // Prepare queries
-      let countQuery: string;
       try {
         const operation = await operationPromise;
         const variablesScoped = Util.inScopeVariables(operation);
-        countQuery = QuerySourceSparql.operationToCountQuery(this.dataFactory, this.algebraFactory, operation);
+        const countQuery = this.operationToNormalizedCountQuery(operation);
         const undefVariables = QuerySourceSparql.getOperationUndefs(operation);
         variablesCount = variablesScoped.map(variable => ({
           variable,
@@ -196,11 +198,14 @@ export class QuerySourceSparql implements IQuerySource {
           return resolve(cachedCardinality);
         }
 
-        // Attempt to estimate locally prior to sending a COUNT request, as this should be much faster
-        const localEstimate = await this.estimateCardinality(operation);
-        if (localEstimate && Number.isFinite(localEstimate.value)) {
-          this.cache?.set(countQuery, localEstimate);
-          return resolve(localEstimate);
+        // Attempt to estimate locally prior to sending a COUNT request, as this should be much faster.
+        // The estimates may be off by varyind amounts, so this is set behind a configuration flag.
+        if (this.cardinalityEstimateConstruction) {
+          const localEstimate = await this.estimateOperationCardinality(operation);
+          if (Number.isFinite(localEstimate.value)) {
+            this.cache?.set(countQuery, localEstimate);
+            return resolve(localEstimate);
+          }
         }
 
         // Don't send count queries if disabled.
@@ -261,31 +266,61 @@ export class QuerySourceSparql implements IQuerySource {
   }
 
   /**
+   * Convert an algebra operation into a query string, and if the operation is a simple triple pattern,
+   * then also replace any variables with s, p, and o to increase the chance of cache hits.
+   * @param {Algebra.Operation} operation The operation to convert into a query string.
+   * @returns {string} Query string for a COUNT query over the operation.
+   */
+  public operationToNormalizedCountQuery(operation: Algebra.Operation): string {
+    const normalizedOperation = operation.type === Algebra.types.PATTERN ?
+      this.algebraFactory.createPattern(
+        operation.subject.termType === 'Variable' ? this.dataFactory.variable('s') : operation.subject,
+        operation.predicate.termType === 'Variable' ? this.dataFactory.variable('p') : operation.predicate,
+        operation.object.termType === 'Variable' ? this.dataFactory.variable('o') : operation.object,
+      ) :
+      operation;
+    const operationString = QuerySourceSparql.operationToCountQuery(
+      this.dataFactory,
+      this.algebraFactory,
+      normalizedOperation,
+    );
+    return operationString;
+  }
+
+  /**
    * Performs local cardinality estimation for the specified SPARQL algebra operation, which should
    * result in better estimation performance at the expense of accuracy.
    * @param {Algebra.Operation} operation A query operation.
    */
-  public async estimateCardinality(operation: Algebra.Operation): Promise<QueryResultCardinality | undefined> {
-    if (this.datasets) {
-      // Try to estimate the cardinality on the default graph if possible.
-      if (this.defaultGraph) {
-        const defaultDataset = this.datasets.find(ds => ds.uri.endsWith(this.defaultGraph!));
-        if (defaultDataset) {
-          return defaultDataset.getCardinality(operation);
-        }
-      }
+  public async estimateOperationCardinality(operation: Algebra.Operation): Promise<QueryResultCardinality> {
+    const dataset: IDataset = {
+      getCardinality: (operation: Algebra.Operation): QueryResultCardinality | undefined => {
+        const queryString = this.operationToNormalizedCountQuery(operation);
 
-      // When metadata for the default graph is not availble directly, sum up the other graphs
-      // when UnionDefaultGraph has been declared for the SPARQL endpoint.
-      if (this.unionDefaultGraph) {
-        const cardinalities = await Promise.all(this.datasets.map(ds => ds.getCardinality(operation)));
-        return {
-          type: cardinalities.some(card => card.type === 'estimate') ? 'estimate' : 'exact',
-          value: cardinalities.reduce((acc, card) => acc + card.value, 0),
-          dataset: this.url,
-        };
-      }
-    }
+        const cachedCardinality = this.cache?.get(queryString);
+        if (cachedCardinality) {
+          return cachedCardinality;
+        }
+
+        if (this.datasets) {
+          const cardinalities = this.datasets
+            .filter(ds => this.unionDefaultGraph || (this.defaultGraph && ds.uri.endsWith(this.defaultGraph)))
+            .map(ds => estimateCardinality(operation, ds));
+
+          const cardinality: QueryResultCardinality = {
+            type: cardinalities.some(card => card.type === 'estimate') ? 'estimate' : 'exact',
+            value: cardinalities.length > 0 ? cardinalities.reduce((acc, card) => acc + card.value, 0) : 0,
+            dataset: this.url,
+          };
+
+          return cardinality;
+        }
+      },
+      source: this.url,
+      uri: this.url,
+    };
+
+    return estimateCardinality(operation, dataset);
   }
 
   /**

--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
@@ -199,7 +199,7 @@ export class QuerySourceSparql implements IQuerySource {
         }
 
         // Attempt to estimate locally prior to sending a COUNT request, as this should be much faster.
-        // The estimates may be off by varyind amounts, so this is set behind a configuration flag.
+        // The estimates may be off by varying amounts, so this is set behind a configuration flag.
         if (this.cardinalityEstimateConstruction) {
           const localEstimate = await this.estimateOperationCardinality(operation);
           if (Number.isFinite(localEstimate.value)) {

--- a/packages/actor-query-source-identify-hypermedia-sparql/package.json
+++ b/packages/actor-query-source-identify-hypermedia-sparql/package.json
@@ -49,6 +49,7 @@
     "@comunica/types": "^4.1.0",
     "@comunica/utils-bindings-factory": "^4.1.0",
     "@comunica/utils-metadata": "^4.1.0",
+    "@comunica/utils-query-operation": "^4.1.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.9.0",
     "fetch-sparql-endpoint": "^5.1.0",

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
@@ -56,6 +56,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
         bindMethod: 'values',
         countTimeout: 3_000,
         cardinalityCountQueries: true,
+        cardinalityEstimateConstruction: false,
       });
     });
 
@@ -113,6 +114,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           countTimeout: 3_000,
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
+          cardinalityEstimateConstruction: false,
         });
         await expect(actor.test({ url: 'URL/sparql', metadata: {}, quads: <any> null, context })).resolves
           .toFailTest('Actor actor could not detect a SPARQL service description or URL ending on /sparql.');
@@ -129,6 +131,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           countTimeout: 3_000,
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
+          cardinalityEstimateConstruction: false,
         });
         await expect(actor
           .test({ url: 'URL/sparql', metadata: {}, quads: <any> null, forceSourceType: 'file', context }))
@@ -146,6 +149,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           countTimeout: 3_000,
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
+          cardinalityEstimateConstruction: false,
         });
         await expect(actor.test({
           url: 'URL',
@@ -167,6 +171,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           countTimeout: 3_000,
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
+          cardinalityEstimateConstruction: false,
         });
         await expect(actor.test({
           url: 'URL',

--- a/packages/actor-rdf-metadata-extract-void/test/ActorRdfMetadataExtractVoid-test.ts
+++ b/packages/actor-rdf-metadata-extract-void/test/ActorRdfMetadataExtractVoid-test.ts
@@ -145,7 +145,7 @@ describe('ActorRdfMetadataExtractVoid', () => {
         }))?.metadata?.datasets.at(0);
         expect(dataset).toBeDefined();
         const pattern = AF.createPattern(DF.variable('s'), DF.variable('p'), DF.variable('o'));
-        await expect(dataset!.getCardinality(pattern)).resolves.toEqual({
+        expect(dataset!.getCardinality(pattern)).toEqual({
           type: 'estimate',
           value: tripleCount,
           dataset: sparqlEndpoint.value,

--- a/packages/types/lib/IDataset.ts
+++ b/packages/types/lib/IDataset.ts
@@ -19,5 +19,5 @@ export interface IDataset {
    * @param {Algebra.Operation} operation SPARQL algebra operation.
    * @returns {QueryResultCardinality} Upper bound for the cardinality.
    */
-  getCardinality: (operation: Algebra.Operation) => Promise<QueryResultCardinality>;
+  getCardinality: (operation: Algebra.Operation) => QueryResultCardinality | undefined;
 }

--- a/packages/utils-query-operation/lib/CardinalityEstimators.ts
+++ b/packages/utils-query-operation/lib/CardinalityEstimators.ts
@@ -1,0 +1,188 @@
+import type { IDataset, QueryResultCardinality } from '@comunica/types';
+import { DataFactory } from 'rdf-data-factory';
+import { Algebra, Factory, Util } from 'sparqlalgebrajs';
+
+// These are only used internally for estimates
+const DF = new DataFactory();
+const AF = new Factory(DF);
+
+/**
+ * Estimate the cardinality of the provided operation using the specified dataset metadata.
+ * This is the primary function that should be called to perform cardinality estimation.
+ */
+export function estimateCardinality(
+  operation: Algebra.Operation,
+  dataset: IDataset,
+): QueryResultCardinality {
+  const estimate = dataset.getCardinality(operation);
+
+  if (estimate) {
+    return estimate;
+  }
+
+  switch (operation.type) {
+    case Algebra.types.ASK:
+      return { type: 'exact', value: 1, dataset: dataset.uri };
+    case Algebra.types.LOAD:
+    case Algebra.types.DELETE_INSERT:
+    case Algebra.types.ADD:
+    case Algebra.types.COMPOSITE_UPDATE:
+    case Algebra.types.CLEAR:
+    case Algebra.types.NOP:
+    case Algebra.types.DROP:
+    case Algebra.types.CREATE:
+    case Algebra.types.MOVE:
+    case Algebra.types.COPY:
+      return { type: 'exact', value: 0, dataset: dataset.uri };
+    case Algebra.types.PROJECT:
+    case Algebra.types.FILTER:
+    case Algebra.types.ORDER_BY:
+    case Algebra.types.GROUP:
+    case Algebra.types.CONSTRUCT:
+    case Algebra.types.DISTINCT:
+    case Algebra.types.REDUCED:
+    case Algebra.types.EXTEND:
+    case Algebra.types.FROM:
+    case Algebra.types.GRAPH:
+      return estimateCardinality(operation.input, dataset);
+    case Algebra.types.ZERO_OR_ONE_PATH:
+    case Algebra.types.ZERO_OR_MORE_PATH:
+    case Algebra.types.ONE_OR_MORE_PATH:
+    case Algebra.types.INV:
+      return estimateCardinality(operation.path, dataset);
+    case Algebra.types.PATH:
+      return estimateCardinality(operation.predicate, dataset);
+    case Algebra.types.NPS:
+      return estimateNpsCardinality(operation, dataset);
+    case Algebra.types.LINK:
+      return estimateCardinality(AF.createPattern(DF.variable('s'), operation.iri, DF.variable('o')), dataset);
+    case Algebra.types.UNION:
+    case Algebra.types.SEQ:
+    case Algebra.types.ALT:
+      return estimateUnionCardinality(operation.input, dataset);
+    case Algebra.types.BGP:
+      return estimateJoinCardinality(operation.patterns, dataset);
+    case Algebra.types.JOIN:
+    case Algebra.types.LEFT_JOIN:
+      return estimateJoinCardinality(operation.input, dataset);
+    case Algebra.types.SLICE:
+      return estimateSliceCardinality(operation, dataset);
+    case Algebra.types.MINUS:
+      return estimateMinusCardinality(operation, dataset);
+    case Algebra.types.VALUES:
+      return { type: 'exact', value: operation.bindings.length, dataset: dataset.uri };
+    case Algebra.types.SERVICE:
+    case Algebra.types.DESCRIBE:
+    case Algebra.types.EXPRESSION:
+    case Algebra.types.PATTERN:
+      return { type: 'estimate', value: Number.POSITIVE_INFINITY, dataset: dataset.uri };
+  }
+}
+
+/**
+ * Estimate the cardinality of a minus, by taking into account the input cardinalities.
+ */
+export function estimateMinusCardinality(
+  minus: Algebra.Minus,
+  dataset: IDataset,
+): QueryResultCardinality {
+  const estimateFirst = estimateCardinality(minus.input[0], dataset);
+  const estimateSecond = estimateCardinality(minus.input[1], dataset);
+  return {
+    type: 'estimate',
+    value: Math.max(estimateFirst.value - estimateSecond.value, 0),
+    dataset: dataset.uri,
+  };
+}
+
+/**
+ * Estimate the cardinality of a slice operation, taking into account the input cardinality and the slice range.
+ */
+export function estimateSliceCardinality(
+  slice: Algebra.Slice,
+  dataset: IDataset,
+): QueryResultCardinality {
+  const estimate = estimateCardinality(slice.input, dataset);
+  if (estimate.value > 0) {
+    estimate.value = Math.max(estimate.value - slice.start, 0);
+    if (slice.length !== undefined) {
+      estimate.value = Math.min(estimate.value, slice.length);
+    }
+  }
+  return estimate;
+}
+
+/**
+ * Estimate the cardinality of a union, using a sum of the individual input cardinalities.
+ */
+export function estimateUnionCardinality(
+  input: Algebra.Operation[],
+  dataset: IDataset,
+): QueryResultCardinality {
+  const estimate: QueryResultCardinality = { type: 'exact', value: 0, dataset: dataset.uri };
+  for (const operation of input) {
+    const cardinality = estimateCardinality(operation, dataset);
+    if (cardinality.type === 'estimate' && estimate.type === 'exact') {
+      estimate.type = cardinality.type;
+    }
+    if (cardinality.value > 0) {
+      estimate.value += cardinality.value;
+    }
+  }
+  return estimate;
+}
+
+/**
+ * Estimate the cardinality of a join. This estimation is done by:
+ *  1. Grouping operations together based on variables.
+ *  2. Selecting the minimum op cardinality in each group as the cardinality of that group.
+ *  3. Multiplying cardinalities of these (detached) groups.
+ *
+ * This should provide a good balance between selective groups of operations,
+ * as well as cartesian joins between groups that do not overlap.
+ */
+export function estimateJoinCardinality(
+  operations: Algebra.Operation[],
+  dataset: IDataset,
+): QueryResultCardinality {
+  const operationGroups: { ops: Algebra.Operation[]; vars: Set<string> }[] = [];
+  for (const operation of operations) {
+    const vars = Util.inScopeVariables(operation).map(v => v.value);
+    const group = operationGroups.find(g => vars.some(v => g.vars.has(v)));
+    if (group) {
+      group.ops.push(operation);
+      for (const v of vars) {
+        group.vars.add(v);
+      }
+    } else {
+      operationGroups.push({ ops: [ operation ], vars: new Set(vars) });
+    }
+  }
+  const cardinality: QueryResultCardinality = {
+    type: 'estimate',
+    value: operationGroups
+      .map(g => Math.min(...g.ops.map(o => estimateCardinality(o, dataset).value)))
+      .reduce((acc, cur) => acc * cur, 1),
+    dataset: dataset.uri,
+  };
+  return cardinality;
+}
+
+/**
+ * Estimate the cardinality of a negated property set, by subtracting the non-inversed
+ * estimate from the total number of triples.
+ */
+export function estimateNpsCardinality(
+  nps: Algebra.Nps,
+  dataset: IDataset,
+): QueryResultCardinality {
+  const seq = AF.createSeq([ ...nps.iris ].reverse().map(iri => AF.createLink(iri)));
+  const seqCardinality = estimateCardinality(seq, dataset);
+  const pattern = AF.createPattern(DF.variable('s'), DF.variable('p'), DF.variable('o'));
+  const patternCardinality = estimateCardinality(pattern, dataset);
+  return {
+    type: 'estimate',
+    value: Math.max(0, patternCardinality.value - seqCardinality.value),
+    dataset: dataset.uri,
+  };
+}

--- a/packages/utils-query-operation/lib/index.ts
+++ b/packages/utils-query-operation/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './CardinalityEstimators';
 export * from './FragmentSelectorShapes';
 export * from './Utils';
 export * from './MaterializeBindings';

--- a/packages/utils-query-operation/package.json
+++ b/packages/utils-query-operation/package.json
@@ -45,6 +45,7 @@
     "@comunica/types": "^4.1.0",
     "@comunica/utils-bindings-factory": "^4.1.0",
     "@rdfjs/types": "*",
+    "rdf-data-factory": "^1.1.2",
     "rdf-string": "^1.6.1",
     "rdf-terms": "^1.11.0",
     "sparqlalgebrajs": "^4.3.8"

--- a/packages/utils-query-operation/test/CardinalityEstimators-test.ts
+++ b/packages/utils-query-operation/test/CardinalityEstimators-test.ts
@@ -1,0 +1,271 @@
+import type { IDataset, QueryResultCardinality } from '@comunica/types';
+import { DataFactory } from 'rdf-data-factory';
+import { Factory, Algebra } from 'sparqlalgebrajs';
+import {
+  estimateCardinality,
+  estimateUnionCardinality,
+} from '../lib/CardinalityEstimators';
+
+const DF = new DataFactory();
+const AF = new Factory(DF);
+
+describe('CardinalityEstimators', () => {
+  let dataset: IDataset;
+  const datasetUri = 'http://localhost/sparql';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    dataset = {
+      getCardinality: jest.fn().mockImplementation(
+        (operation: Algebra.Operation): QueryResultCardinality | undefined => {
+          if (operation.type === Algebra.types.PATTERN) {
+            return { type: 'estimate', value: 2, dataset: datasetUri };
+          }
+        },
+      ),
+      source: datasetUri,
+      uri: datasetUri,
+    };
+  });
+
+  describe('estimateCardinality', () => {
+    const namedNode = DF.namedNode('ex:p');
+    const pattern1 = AF.createPattern(DF.variable('s'), DF.variable('p1'), DF.variable('o1'));
+    const pattern2 = AF.createPattern(DF.variable('s'), DF.variable('p2'), DF.variable('o2'));
+
+    it('should return 1 for ask', () => {
+      const operation = <Algebra.Operation>{ type: Algebra.types.ASK };
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'exact',
+        value: 1,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(1);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+    });
+
+    it.each([
+      Algebra.types.LOAD,
+      Algebra.types.DELETE_INSERT,
+      Algebra.types.ADD,
+      Algebra.types.COMPOSITE_UPDATE,
+      Algebra.types.CLEAR,
+      Algebra.types.NOP,
+      Algebra.types.DROP,
+      Algebra.types.CREATE,
+      Algebra.types.MOVE,
+      Algebra.types.COPY,
+    ])('should return exact 0 for %s', (type) => {
+      const operation = <Algebra.Operation>{ type };
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'exact',
+        value: 0,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(1);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+    });
+
+    it.each([
+      Algebra.types.SERVICE,
+      Algebra.types.DESCRIBE,
+      Algebra.types.EXPRESSION,
+    ])('should return estimated infinity for %s', (type) => {
+      const operation = <Algebra.Operation>{ type };
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: Number.POSITIVE_INFINITY,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(1);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+    });
+
+    it.each([
+      Algebra.types.PROJECT,
+      Algebra.types.FILTER,
+      Algebra.types.ORDER_BY,
+      Algebra.types.GROUP,
+      Algebra.types.CONSTRUCT,
+      Algebra.types.DISTINCT,
+      Algebra.types.REDUCED,
+      Algebra.types.EXTEND,
+      Algebra.types.FROM,
+      Algebra.types.GRAPH,
+    ])('should return estimate for %s using input', (type) => {
+      const operation = <Algebra.Operation>{ type, input: pattern1 };
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 2,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(2);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.input);
+    });
+
+    it.each([
+      Algebra.types.ZERO_OR_ONE_PATH,
+      Algebra.types.ZERO_OR_MORE_PATH,
+      Algebra.types.ONE_OR_MORE_PATH,
+      Algebra.types.INV,
+    ])('should return estimate for %s using path', (type) => {
+      const operation = <Algebra.Operation>{ type, path: pattern1 };
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 2,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(2);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.path);
+    });
+
+    it.each([
+      Algebra.types.UNION,
+      Algebra.types.SEQ,
+      Algebra.types.ALT,
+    ])('should return estimate for %s using input', (type) => {
+      const operation = <Algebra.Operation>{ type, input: [ pattern1, pattern2 ]};
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 4,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(3);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.input[0]);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(3, operation.input[1]);
+    });
+
+    it('should return estimate for join', () => {
+      const input = [ pattern1, pattern2 ];
+      const operation = <Algebra.Operation>{ type: Algebra.types.JOIN, input };
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 2,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(3);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.input[0]);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(3, operation.input[1]);
+    });
+
+    it('should return estimate for bgp', () => {
+      const patterns = [ pattern1, pattern2 ];
+      const operation = <Algebra.Operation>{ type: Algebra.types.BGP, patterns };
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 2,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(3);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.patterns[0]);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(3, operation.patterns[1]);
+    });
+
+    it('should return estimate for slice', () => {
+      const operation = AF.createSlice(pattern1, 1, 2);
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 1,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(2);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.input);
+    });
+
+    it('should return estimate for minus', () => {
+      const operation = AF.createMinus(pattern1, pattern2);
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 0,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(3);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.input[0]);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(3, operation.input[1]);
+    });
+
+    it('should return estimate for pattern', () => {
+      const operation = pattern1;
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 2,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(1);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+    });
+
+    it('should return estimate for nps', () => {
+      const operation = AF.createNps([ namedNode ]);
+      const expectedLink = AF.createLink(namedNode);
+      const expectedSeq = AF.createSeq([ expectedLink ]);
+      const expectedTotalPattern = AF.createPattern(DF.variable('s'), DF.variable('p'), DF.variable('o'));
+      const expectedLinkPattern = AF.createPattern(DF.variable('s'), namedNode, DF.variable('o'));
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 0,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(5);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, expectedSeq);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(3, expectedLink);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(4, expectedLinkPattern);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(5, expectedTotalPattern);
+    });
+
+    it('should return estimate for path', () => {
+      const expectedPredicatePattern = AF.createPattern(DF.variable('s'), namedNode, DF.variable('o'));
+      const operation = AF.createPath(pattern1.subject, AF.createLink(namedNode), pattern1.object);
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'estimate',
+        value: 2,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(3);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(2, operation.predicate);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(3, expectedPredicatePattern);
+    });
+
+    it.each([ 0, 1, 10 ])(`should return estimate for ${Algebra.types.VALUES} with %d bindings`, (count) => {
+      const operation = <Algebra.Operation>{ type: Algebra.types.VALUES, bindings: { length: count }};
+      expect(estimateCardinality(operation, dataset)).toEqual({
+        type: 'exact',
+        value: count,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenCalledTimes(1);
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, operation);
+    });
+  });
+
+  describe('estimateUnionCardinality', () => {
+    it('should return 0 without any input', () => {
+      expect(estimateUnionCardinality([], dataset)).toEqual({
+        type: 'exact',
+        value: 0,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).not.toHaveBeenCalled();
+    });
+
+    it('should return the sum of input', () => {
+      const pattern = AF.createPattern(DF.variable('s'), DF.variable('p'), DF.variable('o'));
+      expect(estimateUnionCardinality([ pattern ], dataset)).toEqual({
+        type: 'estimate',
+        value: 2,
+        dataset: datasetUri,
+      });
+      expect(dataset.getCardinality).toHaveBeenNthCalledWith(1, pattern);
+    });
+  });
+});


### PR DESCRIPTION
This is the set of changes that are needed to use cached `COUNT` query results for SPARQL source cardinality estimation, even without VoID metadata available. The main change here is splitting the cardinality estimation from VoID metadata into two parts:
* Triple pattern cardinality estimates, provided by VoID, based on the formulae from Hagedorn et al. with some vocabulary-based heuristics applied on top.
* Operation cardinality estimates, moved to `utils-query-operation` that break down larger operations down to triple pattern level, and then use pattern cardinalities to construct the higher-level cardinality estimate. This involves some purpose-built heuristics at the moment, but ideally this logic would later be moved into a separate cardinality estimation bus or something for more flexibility and easier implementation.

After these changes, the `QuerySourceSparql` actor uses cached triple pattern cardinalities from `COUNT` queries (done during planning phase) to reconstruct higher-level operation cardinalities when possible, and avoids a lot of larger `COUNT` queries during execution as a result.

With VoID metadata available, the reduction in `COUNT` queries is even bigger. :slightly_smiling_face: