### PR TITLE
Move primary Webpack config back to actor-init-query

### DIFF
--- a/engines/query-sparql-file/webpack.config.ts
+++ b/engines/query-sparql-file/webpack.config.ts
@@ -1,3 +1,3 @@
-import { createConfig } from '../../webpack.config';
+import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(__dirname);
+export default createConfig(import.meta.dirname);

--- a/engines/query-sparql-rdfjs-lite/webpack.config.ts
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.ts
@@ -1,6 +1,6 @@
-import { createConfig } from '../../webpack.config';
+import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-const liteConfig = createConfig(__dirname);
+const liteConfig = createConfig(import.meta.dirname);
 
 if (typeof liteConfig.performance === 'object') {
   liteConfig.performance.maxAssetSize = 915_000;

--- a/engines/query-sparql-rdfjs/webpack.config.ts
+++ b/engines/query-sparql-rdfjs/webpack.config.ts
@@ -1,3 +1,3 @@
-import { createConfig } from '../../webpack.config';
+import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(__dirname);
+export default createConfig(import.meta.dirname);

--- a/engines/query-sparql/webpack.config.ts
+++ b/engines/query-sparql/webpack.config.ts
@@ -1,3 +1,3 @@
-import { createConfig } from '../../webpack.config';
+import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(__dirname);
+export default createConfig(import.meta.dirname);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -122,6 +122,7 @@ module.exports = config([
     rules: {
       'import/extensions': 'off',
       'import/no-nodejs-modules': 'off',
+      'import/no-extraneous-dependencies': 'off',
     },
   },
   {

--- a/packages/actor-init-query/webpack.config.ts
+++ b/packages/actor-init-query/webpack.config.ts
@@ -1,5 +1,4 @@
 import { resolve } from 'node:path';
-import { ProgressPlugin } from 'webpack';
 import type { Configuration } from 'webpack';
 
 function createConfig(packagePath: string): Configuration {
@@ -22,9 +21,6 @@ function createConfig(packagePath: string): Configuration {
       libraryTarget: 'var',
       library: 'Comunica',
     },
-    plugins: [
-      new ProgressPlugin(),
-    ],
     performance: {
       hints: 'error',
       // Bundle size limited to ~1.7 MB

--- a/packages/actor-init-query/webpack.config.ts
+++ b/packages/actor-init-query/webpack.config.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import webpack from 'webpack';
 import type { Configuration } from 'webpack';
 
 function createConfig(packagePath: string): Configuration {
@@ -27,6 +28,9 @@ function createConfig(packagePath: string): Configuration {
       maxAssetSize: 2_000_000,
       maxEntrypointSize: 2_000_000,
     },
+    plugins: [
+      new webpack.ProgressPlugin(),
+    ],
   };
 }
 

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -6,8 +6,7 @@
     "karma.conf.ts",
     "karma.setup.ts",
     "packages/**/*.ts",
-    "performance/**/*.ts",
-    "webpack.config.ts"
+    "performance/**/*.ts"
   ],
   "exclude": [
     "**/node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10950,7 +10950,7 @@ rdf-string@^1.0.0, rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-string@^2.0.0:
+rdf-string@^2.0.0, rdf-string@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-2.0.1.tgz#9beff12486a653d6fb0f229a5e0e5f3cc2e962c6"
   integrity sha512-SMW4ponnKNrsP9kYpOLyICeM4UJmEXIeS3zri7kPK9gzLFsHD88oiza8LnokNYxd76zW4JoYWD+v4x0g8rJBjw==


### PR DESCRIPTION
This is a quick fix for the issue that was pointed out, where moving the Webpack config to the monorepo root in 99997787ae6e034354ff83cec9e9e7b654e7c609 broke use-cases where it was inherited from the actor-init-query package.