### PR TITLE
Add Node 24 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_NODE_VERSION: 24.x
+  DEFAULT_NODE_VERSION: 22.x
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_NODE_VERSION: 22.x
+  DEFAULT_NODE_VERSION: 18.x
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_NODE_VERSION: 22.x
+  DEFAULT_NODE_VERSION: 24.x
 
 jobs:
 
@@ -54,6 +54,7 @@ jobs:
           - 18.x
           - 20.x
           - 22.x
+          - 24.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ensure line endings are consistent
@@ -90,6 +91,7 @@ jobs:
           - 18.x
           - 20.x
           - 22.x
+          - 24.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ensure line endings are consistent

--- a/engines/query-sparql-file/webpack.config.js
+++ b/engines/query-sparql-file/webpack.config.js
@@ -1,3 +1,3 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config';
+const createConfig = require('@comunica/actor-init-query/webpack.config').createConfig;
 
 export default createConfig(__dirname);

--- a/engines/query-sparql-file/webpack.config.js
+++ b/engines/query-sparql-file/webpack.config.js
@@ -1,0 +1,3 @@
+import { createConfig } from '@comunica/actor-init-query/webpack.config';
+
+export default createConfig(__dirname);

--- a/engines/query-sparql-file/webpack.config.ts
+++ b/engines/query-sparql-file/webpack.config.ts
@@ -1,3 +1,0 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
-
-export default createConfig(__dirname);

--- a/engines/query-sparql-file/webpack.config.ts
+++ b/engines/query-sparql-file/webpack.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(import.meta.dirname);
+export default createConfig(globalThis.__dirname ?? import.meta.dirname);

--- a/engines/query-sparql-file/webpack.config.ts
+++ b/engines/query-sparql-file/webpack.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(globalThis.__dirname ?? import.meta.dirname);
+export default createConfig(__dirname);

--- a/engines/query-sparql-rdfjs-lite/webpack.config.js
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.js
@@ -1,4 +1,4 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
+import { createConfig } from '@comunica/actor-init-query/webpack.config';
 
 const liteConfig = createConfig(__dirname);
 

--- a/engines/query-sparql-rdfjs-lite/webpack.config.js
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.js
@@ -1,4 +1,4 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config';
+const createConfig = require('@comunica/actor-init-query/webpack.config').createConfig;
 
 const liteConfig = createConfig(__dirname);
 

--- a/engines/query-sparql-rdfjs-lite/webpack.config.ts
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.ts
@@ -1,6 +1,6 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-const liteConfig = createConfig(import.meta.dirname);
+const liteConfig = createConfig(globalThis.__dirname ?? import.meta.dirname);
 
 if (typeof liteConfig.performance === 'object') {
   liteConfig.performance.maxAssetSize = 915_000;

--- a/engines/query-sparql-rdfjs-lite/webpack.config.ts
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.ts
@@ -1,6 +1,6 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-const liteConfig = createConfig(globalThis.__dirname ?? import.meta.dirname);
+const liteConfig = createConfig(__dirname);
 
 if (typeof liteConfig.performance === 'object') {
   liteConfig.performance.maxAssetSize = 915_000;

--- a/engines/query-sparql-rdfjs/webpack.config.js
+++ b/engines/query-sparql-rdfjs/webpack.config.js
@@ -1,3 +1,3 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config';
+const createConfig = require('@comunica/actor-init-query/webpack.config').createConfig;
 
 export default createConfig(__dirname);

--- a/engines/query-sparql-rdfjs/webpack.config.js
+++ b/engines/query-sparql-rdfjs/webpack.config.js
@@ -1,0 +1,3 @@
+import { createConfig } from '@comunica/actor-init-query/webpack.config';
+
+export default createConfig(__dirname);

--- a/engines/query-sparql-rdfjs/webpack.config.ts
+++ b/engines/query-sparql-rdfjs/webpack.config.ts
@@ -1,3 +1,0 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
-
-export default createConfig(__dirname);

--- a/engines/query-sparql-rdfjs/webpack.config.ts
+++ b/engines/query-sparql-rdfjs/webpack.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(import.meta.dirname);
+export default createConfig(globalThis.__dirname ?? import.meta.dirname);

--- a/engines/query-sparql-rdfjs/webpack.config.ts
+++ b/engines/query-sparql-rdfjs/webpack.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(globalThis.__dirname ?? import.meta.dirname);
+export default createConfig(__dirname);

--- a/engines/query-sparql/webpack.config.js
+++ b/engines/query-sparql/webpack.config.js
@@ -1,3 +1,3 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config';
+const createConfig = require('@comunica/actor-init-query/webpack.config').createConfig;
 
 export default createConfig(__dirname);

--- a/engines/query-sparql/webpack.config.js
+++ b/engines/query-sparql/webpack.config.js
@@ -1,0 +1,3 @@
+import { createConfig } from '@comunica/actor-init-query/webpack.config';
+
+export default createConfig(__dirname);

--- a/engines/query-sparql/webpack.config.ts
+++ b/engines/query-sparql/webpack.config.ts
@@ -1,3 +1,0 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
-
-export default createConfig(__dirname);

--- a/engines/query-sparql/webpack.config.ts
+++ b/engines/query-sparql/webpack.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(import.meta.dirname);
+export default createConfig(globalThis.__dirname ?? import.meta.dirname);

--- a/engines/query-sparql/webpack.config.ts
+++ b/engines/query-sparql/webpack.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
 
-export default createConfig(globalThis.__dirname ?? import.meta.dirname);
+export default createConfig(__dirname);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -117,7 +117,7 @@ module.exports = config([
   {
     // Webpack configurations
     files: [
-      '**/webpack.config.ts',
+      '**/webpack.config.js',
     ],
     rules: {
       'import/extensions': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -120,6 +120,8 @@ module.exports = config([
       '**/webpack.config.js',
     ],
     rules: {
+      'ts/no-var-requires': 'off',
+      'ts/no-require-imports': 'off',
       'import/extensions': 'off',
       'import/no-nodejs-modules': 'off',
       'import/no-extraneous-dependencies': 'off',

--- a/packages/actor-init-query/webpack.config.js
+++ b/packages/actor-init-query/webpack.config.js
@@ -1,10 +1,10 @@
-import { resolve } from 'node:path';
-import webpack from 'webpack';
+const path = require('node:path');
+const webpack = require('webpack');
 
-function createConfig(packagePath) {
+export function createConfig(packagePath) {
   return {
     devtool: 'source-map',
-    entry: resolve(packagePath, 'lib', 'index-browser.ts'),
+    entry: path.resolve(packagePath, 'lib', 'index-browser.ts'),
     mode: 'development',
     module: {
       rules: [
@@ -32,5 +32,3 @@ function createConfig(packagePath) {
     ],
   };
 }
-
-export { createConfig };

--- a/packages/actor-init-query/webpack.config.js
+++ b/packages/actor-init-query/webpack.config.js
@@ -1,8 +1,7 @@
 import { resolve } from 'node:path';
 import webpack from 'webpack';
-import type { Configuration } from 'webpack';
 
-function createConfig(packagePath: string): Configuration {
+function createConfig(packagePath) {
   return {
     devtool: 'source-map',
     entry: resolve(packagePath, 'lib', 'index-browser.ts'),


### PR DESCRIPTION
This is just a small change to add Node 24 to the CI, and to run everything with it by default. This is both in preparation for Node 24 becoming LTS *and* to see if it fixes the browser build issue, because I have Node 23 locally and the CI was failing on Node 22. :thinking: 