### PR TITLE
Fix browser builds on older Node versions

### DIFF
--- a/engines/query-sparql-file/webpack.config.js
+++ b/engines/query-sparql-file/webpack.config.js
@@ -1,0 +1,3 @@
+const createConfig = require('@comunica/actor-init-query/webpack.config.js');
+
+module.exports = createConfig(__dirname);

--- a/engines/query-sparql-file/webpack.config.ts
+++ b/engines/query-sparql-file/webpack.config.ts
@@ -1,3 +1,0 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
-
-export default createConfig(import.meta.dirname);

--- a/engines/query-sparql-rdfjs-lite/webpack.config.js
+++ b/engines/query-sparql-rdfjs-lite/webpack.config.js
@@ -1,10 +1,10 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
+const createConfig = require('@comunica/actor-init-query/webpack.config.js');
 
-const liteConfig = createConfig(import.meta.dirname);
+const liteConfig = createConfig(__dirname);
 
 if (typeof liteConfig.performance === 'object') {
   liteConfig.performance.maxAssetSize = 915_000;
   liteConfig.performance.maxEntrypointSize = 915_000;
 }
 
-export default liteConfig;
+module.exports = liteConfig;

--- a/engines/query-sparql-rdfjs/webpack.config.js
+++ b/engines/query-sparql-rdfjs/webpack.config.js
@@ -1,0 +1,3 @@
+const createConfig = require('@comunica/actor-init-query/webpack.config.js');
+
+module.exports = createConfig(__dirname);

--- a/engines/query-sparql-rdfjs/webpack.config.ts
+++ b/engines/query-sparql-rdfjs/webpack.config.ts
@@ -1,3 +1,0 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
-
-export default createConfig(import.meta.dirname);

--- a/engines/query-sparql/webpack.config.js
+++ b/engines/query-sparql/webpack.config.js
@@ -1,0 +1,3 @@
+const createConfig = require('@comunica/actor-init-query/webpack.config.js');
+
+module.exports = createConfig(__dirname);

--- a/engines/query-sparql/webpack.config.ts
+++ b/engines/query-sparql/webpack.config.ts
@@ -1,3 +1,0 @@
-import { createConfig } from '@comunica/actor-init-query/webpack.config.ts';
-
-export default createConfig(import.meta.dirname);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -117,12 +117,14 @@ module.exports = config([
   {
     // Webpack configurations
     files: [
-      '**/webpack.config.ts',
+      '**/webpack.config.js',
     ],
     rules: {
+      'ts/no-var-requires': 'off',
+      'ts/no-require-imports': 'off',
       'import/extensions': 'off',
-      'import/no-nodejs-modules': 'off',
       'import/no-extraneous-dependencies': 'off',
+      'import/no-nodejs-modules': 'off',
     },
   },
   {

--- a/packages/actor-init-query/webpack.config.js
+++ b/packages/actor-init-query/webpack.config.js
@@ -1,11 +1,10 @@
-import { resolve } from 'node:path';
-import webpack from 'webpack';
-import type { Configuration } from 'webpack';
+const path = require('node:path');
+const webpack = require('webpack');
 
-function createConfig(packagePath: string): Configuration {
+module.exports = function createConfig(packagePath) {
   return {
     devtool: 'source-map',
-    entry: resolve(packagePath, 'lib', 'index-browser.ts'),
+    entry: path.resolve(packagePath, 'lib', 'index-browser.ts'),
     mode: 'development',
     module: {
       rules: [
@@ -24,7 +23,6 @@ function createConfig(packagePath: string): Configuration {
     },
     performance: {
       hints: 'error',
-      // Bundle size limited to ~1.7 MB
       maxAssetSize: 2_000_000,
       maxEntrypointSize: 2_000_000,
     },
@@ -32,6 +30,4 @@ function createConfig(packagePath: string): Configuration {
       new webpack.ProgressPlugin(),
     ],
   };
-}
-
-export { createConfig };
+};


### PR DESCRIPTION
Changing the Webpack configs to CJS should hopefully fix the browser builds. They still work on Node 23, will see what the CI says about older ones.