### PR TITLE
Add federated Wikidata queries to web benchmark

### DIFF
--- a/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/author-birthday.rq
+++ b/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/author-birthday.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Internal_Federation_Guide#How_do_I_use_federation?
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?dateOfBirth WHERE {
+  VALUES ?entity { wd:Q4781761 }
+  ?entity wdt:P50 ?authors .
+  ?authors wdt:P569 ?dateOfBirth .
+} LIMIT 10

--- a/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/paper-subjects.rq
+++ b/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/paper-subjects.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Internal_Federation_Guide#How_to_deal_with_linked_entities_spread_across_multiple_graphs?
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?subject ?subjectType WHERE {
+  VALUES ?paper { wd:Q59458901 }
+  ?paper wdt:P921 ?subject .
+  ?subject wdt:P31 ?subjectType .
+} LIMIT 10

--- a/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/simple-count.rq
+++ b/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/simple-count.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Federated_Queries_Examples#Simple_count
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX p: <http://www.wikidata.org/prop/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT (COUNT(?entity) AS ?count) WHERE {
+  ?entity wdt:P4101 wd:Q41506 .
+  ?entity p:P495 ?o .
+}

--- a/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/sitelinks-lookup.rq
+++ b/performance/benchmark-web/combinations/combination_0/input/queries/wikidata/sitelinks-lookup.rq
@@ -1,0 +1,12 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Federated_Queries_Examples#Sitelinks_lookup
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX schema: <http://schema.org/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+SELECT * WHERE {
+  VALUES ?item { wd:Q330955 wd:Q42 }
+  ?wikimediaUrl schema:about ?item ;
+    schema:isPartOf ?partOf_ ;
+    schema:inLanguage ?inLanguage .
+  BIND(REPLACE(STR(?partOf_), "^https://[^.]+\\.([^.]+)\\.[^.]+/$", "$1") AS ?partOf)
+  BIND(REPLACE(STR(?wikimediaUrl), ".*/wiki/([^/]+)$", "$1") AS ?articleTitle)
+} ORDER BY ?partOf ?inLanguage

--- a/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/author-birthday.rq
+++ b/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/author-birthday.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Internal_Federation_Guide#How_do_I_use_federation?
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?dateOfBirth WHERE {
+  VALUES ?entity { wd:Q4781761 }
+  ?entity wdt:P50 ?authors .
+  ?authors wdt:P569 ?dateOfBirth .
+} LIMIT 10

--- a/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/paper-subjects.rq
+++ b/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/paper-subjects.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Internal_Federation_Guide#How_to_deal_with_linked_entities_spread_across_multiple_graphs?
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?subject ?subjectType WHERE {
+  VALUES ?paper { wd:Q59458901 }
+  ?paper wdt:P921 ?subject .
+  ?subject wdt:P31 ?subjectType .
+} LIMIT 10

--- a/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/simple-count.rq
+++ b/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/simple-count.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Federated_Queries_Examples#Simple_count
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX p: <http://www.wikidata.org/prop/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT (COUNT(?entity) AS ?count) WHERE {
+  ?entity wdt:P4101 wd:Q41506 .
+  ?entity p:P495 ?o .
+}

--- a/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/sitelinks-lookup.rq
+++ b/performance/benchmark-web/combinations/combination_1/input/queries/wikidata/sitelinks-lookup.rq
@@ -1,0 +1,12 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Federated_Queries_Examples#Sitelinks_lookup
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX schema: <http://schema.org/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+SELECT * WHERE {
+  VALUES ?item { wd:Q330955 wd:Q42 }
+  ?wikimediaUrl schema:about ?item ;
+    schema:isPartOf ?partOf_ ;
+    schema:inLanguage ?inLanguage .
+  BIND(REPLACE(STR(?partOf_), "^https://[^.]+\\.([^.]+)\\.[^.]+/$", "$1") AS ?partOf)
+  BIND(REPLACE(STR(?wikimediaUrl), ".*/wiki/([^/]+)$", "$1") AS ?articleTitle)
+} ORDER BY ?partOf ?inLanguage

--- a/performance/benchmark-web/input/queries/wikidata/author-birthday.rq
+++ b/performance/benchmark-web/input/queries/wikidata/author-birthday.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Internal_Federation_Guide#How_do_I_use_federation?
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?dateOfBirth WHERE {
+  VALUES ?entity { wd:Q4781761 }
+  ?entity wdt:P50 ?authors .
+  ?authors wdt:P569 ?dateOfBirth .
+} LIMIT 10

--- a/performance/benchmark-web/input/queries/wikidata/paper-subjects.rq
+++ b/performance/benchmark-web/input/queries/wikidata/paper-subjects.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Internal_Federation_Guide#How_to_deal_with_linked_entities_spread_across_multiple_graphs?
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT ?subject ?subjectType WHERE {
+  VALUES ?paper { wd:Q59458901 }
+  ?paper wdt:P921 ?subject .
+  ?subject wdt:P31 ?subjectType .
+} LIMIT 10

--- a/performance/benchmark-web/input/queries/wikidata/simple-count.rq
+++ b/performance/benchmark-web/input/queries/wikidata/simple-count.rq
@@ -1,0 +1,9 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Federated_Queries_Examples#Simple_count
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX p: <http://www.wikidata.org/prop/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+SELECT (COUNT(?entity) AS ?count) WHERE {
+  ?entity wdt:P4101 wd:Q41506 .
+  ?entity p:P495 ?o .
+}

--- a/performance/benchmark-web/input/queries/wikidata/sitelinks-lookup.rq
+++ b/performance/benchmark-web/input/queries/wikidata/sitelinks-lookup.rq
@@ -1,0 +1,12 @@
+# https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_graph_split/Federated_Queries_Examples#Sitelinks_lookup
+# Datasource: https://query-main.wikidata.org/bigdata/namespace/wdq/sparql https://query-scholarly.wikidata.org/bigdata/namespace/wdq/sparql
+PREFIX schema: <http://schema.org/>
+PREFIX wd: <http://www.wikidata.org/entity/>
+SELECT * WHERE {
+  VALUES ?item { wd:Q330955 wd:Q42 }
+  ?wikimediaUrl schema:about ?item ;
+    schema:isPartOf ?partOf_ ;
+    schema:inLanguage ?inLanguage .
+  BIND(REPLACE(STR(?partOf_), "^https://[^.]+\\.([^.]+)\\.[^.]+/$", "$1") AS ?partOf)
+  BIND(REPLACE(STR(?wikimediaUrl), ".*/wiki/([^/]+)$", "$1") AS ?articleTitle)
+} ORDER BY ?partOf ?inLanguage


### PR DESCRIPTION
This is the version of the VALUES clause expansion actor that I used for the Wikidata experiments. It works around some source assignment issues by filling in the bindings into the operations directly, allowing for VALUES bindings without any matches at the source to be pruned during query optimisation, as well.

I will need to check the variable scoping, to make sure nothing gets substituted that is meant to be projected out of the query, now that I think of it... :sweat_smile: 

The idea is open for comments, though.