### PR TITLE
Fix variable names in empty operations pruning actor

### DIFF
--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
@@ -57,7 +57,7 @@ export class ActorOptimizeQueryOperationPruneEmptySourceOperations extends Actor
     const emptyOperations: Set<Algebra.Operation> = new Set();
     await Promise.all(collectedOperations.map(async(collectedOperation) => {
       const checkOperation = collectedOperation.type === 'link' ?
-        algebraFactory.createPattern(dataFactory.variable('?s'), collectedOperation.iri, dataFactory.variable('?o')) :
+        algebraFactory.createPattern(dataFactory.variable('s'), collectedOperation.iri, dataFactory.variable('o')) :
         collectedOperation;
       if (!await this.hasSourceResults(
         algebraFactory,


### PR DESCRIPTION
This is a fix for what appears to be a typo, where the variable names have an additional `?` in front of them, when there should be none. This issue was discovered by @ecrum19 during their experiments.