### PR TITLE
small changes to actor-query-source-hypermedia-identify-sparql configs

### DIFF
--- a/engines/config-query-sparql/config/query-source-identify-hypermedia/actors-sparql.json
+++ b/engines/config-query-sparql/config/query-source-identify-hypermedia/actors-sparql.json
@@ -8,7 +8,7 @@
   "@type": "Runner",
   "actors": [
     {
-      "@id": "urn:comunica:default:rdf-resolve-quad-pattern/actors#sparql",
+      "@id": "urn:comunica:default:query-source-identify-hypermedia/actors#sparql",
       "@type": "ActorQuerySourceIdentifyHypermediaSparql",
       "mediatorHttp": { "@id": "urn:comunica:default:http/mediators#main" },
       "mediatorMergeBindingsContext": { "@id": "urn:comunica:default:merge-bindings-context/mediators#main" }

--- a/engines/config-query-sparql/config/query-source-identify-hypermedia/actors.json
+++ b/engines/config-query-sparql/config/query-source-identify-hypermedia/actors.json
@@ -18,7 +18,7 @@
       "mediatorMergeBindingsContext": { "@id": "urn:comunica:default:merge-bindings-context/mediators#main" }
     },
     {
-      "@id": "urn:comunica:default:rdf-resolve-quad-pattern/actors#sparql",
+      "@id": "urn:comunica:default:query-source-identify-hypermedia/actors#sparql",
       "@type": "ActorQuerySourceIdentifyHypermediaSparql",
       "mediatorHttp": { "@id": "urn:comunica:default:http/mediators#main" },
       "mediatorMergeBindingsContext": { "@id": "urn:comunica:default:merge-bindings-context/mediators#main" }

--- a/packages/actor-query-source-identify-hypermedia-sparql/README.md
+++ b/packages/actor-query-source-identify-hypermedia-sparql/README.md
@@ -42,7 +42,7 @@ After installing, this package can be added to your engine's configuration as fo
 * `mediatorMergeBindingsContext`: A mediator over the [Merge Bindings Context bus](https://github.com/comunica/comunica/tree/master/packages/bus-merge-bindings-context).
 * `checkUrlSuffix`: If URLs ending with '/sparql' should also be considered SPARQL endpoints, defaults to `true`.
 * `forceHttpGet`: If queries should be sent via HTTP GET instead of POST, defaults to `false`.
-* `forceSourceType`: Forces all sources provided to be interpreted as SPARQL enpooints, defaults to `false`.
+* `forceSourceType`: Forces all sources provided to be interpreted as SPARQL endpoints, defaults to `false`.
 * `cacheSize`: The cache size for COUNT queries, defaults to `1024`.
 * `bindMethod`: The query operation for communicating bindings, defaults to `'values'`, alt: `'union'` or `'filter'`.
 * `countTimeout`: Timeout in ms of how long count queries are allowed to take. If the timeout is reached, an infinity cardinality is returned. Defaults to `3000`.

--- a/packages/actor-query-source-identify-hypermedia-sparql/README.md
+++ b/packages/actor-query-source-identify-hypermedia-sparql/README.md
@@ -42,6 +42,7 @@ After installing, this package can be added to your engine's configuration as fo
 * `mediatorMergeBindingsContext`: A mediator over the [Merge Bindings Context bus](https://github.com/comunica/comunica/tree/master/packages/bus-merge-bindings-context).
 * `checkUrlSuffix`: If URLs ending with '/sparql' should also be considered SPARQL endpoints, defaults to `true`.
 * `forceHttpGet`: If queries should be sent via HTTP GET instead of POST, defaults to `false`.
+* `forceSourceType`: Forces all sources provided to be interpreted as SPARQL enpooints, defaults to `false`.
 * `cacheSize`: The cache size for COUNT queries, defaults to `1024`.
 * `bindMethod`: The query operation for communicating bindings, defaults to `'values'`, alt: `'union'` or `'filter'`.
 * `countTimeout`: Timeout in ms of how long count queries are allowed to take. If the timeout is reached, an infinity cardinality is returned. Defaults to `3000`.


### PR DESCRIPTION
Added the `forceSourceType` config parameter to the ReadMe.

Changed the path of `"@id": "urn:comunica:default:query-source-identify-hypermedia/actors#sparql"` to `"@id": "urn:comunica:default:query-source-identify-hypermedia/actors#sparql"` in configs within `query-source-identify-hypermedia` in the engine `query-sparql-config` to reflect current config structure. 