### PR TITLE
Update documentation for bindings factory

### DIFF
--- a/packages/utils-bindings-factory/README.md
+++ b/packages/utils-bindings-factory/README.md
@@ -24,7 +24,7 @@ $ yarn add @comunica/utils-bindings-factory
 
 ```typescript
 import * as RDF from '@rdfjs/types';
-import { DataFactory } from '@comunica/utils-data-factory';
+import { DataFactory } from 'rdf-data-factory';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
 
 const DF = new DataFactory();


### PR DESCRIPTION
As per discussion https://github.com/comunica/comunica/issues/1628#issuecomment-3326650747

The [bindings factory documentation](https://github.com/comunica/comunica/tree/master/packages/utils-bindings-factory) currently demonstrates usage via [@comunica/utils-data-factory](https://github.com/comunica/comunica/tree/master/packages/utils-data-factory), however that package appears to be a work in progress/placeholder, so anyone running the example given in the documentation will find it doesn't work.

The [tests for bindings factory](https://github.com/comunica/comunica/blob/master/packages/utils-bindings-factory/test/BindingsFactory-test.ts) use the [rdf-data-factory](https://github.com/rubensworks/rdf-data-factory.js) package instead - this PR just updates the documentation to reflect package used in the tests.