### PR TITLE
Use ASK to verify cardinality estimate-based source assignments

### DIFF
--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
@@ -7,7 +7,13 @@ import { ActorOptimizeQueryOperation } from '@comunica/bus-optimize-query-operat
 import { KeysInitQuery, KeysQuerySourceIdentify } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { failTest, passTestVoid } from '@comunica/core';
-import type { ComunicaDataFactory, IActionContext, IQuerySourceWrapper, MetadataBindings } from '@comunica/types';
+import type {
+  ComunicaDataFactory,
+  IActionContext,
+  IQuerySourceWrapper,
+  MetadataBindings,
+  QueryResultCardinality,
+} from '@comunica/types';
 import { doesShapeAcceptOperation, getOperationSource } from '@comunica/utils-query-operation';
 import { Algebra, Factory, Util } from 'sparqlalgebrajs';
 
@@ -200,23 +206,37 @@ export class ActorOptimizeQueryOperationPruneEmptySourceOperations extends Actor
       return true;
     }
 
-    // Send an ASK query
+    // Prefer ASK over COUNT when instructed to, and the source allows it
     if (this.useAskIfSupported) {
       const askOperation = algebraFactory.createAsk(input);
-      if (doesShapeAcceptOperation(await source.source.getSelectorShape(context), askOperation)) {
+      const askSupported = doesShapeAcceptOperation(await source.source.getSelectorShape(context), askOperation);
+      if (askSupported) {
         return source.source.queryBoolean(askOperation, context);
       }
     }
 
-    // Send the operation as-is and check the response cardinality
+    // Fall back to sending the full operation, and extracting the cardinality from metadata
     const bindingsStream = source.source.queryBindings(input, context);
-    return new Promise((resolve, reject) => {
+    const cardinality = await new Promise<QueryResultCardinality>((resolve, reject) => {
       bindingsStream.on('error', reject);
       bindingsStream.getProperty('metadata', (metadata: MetadataBindings) => {
         bindingsStream.destroy();
-        resolve(metadata.cardinality.value > 0);
+        resolve(metadata.cardinality);
       });
     });
+
+    // If the cardinality is an estimate, such as from a VoID description,
+    // verify it using ASK if the source supports it.
+    // Since the VoID estimators in Comunica cannot produce false negatives, only positive assignments must be verified.
+    if (cardinality.type === 'estimate' && cardinality.value > 0) {
+      const askOperation = algebraFactory.createAsk(input);
+      const askSupported = doesShapeAcceptOperation(await source.source.getSelectorShape(context), askOperation);
+      if (askSupported) {
+        return source.source.queryBoolean(askOperation, context);
+      }
+    }
+
+    return cardinality.value > 0;
   }
 }
 


### PR DESCRIPTION
This is a logic change to ensure Comunica follows the SPLENDID source assignment approach more carefully, by using ASK queries to avoid false positives caused by local cardinality estimation, that is used for pruning empty sources.

Previously, Comunica performed source assignment in a single pass, regardless of whether the estimate was produced locally using VoID descriptions or acquired from a remote source via COUNT query. This allows false positive source assignments for triple patterns with subject or object values that would restrict them to specific sources, because the VoID description does not encode subject or object information.

After this change, when the cardinality estimate from metadata is an estimate, and the source supports ASK queries, Comunica will issue an ASK query to verify positive source assignment results, to avoid false positives. When the cardinality is the result of a COUNT query, and is marked as accurate, it will be used as-is, and no further ASK queries are issues.