### PR TITLE
Fix error handler ordering in N3 parser and unhandled JSON.parse in document loader

### DIFF
--- a/packages/actor-rdf-parse-jsonld/lib/DocumentLoaderMediated.ts
+++ b/packages/actor-rdf-parse-jsonld/lib/DocumentLoaderMediated.ts
@@ -38,7 +38,16 @@ export class DocumentLoaderMediated extends FetchDocumentLoader {
         lastCachePolicies[<string> url] = (context: IActionContext) => response
           .cachePolicy!.satisfiesWithoutRevalidation({ input: url, init, context });
       }
-      response.json = async() => JSON.parse(await stringifyStream(ActorHttp.toNodeReadable(response.body)));
+      response.json = async() => {
+        const body = await stringifyStream(ActorHttp.toNodeReadable(response.body));
+        try {
+          return JSON.parse(body);
+        } catch (error: unknown) {
+          throw new Error(
+            `Failed to parse JSON-LD response from ${url}: ${(<Error> error).message}`,
+          );
+        }
+      };
       return response;
     };
   }

--- a/packages/actor-rdf-parse-jsonld/lib/DocumentLoaderMediated.ts
+++ b/packages/actor-rdf-parse-jsonld/lib/DocumentLoaderMediated.ts
@@ -43,8 +43,9 @@ export class DocumentLoaderMediated extends FetchDocumentLoader {
         try {
           return JSON.parse(body);
         } catch (error: unknown) {
+          const urlStr: string = typeof url === 'string' ? url : url.url;
           throw new Error(
-            `Failed to parse JSON-LD response from ${url}: ${(<Error> error).message}`,
+            `Failed to parse JSON-LD response from ${urlStr}: ${(<Error> error).message}`,
           );
         }
       };

--- a/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
+++ b/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
@@ -1,0 +1,94 @@
+import { Readable } from 'node:stream';
+import { ActionContext } from '@comunica/core';
+import { KeysInitQuery } from '@comunica/context-entries';
+import { DataFactory } from 'rdf-data-factory';
+import { DocumentLoaderMediated } from '../lib/DocumentLoaderMediated';
+
+const DF = new DataFactory();
+
+describe('DocumentLoaderMediated', () => {
+  let context: any;
+  let mediatorHttp: any;
+
+  beforeEach(() => {
+    context = new ActionContext({ [KeysInitQuery.dataFactory.name]: DF });
+    mediatorHttp = {
+      mediate: jest.fn(),
+    };
+  });
+
+  describe('createFetcher', () => {
+    it('should parse valid JSON from response body', async() => {
+      const payload = { '@context': { '@vocab': 'http://example.org/' } };
+      mediatorHttp.mediate.mockResolvedValueOnce({
+        body: Readable.from([ JSON.stringify(payload) ]),
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'Content-Type': 'application/ld+json' }),
+      });
+
+      const fetcher = (<any> DocumentLoaderMediated).createFetcher(mediatorHttp, context, {});
+      const response = await fetcher('http://example.org/context.json', {});
+      const result = await response.json();
+
+      expect(result).toEqual(payload);
+    });
+
+    it('should throw a descriptive error when response body contains invalid JSON', async() => {
+      mediatorHttp.mediate.mockResolvedValueOnce({
+        body: Readable.from([ 'not valid json {{{' ]),
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'Content-Type': 'application/ld+json' }),
+      });
+
+      const fetcher = (<any> DocumentLoaderMediated).createFetcher(mediatorHttp, context, {});
+      const response = await fetcher('http://example.org/bad-context.json', {});
+
+      await expect(response.json()).rejects.toThrow(
+        'Failed to parse JSON-LD response from http://example.org/bad-context.json:',
+      );
+    });
+
+    it('should include the JSON parse error message in the thrown error', async() => {
+      mediatorHttp.mediate.mockResolvedValueOnce({
+        body: Readable.from([ '{invalid' ]),
+        ok: true,
+        status: 200,
+        headers: new Headers({ 'Content-Type': 'application/ld+json' }),
+      });
+
+      const fetcher = (<any> DocumentLoaderMediated).createFetcher(mediatorHttp, context, {});
+      const response = await fetcher('http://example.org/broken.json', {});
+
+      let thrown: Error | undefined;
+      try {
+        await response.json();
+      } catch (error: unknown) {
+        thrown = error as Error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown!.message).toContain('Failed to parse JSON-LD response from http://example.org/broken.json:');
+    });
+
+    it('should store cache policy when present in response', async() => {
+      const lastCachePolicies: Record<string, any> = {};
+      const cachePolicyFn = jest.fn().mockReturnValue(true);
+      mediatorHttp.mediate.mockResolvedValueOnce({
+        body: Readable.from([ '{}' ]),
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        cachePolicy: {
+          satisfiesWithoutRevalidation: cachePolicyFn,
+        },
+      });
+
+      const fetcher = (<any> DocumentLoaderMediated).createFetcher(mediatorHttp, context, lastCachePolicies);
+      await fetcher('http://example.org/cached.json', {});
+
+      expect(lastCachePolicies['http://example.org/cached.json']).toBeDefined();
+    });
+  });
+});

--- a/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
+++ b/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
@@ -19,7 +19,7 @@ describe('DocumentLoaderMediated', () => {
 
   describe('createFetcher', () => {
     it('should parse valid JSON from response body', async() => {
-      const payload = { '@context': { '@vocab': 'http://example.org/'}};
+      const payload = { '@context': { '@vocab': 'http://example.org/' } };
       mediatorHttp.mediate.mockResolvedValueOnce({
         body: Readable.from([ JSON.stringify(payload) ]),
         ok: true,

--- a/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
+++ b/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
@@ -72,6 +72,23 @@ describe('DocumentLoaderMediated', () => {
       expect(thrown!.message).toContain('Failed to parse JSON-LD response from http://example.org/broken.json:');
     });
 
+    it('should use Request.url when url is a Request object and JSON parse fails', async() => {
+      mediatorHttp.mediate.mockResolvedValueOnce({
+        body: Readable.from([ 'not json' ]),
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+      });
+
+      const fetcher = (<any> DocumentLoaderMediated).createFetcher(mediatorHttp, context, {});
+      const request = new Request('http://example.org/request-url.json');
+      const response = await fetcher(request, {});
+
+      await expect(response.json()).rejects.toThrow(
+        'Failed to parse JSON-LD response from http://example.org/request-url.json:',
+      );
+    });
+
     it('should store cache policy when present in response', async() => {
       const lastCachePolicies: Record<string, any> = {};
       const cachePolicyFn = jest.fn().mockReturnValue(true);

--- a/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
+++ b/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
@@ -19,7 +19,7 @@ describe('DocumentLoaderMediated', () => {
 
   describe('createFetcher', () => {
     it('should parse valid JSON from response body', async() => {
-      const payload = { '@context': { '@vocab': 'http://example.org/' } };
+      const payload = { '@context': { '@vocab': 'http://example.org/' }};
       mediatorHttp.mediate.mockResolvedValueOnce({
         body: Readable.from([ JSON.stringify(payload) ]),
         ok: true,

--- a/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
+++ b/packages/actor-rdf-parse-jsonld/test/DocumentLoaderMediated-test.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'node:stream';
-import { ActionContext } from '@comunica/core';
 import { KeysInitQuery } from '@comunica/context-entries';
+import { ActionContext } from '@comunica/core';
 import { DataFactory } from 'rdf-data-factory';
 import { DocumentLoaderMediated } from '../lib/DocumentLoaderMediated';
 
@@ -19,7 +19,7 @@ describe('DocumentLoaderMediated', () => {
 
   describe('createFetcher', () => {
     it('should parse valid JSON from response body', async() => {
-      const payload = { '@context': { '@vocab': 'http://example.org/' } };
+      const payload = { '@context': { '@vocab': 'http://example.org/'}};
       mediatorHttp.mediate.mockResolvedValueOnce({
         body: Readable.from([ JSON.stringify(payload) ]),
         ok: true,
@@ -65,7 +65,7 @@ describe('DocumentLoaderMediated', () => {
       try {
         await response.json();
       } catch (error: unknown) {
-        thrown = error as Error;
+        thrown = <Error> error;
       }
 
       expect(thrown).toBeInstanceOf(Error);

--- a/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
+++ b/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
@@ -35,7 +35,6 @@ export class ActorRdfParseN3 extends ActorRdfParseFixedMediaTypes {
   public async runHandle(action: IActionRdfParse, mediaType: string, _context: IActionContext):
   Promise<IActorRdfParseOutput> {
     const dataFactory: ComunicaDataFactory = action.context.getSafe(KeysInitQuery.dataFactory);
-    action.data.on('error', error => data.emit('error', error));
     const data = <Readable><any>action.data.pipe(new StreamParser({
       factory: dataFactory,
       baseIRI: action.metadata?.baseIRI,
@@ -47,6 +46,7 @@ export class ActorRdfParseN3 extends ActorRdfParseFixedMediaTypes {
       parseUnsupportedVersions: Boolean(action.context.get(KeysInitQuery.parseUnsupportedVersions)),
       version: action.metadata?.version,
     }));
+    action.data.on('error', error => data.emit('error', error));
     return {
       data,
       metadata: {

--- a/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
+++ b/packages/actor-rdf-parse-n3/lib/ActorRdfParseN3.ts
@@ -35,7 +35,7 @@ export class ActorRdfParseN3 extends ActorRdfParseFixedMediaTypes {
   public async runHandle(action: IActionRdfParse, mediaType: string, _context: IActionContext):
   Promise<IActorRdfParseOutput> {
     const dataFactory: ComunicaDataFactory = action.context.getSafe(KeysInitQuery.dataFactory);
-    const data = <Readable><any>action.data.pipe(new StreamParser({
+    const parser = new StreamParser({
       factory: dataFactory,
       baseIRI: action.metadata?.baseIRI,
       // Enable RDF-star-mode on all formats, except N3, where this is not supported.
@@ -45,8 +45,9 @@ export class ActorRdfParseN3 extends ActorRdfParseFixedMediaTypes {
       // @ts-expect-error
       parseUnsupportedVersions: Boolean(action.context.get(KeysInitQuery.parseUnsupportedVersions)),
       version: action.metadata?.version,
-    }));
-    action.data.on('error', error => data.emit('error', error));
+    });
+    action.data.on('error', error => parser.emit('error', error));
+    const data = <Readable><any>action.data.pipe(parser);
     return {
       data,
       metadata: {

--- a/packages/actor-rdf-parse-n3/test/ActorRdfParseN3-test.ts
+++ b/packages/actor-rdf-parse-n3/test/ActorRdfParseN3-test.ts
@@ -266,6 +266,15 @@ describe('ActorRdfParseN3', () => {
           .handle.data)).rejects.toBeTruthy();
       });
 
+      it('should propagate the original error message from input stream errors', async() => {
+        const specificError = new Readable();
+        specificError._read = () => specificError.emit('error', new Error('specific-parse-error-message'));
+        await expect(arrayifyStream((<any>(await actor.run(
+          { handle: { data: specificError, context }, handleMediaType: 'application/trig', context },
+        )))
+          .handle.data)).rejects.toThrow('specific-parse-error-message');
+      });
+
       it('should reject on an invalid version media type parameter', async() => {
         await expect(arrayifyStream((<any> (await actor.run({
           handle: { data: input, metadata: { baseIRI: '', version: '1.2-invalid' }, context },


### PR DESCRIPTION
## Summary

Was reading through the RDF parse actors and noticed two issues:

**1. Error handler references `data` before declaration in `ActorRdfParseN3`**

In `runHandle()`, the error handler on `action.data` (line 38) references the `data` variable, but `data` isn't declared until line 39 — the `const` binding is in the temporal dead zone at the point the handler is registered. While this normally works because Node.js stream errors fire asynchronously (so `data` is initialized by the time the callback runs), it's fragile: if an error were to fire synchronously during `.pipe()` setup, it would throw a `ReferenceError` instead of propagating the stream error. The HTML parse actor (`ActorRdfParseHtml`) avoids this by attaching error handlers after the target stream is created — just moved the line to match that pattern.

**2. Unhandled `JSON.parse` in `DocumentLoaderMediated`**

The `response.json` override in `createFetcher()` calls `JSON.parse()` without a try-catch. If a remote JSON-LD context endpoint returns malformed JSON (truncated response, HTML error page from a proxy, etc.), the raw `SyntaxError` propagates with no indication of which URL failed. Wrapped it in try-catch with a contextual error message that includes the URL, matching the pattern used in `HttpServiceSparqlEndpoint.ts` where `JSON.parse` is already guarded.

### Changes

- **`ActorRdfParseN3.ts`**: Move `action.data.on('error', ...)` after `const data = ...` declaration
- **`DocumentLoaderMediated.ts`**: Wrap `JSON.parse` in try-catch with URL in error message

## Test plan

- [ ] Existing N3/Turtle/N-Quads parsing tests still pass
- [ ] JSON-LD context loading with valid contexts still works
- [ ] Malformed JSON-LD context now produces error message with the failing URL