### PR TITLE
Add federated explain actor

### DIFF
--- a/engines/config-query-sparql/config/query-process/actors.json
+++ b/engines/config-query-sparql/config/query-process/actors.json
@@ -5,6 +5,7 @@
   ],
   "import": [
     "ccqs:config/query-process/actors/sequential.json",
+    "ccqs:config/query-process/actors/explain-federated.json",
     "ccqs:config/query-process/actors/explain-parsed.json",
     "ccqs:config/query-process/actors/explain-logical.json",
     "ccqs:config/query-process/actors/explain-physical.json"

--- a/engines/config-query-sparql/config/query-process/actors/explain-federated.json
+++ b/engines/config-query-sparql/config/query-process/actors/explain-federated.json
@@ -1,0 +1,16 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/runner/^4.0.0/components/context.jsonld",
+
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-process-explain-federated/^4.0.0/components/context.jsonld"
+  ],
+  "@id": "urn:comunica:default:Runner",
+  "@type": "Runner",
+  "actors": [
+    {
+      "@id": "urn:comunica:default:query-process/actors#explain-federated",
+      "@type": "ActorQueryProcessExplainFederated",
+      "queryProcessor": { "@id": "urn:comunica:default:query-process/actors#sequential" }
+    }
+  ]
+}

--- a/engines/query-sparql-file/package.json
+++ b/engines/query-sparql-file/package.json
@@ -219,6 +219,7 @@
     "@comunica/actor-query-operation-values": "^4.2.0",
     "@comunica/actor-query-parse-graphql": "^4.2.0",
     "@comunica/actor-query-parse-sparql": "^4.2.0",
+    "@comunica/actor-query-process-explain-federated": "^4.3.0",
     "@comunica/actor-query-process-explain-logical": "^4.2.0",
     "@comunica/actor-query-process-explain-parsed": "^4.2.0",
     "@comunica/actor-query-process-explain-physical": "^4.2.0",

--- a/engines/query-sparql-rdfjs/package.json
+++ b/engines/query-sparql-rdfjs/package.json
@@ -201,6 +201,7 @@
     "@comunica/actor-query-operation-values": "^4.2.0",
     "@comunica/actor-query-parse-graphql": "^4.2.0",
     "@comunica/actor-query-parse-sparql": "^4.2.0",
+    "@comunica/actor-query-process-explain-federated": "^4.3.0",
     "@comunica/actor-query-process-explain-logical": "^4.2.0",
     "@comunica/actor-query-process-explain-parsed": "^4.2.0",
     "@comunica/actor-query-process-explain-physical": "^4.2.0",

--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -231,6 +231,7 @@
     "@comunica/actor-query-operation-values": "^4.2.0",
     "@comunica/actor-query-parse-graphql": "^4.2.0",
     "@comunica/actor-query-parse-sparql": "^4.2.0",
+    "@comunica/actor-query-process-explain-federated": "^4.3.0",
     "@comunica/actor-query-process-explain-logical": "^4.2.0",
     "@comunica/actor-query-process-explain-parsed": "^4.2.0",
     "@comunica/actor-query-process-explain-physical": "^4.2.0",

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -84,6 +84,7 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
           describe: 'Print the query plan',
           choices: [
             'parsed',
+            'federated',
             'logical',
             'physical',
             'physical-json',

--- a/packages/actor-query-process-explain-federated/README.md
+++ b/packages/actor-query-process-explain-federated/README.md
@@ -1,0 +1,41 @@
+# Comunica Explain Federated Query Process Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-query-process-explain-federated.svg)](https://www.npmjs.com/package/@comunica/actor-query-process-explain-federated)
+
+A [Query Process](https://github.com/comunica/comunica/tree/master/packages/bus-query-process) actor
+that produces the federated version of a query after parsing and optimization,
+by converting algebra operation source assignments into `SERVICE` clauses,
+allowing for the inspection and comparison of automated query federation by the engine,
+as well as for the use of Comunica to handle the federation of a query but another engine to execute it.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica),
+and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
+
+[Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-query-process-explain-federated
+```
+
+## Configure
+
+After installing, this package can be added to your engine's configuration as follows:
+```json
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-query-process-explain-federated/^4.0.0/components/context.jsonld"
+  ],
+  "actors": [
+    {
+      "@id": "urn:comunica:default:query-process/actors#explain-federated",
+      "@type": "ActorQueryProcessExplainFederated"
+    }
+  ]
+}
+```
+
+### Config Parameters
+
+* `queryProcessor`: Reference to the query processor.

--- a/packages/actor-query-process-explain-federated/lib/ActorQueryProcessExplainFederated.ts
+++ b/packages/actor-query-process-explain-federated/lib/ActorQueryProcessExplainFederated.ts
@@ -1,0 +1,69 @@
+import type {
+  IActionQueryProcess,
+  IActorQueryProcessOutput,
+  IActorQueryProcessArgs,
+  IQueryProcessSequential,
+} from '@comunica/bus-query-process';
+import {
+  ActorQueryProcess,
+} from '@comunica/bus-query-process';
+import { KeysInitQuery } from '@comunica/context-entries';
+import type { IActorTest, TestResult } from '@comunica/core';
+import { failTest, passTestVoid, ActionContextKey } from '@comunica/core';
+import type { IQuerySource } from '@comunica/types';
+import type { Factory } from 'sparqlalgebrajs';
+import { Algebra, Util, toSparql } from 'sparqlalgebrajs';
+
+/**
+ * Comunica query process actor to produce a federated version of the input query,
+ * with algebra operation source assignments converted into SERVICE clauses.
+ */
+export class ActorQueryProcessExplainFederated extends ActorQueryProcess {
+  public readonly queryProcessor: IQueryProcessSequential;
+
+  public constructor(args: IActorQueryProcessExplainFederatedArgs) {
+    super(args);
+  }
+
+  public async test(action: IActionQueryProcess): Promise<TestResult<IActorTest>> {
+    if ((action.context.get(KeysInitQuery.explain) ??
+      action.context.get(new ActionContextKey('explain'))) !== 'federated') {
+      return failTest(`${this.name} can only explain in 'federated' mode.`);
+    }
+    return passTestVoid();
+  }
+
+  public async run(action: IActionQueryProcess): Promise<IActorQueryProcessOutput> {
+    // Parse and optimize the query
+    let { operation, context } = await this.queryProcessor.parse(action.query, action.context);
+    ({ operation, context } = await this.queryProcessor.optimize(operation, context));
+
+    const callbacks = Object.fromEntries([
+      Algebra.types.PATTERN,
+      Algebra.types.BGP,
+    ].map(at => [ at, (op: Algebra.Operation, factory: Factory) => {
+      const innerSource = <IQuerySource | undefined>(<any>op.metadata?.scopedSource)?.source?.innerSource;
+
+      if (innerSource && typeof innerSource.referenceValue === 'string') {
+        const service = factory.createService(op, factory.dataFactory.namedNode(innerSource.referenceValue));
+        return { recurse: false, result: service };
+      }
+
+      return { recurse: true, result: op };
+    } ]));
+
+    const operationWithServiceClauses = Util.mapOperation(operation, callbacks);
+
+    return {
+      result: {
+        explain: true,
+        type: 'federated',
+        data: toSparql(operationWithServiceClauses),
+      },
+    };
+  }
+}
+
+export interface IActorQueryProcessExplainFederatedArgs extends IActorQueryProcessArgs {
+  queryProcessor: IQueryProcessSequential;
+}

--- a/packages/actor-query-process-explain-federated/lib/index.ts
+++ b/packages/actor-query-process-explain-federated/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './ActorQueryProcessExplainFederated';

--- a/packages/actor-query-process-explain-federated/package.json
+++ b/packages/actor-query-process-explain-federated/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@comunica/actor-query-process-explain-federated",
+  "version": "4.3.0",
+  "description": "Comunica query process actor to explain federated",
+  "lsd:module": true,
+  "license": "MIT",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/comunica-association"
+  },
+  "homepage": "https://comunica.dev/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/comunica/comunica.git",
+    "directory": "packages/actor-query-process-explain-federated"
+  },
+  "bugs": {
+    "url": "https://github.com/comunica/comunica/issues"
+  },
+  "keywords": [
+    "comunica",
+    "actor",
+    "query-process",
+    "explain-federated"
+  ],
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "typings": "lib/index",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.js.map"
+  ],
+  "scripts": {
+    "build": "yarn run build:ts && yarn run build:components",
+    "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
+    "build:components": "componentsjs-generator"
+  },
+  "dependencies": {
+    "@comunica/bus-query-process": "^4.2.0",
+    "@comunica/context-entries": "^4.2.0",
+    "@comunica/core": "^4.2.0",
+    "sparqlalgebrajs": "^4.3.8"
+  }
+}

--- a/packages/actor-query-process-explain-federated/test/ActorQueryProcessExplainFederated-test.ts
+++ b/packages/actor-query-process-explain-federated/test/ActorQueryProcessExplainFederated-test.ts
@@ -1,0 +1,89 @@
+import { KeysInitQuery } from '@comunica/context-entries';
+import { ActionContext, ActionContextKey } from '@comunica/core';
+import type { IActionContext } from '@comunica/types';
+import { DataFactory } from 'rdf-data-factory';
+import type { Algebra } from 'sparqlalgebrajs';
+import { Factory, toSparql } from 'sparqlalgebrajs';
+import { ActorQueryProcessExplainFederated } from '../lib/ActorQueryProcessExplainFederated';
+import '@comunica/utils-jest';
+
+const DF = new DataFactory();
+const AF = new Factory(DF);
+
+describe('ActorQueryProcessExplainFederated', () => {
+  let bus: any;
+  let queryProcessor: any;
+  let actor: ActorQueryProcessExplainFederated;
+  let context: IActionContext;
+  let query: Algebra.Operation;
+  let queryString: string;
+
+  beforeEach(() => {
+    bus = {
+      subscribe: jest.fn(),
+    };
+    queryProcessor = {
+      parse: jest.fn().mockImplementation(() => ({ operation: query, context: 'context' })),
+      optimize: jest.fn().mockImplementation(() => ({ operation: query, context: 'context' })),
+    };
+    actor = new ActorQueryProcessExplainFederated({
+      bus,
+      name: 'actor',
+      queryProcessor,
+    });
+    context = new ActionContext();
+    query = AF.createProject(
+      AF.createPattern(DF.variable('s'), DF.variable('p'), DF.variable('o')),
+      [ DF.variable('s'), DF.variable('p'), DF.variable('o') ],
+    );
+    queryString = toSparql(query);
+  });
+
+  describe('test', () => {
+    it('should pass with KeysInitQuery.explain', async() => {
+      context = context.set(KeysInitQuery.explain, 'federated');
+      await expect(actor.test({ context, query: queryString })).resolves.toPassTestVoid();
+    });
+
+    it('should pass with string value explain', async() => {
+      context = context.set(new ActionContextKey('explain'), 'federated');
+      await expect(actor.test({ context, query: queryString })).resolves.toPassTestVoid();
+    });
+
+    it('should reject without explain context key', async() => {
+      await expect(actor.test({ context, query: queryString })).resolves
+        .toFailTest('actor can only explain in \'federated\' mode');
+    });
+  });
+
+  describe('run', () => {
+    it('should return original query without source assignments', async() => {
+      await expect(actor.run({ context, query: queryString })).resolves.toEqual({
+        result: {
+          data: queryString,
+          explain: true,
+          type: 'federated',
+        },
+      });
+    });
+
+    it('should return query with service clauses with source assignments', async() => {
+      (<Algebra.Pattern>query.input).metadata = {
+        scopedSource: {
+          source: {
+            innerSource: {
+              referenceValue: 'ex:source',
+            },
+          },
+        },
+      };
+      await expect(actor.run({ context, query: queryString })).resolves.toEqual({
+        result: {
+          data: 'SELECT ?s ?p ?o WHERE { SERVICE <ex:source> { ?s ?p ?o. } }',
+          explain: true,
+          type: 'federated',
+        },
+      });
+    });
+  });
+});

--- a/packages/actor-query-process-explain-physical/lib/ActorQueryProcessExplainPhysical.ts
+++ b/packages/actor-query-process-explain-physical/lib/ActorQueryProcessExplainPhysical.ts
@@ -10,6 +10,7 @@ import {
 import { KeysInitQuery } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { failTest, passTestVoid, ActionContextKey } from '@comunica/core';
+import type { QueryExplainMode } from '@comunica/types';
 import { MemoryPhysicalQueryPlanLogger } from './MemoryPhysicalQueryPlanLogger';
 
 /**
@@ -58,8 +59,9 @@ export class ActorQueryProcessExplainPhysical extends ActorQueryProcess {
         break;
     }
 
-    const mode: 'parsed' | 'logical' | 'physical' | 'physical-json' = (action.context.get(KeysInitQuery.explain) ??
-      action.context.getSafe(new ActionContextKey('explain')));
+    const mode = action.context.get(KeysInitQuery.explain) ??
+      action.context.getSafe<QueryExplainMode>(new ActionContextKey('explain'));
+
     return {
       result: {
         explain: true,

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -186,7 +186,7 @@ export const KeysInitQuery = {
    */
   cliArgsHandlers: new ActionContextKey<ICliArgsHandler[]>('@comunica/actor-init-query:cliArgsHandlers'),
   /**
-   * Explain mode of the query. Can be 'parsed', 'logical', 'physical', or 'physical-json'.
+   * Explain mode of the query. Can be 'parsed', 'federated', 'logical', 'physical', or 'physical-json'.
    */
   explain: new ActionContextKey<QueryExplainMode>('@comunica/actor-init-query:explain'),
   /**

--- a/packages/types/lib/IQueryOperationResult.ts
+++ b/packages/types/lib/IQueryOperationResult.ts
@@ -146,7 +146,7 @@ export type QueryEnhanced =
 /**
  * Different manners in which a query can be explained.
  */
-export type QueryExplainMode = 'parsed' | 'logical' | 'physical' | 'physical-json';
+export type QueryExplainMode = 'parsed' | 'logical' | 'federated' | 'physical' | 'physical-json';
 
 /**
  * An interface marking an explained query.


### PR DESCRIPTION
This is an implementation of an explain actor that produces the federated SPARQL serialization of the query as its output, after parsing and optimisation, with scoped source assignments converted into service clauses.

This will allow comparisons between manually federated queries, and the automated federation of Comunica, by comparing the explain output against the manually crafted query. This will also allow for the use of Comunica to split queries between sources, while using another engine to execute them.

Any feedback would be welcome. :slightly_smiling_face: Currently, it will only do the service clause conversion on triple patterns and BGPs. I need to do some more testing to see what other operations are likely to have sources assigned to them, in a way that makes sense to wrap them in service clauses.