### PR TITLE
Allow the use of VoID cardinality estimates for ASK queries

### DIFF
--- a/packages/actor-query-source-identify-hypermedia-sparql/README.md
+++ b/packages/actor-query-source-identify-hypermedia-sparql/README.md
@@ -48,3 +48,4 @@ After installing, this package can be added to your engine's configuration as fo
 * `countTimeout`: Timeout in ms of how long count queries are allowed to take. If the timeout is reached, an infinity cardinality is returned. Defaults to `3000`.
 * `cardinalityCountQueries`: If count queries should be sent to obtain the cardinality of (sub)queries. If set to false, resulting cardinalities will always be considered infinity. Defaults to `true`
 * `cardinalityEstimateConstruction`: If cardinality estimates for larger queries should be constructed locally from (sub)query cardinalities when possible. Defaults to `false`. If set to false, count queries will be sent for every operation at all levels.
+* `estimateAskResults`: If ask queries should be processed locally using cardinality estimates, instead of being passed to the endpoint.

--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/ActorQuerySourceIdentifyHypermediaSparql.ts
@@ -31,6 +31,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
   public readonly countTimeout: number;
   public readonly cardinalityCountQueries: boolean;
   public readonly cardinalityEstimateConstruction: boolean;
+  public readonly estimateAskResults: boolean;
   public readonly forceGetIfUrlLengthBelow: number;
 
   public constructor(args: IActorQuerySourceIdentifyHypermediaSparqlArgs) {
@@ -67,6 +68,7 @@ export class ActorQuerySourceIdentifyHypermediaSparql extends ActorQuerySourceId
       // Cardinalities can be infinity when we're querying just a single source.
       this.cardinalityCountQueries && !isSingularSource,
       this.cardinalityEstimateConstruction,
+      this.estimateAskResults,
       this.forceGetIfUrlLengthBelow,
       action.metadata.defaultGraph,
       action.metadata.unionDefaultGraph,
@@ -129,6 +131,12 @@ export interface IActorQuerySourceIdentifyHypermediaSparqlArgs extends IActorQue
    * @default {false}
    */
   cardinalityEstimateConstruction: boolean;
+  /**
+   * If ask query results should be produced locally using cardinality estimates.
+   * This may result in inaccurate source assignment for query operations when using ask queries.
+   * @default {false}
+   */
+  estimateAskResults: boolean;
   /**
    * Force an HTTP GET instead of default POST (when forceHttpGet is false)
    * when the url length (including encoded query) is below this number.

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/ActorQuerySourceIdentifyHypermediaSparql-test.ts
@@ -57,6 +57,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
         countTimeout: 3_000,
         cardinalityCountQueries: true,
         cardinalityEstimateConstruction: false,
+        estimateAskResults: false,
         forceGetIfUrlLengthBelow: 600,
       });
     });
@@ -121,6 +122,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
           cardinalityEstimateConstruction: false,
+          estimateAskResults: false,
         });
         await expect(actor.test({ url: 'URL/sparql', metadata: {}, quads: <any> null, context })).resolves
           .toFailTest('Actor actor could not detect a SPARQL service description or URL ending on /sparql.');
@@ -138,6 +140,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
           cardinalityEstimateConstruction: false,
+          estimateAskResults: false,
         });
         await expect(actor
           .test({ url: 'URL/sparql', metadata: {}, quads: <any> null, forceSourceType: 'file', context }))
@@ -156,6 +159,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
           cardinalityEstimateConstruction: false,
+          estimateAskResults: false,
         });
         await expect(actor.test({
           url: 'URL',
@@ -178,6 +182,7 @@ describe('ActorQuerySourceIdentifyHypermediaSparql', () => {
           mediatorMergeBindingsContext,
           cardinalityCountQueries: true,
           cardinalityEstimateConstruction: false,
+          estimateAskResults: false,
         });
         await expect(actor.test({
           url: 'URL',

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
@@ -73,7 +73,7 @@ describe('QuerySourceSparql', () => {
       [KeysCore.log.name]: logger,
       [KeysInitQuery.queryFormat.name]: { language: 'sparql', version: '1.1' },
     });
-    source = new QuerySourceSparql(url, ctx, mediatorHttp, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+    source = new QuerySourceSparql(url, ctx, mediatorHttp, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
   });
 
   describe('getSelectorShape', () => {
@@ -185,7 +185,7 @@ describe('QuerySourceSparql', () => {
           };
         }),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       await expect(source.queryBindings(AF.createPattern(DF.variable('s'), DF.namedNode('p'), DF.namedNode('o')), ctx))
         .toEqualBindingsStream([
           BF.fromRecord({
@@ -239,7 +239,7 @@ describe('QuerySourceSparql', () => {
           };
         }),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       await expect(
         source.queryBindings(AF.createPattern(
           DF.quad(DF.variable('s'), DF.namedNode('p'), DF.namedNode('o')),
@@ -299,7 +299,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       await expect(source.queryBindings(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), ctx))
         .toEqualBindingsStream([
           BF.fromRecord({
@@ -343,7 +343,7 @@ describe('QuerySourceSparql', () => {
     });
 
     it('should emit metadata when cardinalityCountQueries is false', async() => {
-      source = new QuerySourceSparql(url, ctx, mediatorHttp, 'values', DF, AF, BF, false, 64, 10, false, true, 0);
+      source = new QuerySourceSparql(url, ctx, mediatorHttp, 'values', DF, AF, BF, false, 64, 10, false, true, true, 0);
       const stream = source.queryBindings(AF.createPattern(
         DF.namedNode('s'),
         DF.variable('p'),
@@ -449,7 +449,7 @@ describe('QuerySourceSparql', () => {
     });
 
     it('should not cache if cache is disabled', async() => {
-      source = new QuerySourceSparql(url, ctx, mediatorHttp, 'values', DF, AF, BF, false, 0, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, mediatorHttp, 'values', DF, AF, BF, false, 0, 10, true, true, true, 0);
 
       const stream1 = source.queryBindings(AF.createPattern(
         DF.namedNode('s'),
@@ -501,7 +501,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       await expect(source.queryBindings(
         AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')),
         ctx,
@@ -548,7 +548,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       await expect(source.queryBindings(
         AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o'), DF.defaultGraph()),
         ctx,
@@ -601,7 +601,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       const stream = source.queryBindings(
         AF.createLeftJoin(
           AF.createPattern(DF.namedNode('s'), DF.variable('p1'), DF.namedNode('o'), DF.defaultGraph()),
@@ -640,7 +640,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       await expect(source
         .queryBindings(
           AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o'), DF.defaultGraph()),
@@ -688,7 +688,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       const stream = source.queryBindings(
         AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')),
         ctx,
@@ -743,7 +743,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       const stream = source.queryBindings(
         AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')),
         ctx,
@@ -810,7 +810,7 @@ describe('QuerySourceSparql', () => {
           };
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, true, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, true, 64, 10, true, true, true, 0);
       await expect(source.queryBindings(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), ctx))
         .toEqualBindingsStream([
           BF.fromRecord({
@@ -826,7 +826,22 @@ describe('QuerySourceSparql', () => {
     });
 
     it('should perform HTTP GET request when url length is below forceGetIfUrlLengthBelow', async() => {
-      source = new QuerySourceSparql(url, ctx, mediatorHttp, 'values', DF, AF, BF, false, 64, 10, true, true, 300);
+      source = new QuerySourceSparql(
+        url,
+        ctx,
+        mediatorHttp,
+        'values',
+        DF,
+        AF,
+        BF,
+        false,
+        64,
+        10,
+        true,
+        true,
+        true,
+        300,
+      );
 
       await expect(source.queryBindings(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), ctx))
         .toEqualBindingsStream([
@@ -982,7 +997,7 @@ describe('QuerySourceSparql', () => {
           });
         },
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
       const stream = source.queryBindings(
         AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')),
         ctx,
@@ -1072,7 +1087,7 @@ describe('QuerySourceSparql', () => {
           ok: true,
         })),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
 
       await expect(source.queryQuads(
         AF.createConstruct(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), []),
@@ -1121,7 +1136,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
           };
         }),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
 
       const stream = source.queryQuads(
         AF.createConstruct(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), []),
@@ -1150,7 +1165,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
           ok: true,
         })),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
 
       await expect(source.queryQuads(
         AF.createConstruct(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), []),
@@ -1174,7 +1189,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
   });
 
   describe('queryBoolean', () => {
-    it('should return data', async() => {
+    it('should perform ASK query to the endpoint', async() => {
       const thisMediator: any = {
         mediate: jest.fn(() => ({
           headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
@@ -1186,7 +1201,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
           ok: true,
         })),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, false, 0);
 
       await expect(source.queryBoolean(
         AF.createAsk(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o'))),
@@ -1216,7 +1231,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
           ok: true,
         })),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, false, 0);
 
       await expect(source.queryBoolean(
         AF.createAsk(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o'))),
@@ -1233,6 +1248,19 @@ WHERE { undefined:s ?p undefined:o. }` }),
         input: url,
       });
     });
+
+    it('should not send ASK queries when estimation is enabled', async() => {
+      const thisMediator: any = {
+        mediate: jest.fn().mockRejectedValue(new Error('request sent when not supposed to')),
+      };
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
+      const op = AF.createAsk(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')));
+      jest.spyOn(source, 'estimateOperationCardinality').mockResolvedValue({ type: 'estimate', value: 1 });
+      await expect(source.queryBoolean(op, ctx)).resolves.toBe(true);
+      jest.spyOn(source, 'estimateOperationCardinality').mockResolvedValue({ type: 'estimate', value: 0 });
+      await expect(source.queryBoolean(op, ctx)).resolves.toBe(false);
+      expect(thisMediator.mediate).not.toHaveBeenCalled();
+    });
   });
 
   describe('queryVoid', () => {
@@ -1244,7 +1272,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
           ok: true,
         })),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
 
       await source.queryVoid(
         AF.createDrop(DF.namedNode('s')),
@@ -1273,7 +1301,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
           ok: true,
         })),
       };
-      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, 0);
+      source = new QuerySourceSparql(url, ctx, thisMediator, 'values', DF, AF, BF, false, 64, 10, true, true, true, 0);
 
       await source.queryVoid(
         AF.createDrop(DF.namedNode('s')),
@@ -1481,6 +1509,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
         10,
         true,
         true,
+        true,
         0,
         defaultGraphUri,
         undefined,
@@ -1508,6 +1537,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
         false,
         64,
         10,
+        true,
         true,
         true,
         0,
@@ -1546,6 +1576,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
         false,
         64,
         10,
+        true,
         true,
         true,
         0,
@@ -1588,6 +1619,7 @@ WHERE { undefined:s ?p undefined:o. }` }),
         false,
         64,
         10,
+        true,
         true,
         true,
         0,


### PR DESCRIPTION
This change allows the (optional, disabled by default) use of VoID description cardinality estimates to answer ASK queries, to avoid sending them to the endpoint. I had to implement this for my experiments, and I thought it would be useful to get it merged into main Comunica.

I added a note in the parameter description to warn users that it can produce inaccurate source assignments, which it does, when the pattern has a subject or object value that restricts the pattern to a single source, even though the predicate is present in multiple ones.

Any feedback would be welcome.