### PR TITLE
Fixes to readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/comunica/comunica/actions/workflows/ci.yml"><img src="https://github.com/comunica/comunica/actions/workflows/ci.yml/badge.svg?branch=master" alt="Build Status"></a>
-<a href="https://coveralls.io/github/comunica/comunica?branch=master"><img src="https://coveralls.io/repos/github/comunica/comunica/badge.svg?branch=master" alt="Coverage Status"></a>
-<a href="https://zenodo.org/badge/latestdoi/107345960"><img src="https://zenodo.org/badge/107345960.svg" alt="DOI"></a>
-<a href="https://gitter.im/comunica/Lobby"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?label=Lobby-Chat" alt="Gitter Lobby chat"></a>
-<a href="https://gitter.im/comunica/core-dev"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?label=Dev-Chat" alt="Gitter Dev chat"></a>
+  <a href="https://github.com/comunica/comunica/actions/workflows/ci.yml"><img src="https://github.com/comunica/comunica/actions/workflows/ci.yml/badge.svg?branch=master" alt="Build Status"></a>
+  <a href="https://coveralls.io/github/comunica/comunica?branch=master"><img src="https://coveralls.io/repos/github/comunica/comunica/badge.svg?branch=master" alt="Coverage Status"></a>
+  <a href="https://zenodo.org/badge/latestdoi/107345960"><img src="https://zenodo.org/badge/107345960.svg" alt="DOI"></a>
+  <a href="https://gitter.im/comunica/Lobby"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?label=Lobby-Chat" alt="Gitter Lobby chat"></a>
+  <a href="https://gitter.im/comunica/core-dev"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?label=Dev-Chat" alt="Gitter Dev chat"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/comunica/comunica/actions?query=workflow%3ACI"><img src="https://github.com/comunica/comunica/workflows/CI/badge.svg" alt="Build Status"></a>
+<a href="https://github.com/comunica/comunica/actions/workflows/ci.yml"><img src="https://github.com/comunica/comunica/actions/workflows/ci.yml/badge.svg?branch=master" alt="Build Status"></a>
 <a href="https://coveralls.io/github/comunica/comunica?branch=master"><img src="https://coveralls.io/repos/github/comunica/comunica/badge.svg?branch=master" alt="Coverage Status"></a>
 <a href="https://zenodo.org/badge/latestdoi/107345960"><img src="https://zenodo.org/badge/107345960.svg" alt="DOI"></a>
 <a href="https://gitter.im/comunica/Lobby"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?style=plastic&label=Lobby-Chat" alt="Gitter Lobby chat"></a>

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 <a href="https://github.com/comunica/comunica/actions/workflows/ci.yml"><img src="https://github.com/comunica/comunica/actions/workflows/ci.yml/badge.svg?branch=master" alt="Build Status"></a>
 <a href="https://coveralls.io/github/comunica/comunica?branch=master"><img src="https://coveralls.io/repos/github/comunica/comunica/badge.svg?branch=master" alt="Coverage Status"></a>
 <a href="https://zenodo.org/badge/latestdoi/107345960"><img src="https://zenodo.org/badge/107345960.svg" alt="DOI"></a>
-<a href="https://gitter.im/comunica/Lobby"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?style=plastic&label=Lobby-Chat" alt="Gitter Lobby chat"></a>
-<a href="https://gitter.im/comunica/core-dev"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?style=plastic&label=Dev-Chat" alt="Gitter Dev chat"></a>
+<a href="https://gitter.im/comunica/Lobby"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?label=Lobby-Chat" alt="Gitter Lobby chat"></a>
+<a href="https://gitter.im/comunica/core-dev"><img src="https://img.shields.io/gitter/room/comunica/Lobby.svg?label=Dev-Chat" alt="Gitter Dev chat"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
This is a small set of changes to fix some tiny annoyances with the CI badges that I have:
* Fix the indentation, because the badges are not indented, but everything else around them is.
* Remove the plastic style definitions from Gitter badges, because they look nothing like the other badges now.
* Lock the CI badge to master branch, I have no idea how or why, but this seems to fix the status showing up as failed, even though the latest run has been a success.

Any feedback would be welcome, though. I know this is a really random thing, but especially the CI badge has been bothering me for ages. :grimacing: 