### PR TITLE
Compute rdfjs source cardinality metadata lazily, with a pattern cache

### DIFF
--- a/packages/actor-optimize-query-operation-query-source-skolemize/lib/utils.ts
+++ b/packages/actor-optimize-query-operation-query-source-skolemize/lib/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from '@comunica/types';
 import { Algebra, AlgebraFactory, algebraUtils } from '@comunica/utils-algebra';
 import { BlankNodeScoped } from '@comunica/utils-data-factory';
+import { deferMetadata } from '@comunica/utils-metadata';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { mapTermsNested } from 'rdf-terms';
@@ -102,7 +103,8 @@ export function skolemizeQuadStream(
       metadata.state.addInvalidateListener(inheritMetadata);
     });
   }
-  inheritMetadata();
+  // Inherit lazily upon the first request, so that sources can avoid computing unrequested metadata.
+  deferMetadata(ret, inheritMetadata);
   return ret;
 }
 
@@ -125,7 +127,8 @@ export function skolemizeBindingsStream(
       metadata.state.addInvalidateListener(inheritMetadata);
     });
   }
-  inheritMetadata();
+  // Inherit lazily upon the first request, so that sources can avoid computing unrequested metadata.
+  deferMetadata(ret, inheritMetadata);
   return ret;
 }
 

--- a/packages/actor-optimize-query-operation-query-source-skolemize/test/utils-test.ts
+++ b/packages/actor-optimize-query-operation-query-source-skolemize/test/utils-test.ts
@@ -1,0 +1,79 @@
+import { BindingsFactory } from '@comunica/utils-bindings-factory';
+import { MetadataValidationState } from '@comunica/utils-metadata';
+import type * as RDF from '@rdfjs/types';
+import { ArrayIterator } from 'asynciterator';
+import { DataFactory } from 'rdf-data-factory';
+import { skolemizeBindingsStream, skolemizeQuadStream } from '../lib';
+
+const DF = new DataFactory();
+const BF = new BindingsFactory(DF);
+
+describe('utils', () => {
+  describe('skolemizeQuadStream', () => {
+    let inner: ArrayIterator<RDF.Quad>;
+    beforeEach(() => {
+      inner = new ArrayIterator([
+        DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.blankNode('o')),
+      ], { autoStart: false });
+    });
+
+    it('should inherit metadata lazily upon the first request', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeQuadStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+    });
+
+    it('should re-inherit metadata upon invalidation', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeQuadStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+
+      inner.setProperty('metadata', {
+        state: new MetadataValidationState(),
+        cardinality: { type: 'exact', value: 2 },
+      });
+      state.invalidate();
+      await new Promise(resolve => setImmediate(resolve));
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+    });
+  });
+
+  describe('skolemizeBindingsStream', () => {
+    let inner: ArrayIterator<RDF.Bindings>;
+    beforeEach(() => {
+      inner = new ArrayIterator<RDF.Bindings>([
+        <RDF.Bindings> BF.fromRecord({ a: DF.blankNode('a0') }),
+      ], { autoStart: false });
+    });
+
+    it('should inherit metadata lazily upon the first request', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeBindingsStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+    });
+
+    it('should re-inherit metadata upon invalidation', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeBindingsStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+
+      inner.setProperty('metadata', {
+        state: new MetadataValidationState(),
+        cardinality: { type: 'exact', value: 2 },
+      });
+      state.invalidate();
+      await new Promise(resolve => setImmediate(resolve));
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+    });
+  });
+});

--- a/packages/actor-query-source-identify-rdfjs/lib/ActorQuerySourceIdentifyRdfJs.ts
+++ b/packages/actor-query-source-identify-rdfjs/lib/ActorQuerySourceIdentifyRdfJs.ts
@@ -18,10 +18,12 @@ import { QuerySourceRdfJs } from './QuerySourceRdfJs';
  */
 export class ActorQuerySourceIdentifyRdfJs extends ActorQuerySourceIdentify {
   public readonly mediatorMergeBindingsContext: MediatorMergeBindingsContext;
+  public readonly cacheSize: number;
 
   public constructor(args: IActorQuerySourceIdentifyRdfJsArgs) {
     super(args);
     this.mediatorMergeBindingsContext = args.mediatorMergeBindingsContext;
+    this.cacheSize = args.cacheSize;
   }
 
   public async test(action: IActionQuerySourceIdentify): Promise<TestResult<IActorTest>> {
@@ -43,6 +45,7 @@ export class ActorQuerySourceIdentifyRdfJs extends ActorQuerySourceIdentify {
           <RDF.Source | RDF.DatasetCore> action.querySourceUnidentified.value,
           dataFactory,
           await BindingsFactory.create(this.mediatorMergeBindingsContext, action.context, dataFactory),
+          this.cacheSize,
         ),
         context: action.querySourceUnidentified.context ?? new ActionContext(),
       },
@@ -55,4 +58,10 @@ export interface IActorQuerySourceIdentifyRdfJsArgs extends IActorQuerySourceIde
    * A mediator for creating binding context merge handlers
    */
   mediatorMergeBindingsContext: MediatorMergeBindingsContext;
+  /**
+   * The maximum number of entries in the pattern cardinality cache, set to 0 to disable.
+   * @range {integer}
+   * @default {1024}
+   */
+  cacheSize: number;
 }

--- a/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
+++ b/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
@@ -10,9 +10,11 @@ import type {
 } from '@comunica/types';
 import { Algebra, AlgebraFactory, isKnownOperation, TypesComunica } from '@comunica/utils-algebra';
 import type { BindingsFactory } from '@comunica/utils-bindings-factory';
-import { MetadataValidationState } from '@comunica/utils-metadata';
+import { deferMetadata, MetadataValidationState } from '@comunica/utils-metadata';
 import type * as RDF from '@rdfjs/types';
 import { ArrayIterator, AsyncIterator, wrap as wrapAsyncIterator } from 'asynciterator';
+import { LRUCache } from 'lru-cache';
+import { termToString } from 'rdf-string';
 import { filterTermsNested, someTerms, someTermsNested, uniqTerms } from 'rdf-terms';
 import type { IRdfJsSourceExtended } from './IRdfJsSourceExtended';
 
@@ -23,16 +25,23 @@ export class QuerySourceRdfJs implements IQuerySource {
   private readonly dataFactory: ComunicaDataFactory;
   private readonly bindingsFactory: BindingsFactory;
   private readonly dummyDefaultGraph: RDF.Variable;
+  private readonly cardinalityCache: LRUCache<string, number> | undefined;
+  private cardinalityCacheStoreSize: number | undefined;
 
   public constructor(
     source: RDF.Source | RDF.DatasetCore,
     dataFactory: ComunicaDataFactory,
     bindingsFactory: BindingsFactory,
+    cacheSize = 1_024,
   ) {
     this.source = source;
     this.referenceValue = source;
     this.dataFactory = dataFactory;
     this.bindingsFactory = bindingsFactory;
+    // Only enable cardinality caching if cache invalidation can be based on the source's size.
+    this.cardinalityCache = cacheSize > 0 && typeof (<RDF.DatasetCore> source).size === 'number' ?
+      new LRUCache({ max: cacheSize }) :
+      undefined;
     const AF = new AlgebraFactory(<RDF.DataFactory> this.dataFactory);
     let selectorShape: FragmentSelectorShape = {
       type: 'operation',
@@ -92,6 +101,21 @@ export class QuerySourceRdfJs implements IQuerySource {
   public static hasDuplicateVariables(pattern: RDF.BaseQuad): boolean {
     const variables = filterTermsNested(pattern, term => term.termType === 'Variable');
     return variables.length > 1 && uniqTerms(variables).length < variables.length;
+  }
+
+  /**
+   * Get the cardinality cache, after invalidating it if the source's size has changed.
+   * Sources without a synchronously accessible size never have a cache.
+   */
+  protected getValidatedCardinalityCache(): LRUCache<string, number> | undefined {
+    if (this.cardinalityCache) {
+      const size = (<RDF.DatasetCore> this.source).size;
+      if (size !== this.cardinalityCacheStoreSize) {
+        this.cardinalityCache.clear();
+        this.cardinalityCacheStoreSize = size;
+      }
+    }
+    return this.cardinalityCache;
   }
 
   public async getSelectorShape(): Promise<FragmentSelectorShape> {
@@ -196,11 +220,15 @@ export class QuerySourceRdfJs implements IQuerySource {
         operation.graph = this.dataFactory.defaultGraph();
       }
 
-      // Determine metadata
+      // Determine metadata lazily upon the first request,
+      // so that expensive cardinality counting is avoided when the metadata is never consumed.
       if (!it.getProperty('metadata')) {
         const variables = getVariables(operation).map(variable => ({ variable, canBeUndef: false }));
-        this.setMetadata(it, operation, context, forceEstimateCardinality, { variables })
-          .catch(error => it.destroy(error));
+        const target = it;
+        deferMetadata(target, () => {
+          this.setMetadata(target, operation, context, forceEstimateCardinality, { variables })
+            .catch(error => target.destroy(error));
+        });
       }
 
       return it;
@@ -225,24 +253,30 @@ export class QuerySourceRdfJs implements IQuerySource {
       it = filterMatchingQuotedQuads(operation, it);
     }
 
-    // Determine metadata
-    if (!it.getProperty('metadata')) {
-      this.setMetadata(it, operation, context)
-        .catch(error => it.destroy(error));
-    }
-
     // Restore graph for determining variable metadata
     if (operation.graph.equals(this.dummyDefaultGraph)) {
       operation.graph = this.dataFactory.defaultGraph();
     }
 
-    return quadsToBindings(
+    const bindings = quadsToBindings(
       it,
       operation,
       this.dataFactory,
       this.bindingsFactory,
       Boolean(context.get(KeysQueryOperation.unionDefaultGraph)),
     );
+
+    // Determine metadata lazily upon the first request,
+    // so that expensive cardinality counting is avoided when the metadata is never consumed.
+    // Metadata assigned to the quads iterator is propagated to the bindings stream by `quadsToBindings`.
+    if (!it.getProperty('metadata')) {
+      deferMetadata(bindings, () => {
+        this.setMetadata(it, operation, context)
+          .catch(error => it.destroy(error));
+      });
+    }
+
+    return bindings;
   }
 
   protected async setMetadata(
@@ -257,41 +291,48 @@ export class QuerySourceRdfJs implements IQuerySource {
 
     // Check if we're running in union default graph mode
     const unionDefaultGraph = Boolean(context.get(KeysQueryOperation.unionDefaultGraph));
-    if (operation.graph.termType === 'DefaultGraph' && unionDefaultGraph) {
-      operation.graph = this.dummyDefaultGraph;
+    let graph: RDF.Term = operation.graph;
+    if (graph.termType === 'DefaultGraph' && unionDefaultGraph) {
+      graph = this.dummyDefaultGraph;
     }
 
-    let cardinality: number;
-    if ('countQuads' in this.source && this.source.countQuads) {
-      // If the source provides a dedicated method for determining cardinality, use that.
-      cardinality = await this.source.countQuads(
-        QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.graph, quotedTripleFiltering),
-      );
-    } else {
-      // Otherwise, fallback to a sub-optimal alternative where we just call match again to count the quads.
-      // WARNING: we can NOT reuse the original data stream here,
-      // because we may lose data elements due to things happening async.
-      let i = 0;
-      cardinality = await new Promise((resolve, reject) => {
-        let matches = this.source.match(
-          QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering),
-          QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering),
-          QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering),
-          QuerySourceRdfJs.nullifyVariables(operation.graph, quotedTripleFiltering),
-        );
+    const subject = QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering);
+    const predicate = QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering);
+    const object = QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering);
+    const graphNullified = QuerySourceRdfJs.nullifyVariables(graph, quotedTripleFiltering);
 
-        // If it's not a stream, turn it into one
-        if (typeof (<any> matches).on !== 'function') {
-          matches = <RDF.Stream>(new ArrayIterator(<RDF.DatasetCore> matches, { autoStart: false }));
-        }
+    // Cardinalities of identical patterns are cached,
+    // as query plans (such as bind-joins) may request them many times.
+    // The cache is invalidated when the source's size changes.
+    const cache = this.getValidatedCardinalityCache();
+    const cacheKey = cache ?
+      JSON.stringify([ subject, predicate, object, graphNullified ]
+        .map(term => term ? termToString(term) : null)) :
+      undefined;
+    let cardinality: number | undefined = cache?.get(cacheKey!);
+    if (cardinality === undefined) {
+      if ('countQuads' in this.source && this.source.countQuads) {
+        // If the source provides a dedicated method for determining cardinality, use that.
+        cardinality = await this.source.countQuads(subject, predicate, object, graphNullified);
+      } else {
+        // Otherwise, fallback to a sub-optimal alternative where we just call match again to count the quads.
+        // WARNING: we can NOT reuse the original data stream here,
+        // because we may lose data elements due to things happening async.
+        let i = 0;
+        cardinality = await new Promise((resolve, reject) => {
+          let matches = this.source.match(subject, predicate, object, graphNullified);
 
-        (<RDF.Stream>matches).on('error', reject);
-        (<RDF.Stream>matches).on('end', () => resolve(i));
-        (<RDF.Stream>matches).on('data', () => i++);
-      });
+          // If it's not a stream, turn it into one
+          if (typeof (<any> matches).on !== 'function') {
+            matches = <RDF.Stream>(new ArrayIterator(<RDF.DatasetCore> matches, { autoStart: false }));
+          }
+
+          (<RDF.Stream>matches).on('error', reject);
+          (<RDF.Stream>matches).on('end', () => resolve(i));
+          (<RDF.Stream>matches).on('data', () => i++);
+        });
+      }
+      cache?.set(cacheKey!, cardinality);
     }
 
     // If `match` would require filtering afterwards, our count will be an over-estimate.

--- a/packages/actor-query-source-identify-rdfjs/package.json
+++ b/packages/actor-query-source-identify-rdfjs/package.json
@@ -51,6 +51,8 @@
     "@comunica/utils-metadata": "^5.2.3",
     "@rdfjs/types": "*",
     "asynciterator": "^3.10.0",
+    "lru-cache": "^11.2.2",
+    "rdf-string": "^2.0.1",
     "rdf-terms": "^2.0.0"
   }
 }

--- a/packages/actor-query-source-identify-rdfjs/test/ActorQuerySourceIdentifyRdfJs-test.ts
+++ b/packages/actor-query-source-identify-rdfjs/test/ActorQuerySourceIdentifyRdfJs-test.ts
@@ -44,7 +44,7 @@ describe('ActorQuerySourceIdentifyRdfJs', () => {
     let dataset: RDF.DatasetCore;
 
     beforeEach(() => {
-      actor = new ActorQuerySourceIdentifyRdfJs({ name: 'actor', bus, mediatorMergeBindingsContext });
+      actor = new ActorQuerySourceIdentifyRdfJs({ name: 'actor', bus, mediatorMergeBindingsContext, cacheSize: 100 });
       source = { match: () => <any> null };
 
       // Mock of empty dataset

--- a/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
+++ b/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
@@ -1075,4 +1075,150 @@ describe('QuerySourceRdfJs', () => {
         .toThrow(`queryVoid is not implemented in QuerySourceRdfJs`);
     });
   });
+
+  describe('cardinality metadata', () => {
+    let pattern: any;
+    beforeEach(() => {
+      store = new Store();
+      store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+      store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+      source = new QuerySourceRdfJs(store, DF, BF);
+      pattern = AF.createPattern(DF.variable('s'), DF.namedNode('p'), DF.variable('o'));
+    });
+
+    it('should not count quads if the metadata is never requested', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data = source.queryBindings(pattern, ctx);
+      await arrayifyStream(data);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should count quads once the metadata is requested', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      await arrayifyStream(data);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should serve repeated counts of the same pattern from the cache', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      for (let i = 0; i < 3; i++) {
+        const data = source.queryBindings(pattern, ctx);
+        await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+          .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      }
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should count different patterns separately', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data1 = source.queryBindings(pattern, ctx);
+      await new Promise(resolve => data1.getProperty('metadata', resolve));
+      const data2 = source.queryBindings(AF.createPattern(
+        DF.variable('s'),
+        DF.variable('p'),
+        DF.variable('o'),
+      ), ctx);
+      await expect(new Promise(resolve => data2.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should invalidate the cache when the store size changes', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data1 = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data1.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.namedNode('o3')));
+      const data2 = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data2.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 3 }}));
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache when cacheSize is 0', async() => {
+      source = new QuerySourceRdfJs(store, DF, BF, 0);
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      for (let i = 0; i < 2; i++) {
+        const data = source.queryBindings(pattern, ctx);
+        await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+          .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      }
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should count by matching for sources without countQuads and without size', async() => {
+      const match = jest.fn(() => new ArrayIterator([
+        DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')),
+      ], { autoStart: false }));
+      source = new QuerySourceRdfJs(<any> { match }, DF, BF);
+      for (let i = 0; i < 2; i++) {
+        const data = source.queryBindings(pattern, ctx);
+        await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+          .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+      }
+      // Twice per request: once for matching, once for counting; and no caching without a source size.
+      expect(match).toHaveBeenCalledTimes(4);
+    });
+
+    it('should count by iterating for sources returning non-stream matches', async() => {
+      const quads = [ DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')) ];
+      let calls = 0;
+      source = new QuerySourceRdfJs(<any> {
+        // Return an iterator for the data request, and a non-stream iterable for the count request.
+        match: () => calls++ === 0 ? new ArrayIterator(quads, { autoStart: false }) : <any> quads,
+      }, DF, BF);
+      const data = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+    });
+
+    it('should compute metadata lazily for matchBindings sources', async() => {
+      (<any> store).matchBindings = () => new ArrayIterator([], { autoStart: false });
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data = source.queryBindings(pattern, ctx);
+      await arrayifyStream(data);
+      expect(spy).not.toHaveBeenCalled();
+      await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should destroy the stream when lazy metadata computation fails for matchBindings sources', async() => {
+      (<any> store).matchBindings = () => new ArrayIterator([], { autoStart: false });
+      jest.spyOn(<Store> store, 'countQuads').mockImplementation(() => {
+        throw new Error('countQuads error in QuerySourceRdfJs-test');
+      });
+      const data = source.queryBindings(pattern, ctx);
+      data.getProperty('metadata', () => {
+        // Metadata will never be set.
+      });
+      await expect(new Promise((resolve, reject) => {
+        data.on('error', reject);
+        data.on('end', resolve);
+        data.on('data', () => {
+          // Consume data.
+        });
+      })).rejects.toThrow('countQuads error in QuerySourceRdfJs-test');
+    });
+
+    it('should destroy the stream when lazy metadata computation fails for match sources', async() => {
+      jest.spyOn(<Store> store, 'countQuads').mockImplementation(() => {
+        throw new Error('countQuads error in QuerySourceRdfJs-test');
+      });
+      const data = source.queryBindings(pattern, ctx);
+      data.getProperty('metadata', () => {
+        // Metadata will never be set.
+      });
+      await expect(new Promise((resolve, reject) => {
+        data.on('error', reject);
+        data.on('end', resolve);
+        data.on('data', () => {
+          // Consume data.
+        });
+      })).rejects.toThrow('countQuads error in QuerySourceRdfJs-test');
+    });
+  });
 });

--- a/packages/utils-metadata/lib/Utils.ts
+++ b/packages/utils-metadata/lib/Utils.ts
@@ -51,6 +51,35 @@ export function validateMetadataBindings(metadataRaw: Record<string, any>): Meta
 }
 
 /**
+ * Defer the computation of the 'metadata' property of a stream
+ * until the property is requested for the first time via `getProperty`.
+ *
+ * This avoids computing metadata (which may for example require expensive cardinality counting)
+ * for streams of which the metadata is never consumed,
+ * such as bindings streams of bound operations within a bind-join.
+ *
+ * @param data The stream to defer the metadata computation of.
+ * @param compute A callback that computes the metadata,
+ *                and eventually assigns it via `data.setProperty('metadata', ...)`.
+ *                It is invoked at most once,
+ *                synchronously upon the first `getProperty` call involving 'metadata'.
+ */
+export function deferMetadata(data: AsyncIterator<any>, compute: () => void): void {
+  // eslint-disable-next-line ts/unbound-method
+  const originalGetProperty = data.getProperty;
+  let pending = true;
+  data.getProperty = function<P>(this: AsyncIterator<any>, propertyName: string, listener?: (value: P) => void):
+  P | undefined {
+    if (pending && propertyName === 'metadata') {
+      pending = false;
+      this.getProperty = originalGetProperty;
+      compute();
+    }
+    return <P | undefined> originalGetProperty.call(this, propertyName, <((value: any) => void) | undefined> listener);
+  };
+}
+
+/**
  * Convert a metadata callback to a lazy callback where the response value is cached.
  * @param {() => Promise<IMetadata>} metadata A metadata callback
  * @return {() => Promise<{[p: string]: any}>} The callback where the response will be cached.

--- a/packages/utils-metadata/test/Utils-test.ts
+++ b/packages/utils-metadata/test/Utils-test.ts
@@ -1,6 +1,6 @@
 import type * as RDF from '@rdfjs/types';
 import { ArrayIterator } from 'asynciterator';
-import { cachifyMetadata, getMetadataBindings, getMetadataQuads, MetadataValidationState } from '../lib';
+import { cachifyMetadata, deferMetadata, getMetadataBindings, getMetadataQuads, MetadataValidationState } from '../lib';
 
 describe('Utils', () => {
   describe('getMetadataQuads', () => {
@@ -86,6 +86,42 @@ describe('Utils', () => {
       const it = new ArrayIterator<RDF.Bindings>([], { autoStart: false });
       setImmediate(() => it.setProperty('metadata', {}));
       await expect(getMetadataBindings(it)()).rejects.toThrow(`Invalid metadata: missing cardinality in {}`);
+    });
+  });
+
+  describe('deferMetadata', () => {
+    let iterator: ArrayIterator<number>;
+    beforeEach(() => {
+      iterator = new ArrayIterator([ 1, 2, 3 ], { autoStart: false });
+    });
+
+    it('should not compute if the metadata property is never requested', () => {
+      const compute = jest.fn();
+      deferMetadata(iterator, compute);
+      iterator.setProperty('other', 123);
+      expect(iterator.getProperty('other')).toBe(123);
+      expect(compute).not.toHaveBeenCalled();
+    });
+
+    it('should compute once upon the first metadata request', () => {
+      const compute = jest.fn(() => iterator.setProperty('metadata', 'META'));
+      deferMetadata(iterator, compute);
+      expect(iterator.getProperty('metadata')).toBe('META');
+      expect(iterator.getProperty('metadata')).toBe('META');
+      expect(compute).toHaveBeenCalledTimes(1);
+    });
+
+    it('should compute once upon the first metadata request with a listener', async() => {
+      const compute = jest.fn();
+      deferMetadata(iterator, compute);
+      const listener = jest.fn();
+      iterator.getProperty('metadata', listener);
+      iterator.getProperty('metadata', listener);
+      expect(compute).toHaveBeenCalledTimes(1);
+      iterator.setProperty('metadata', 'META');
+      await new Promise(resolve => setImmediate(resolve));
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledWith('META');
     });
   });
 


### PR DESCRIPTION
### Summary

`QuerySourceRdfJs` eagerly counts the cardinality of every pattern it is asked to evaluate, to populate the stream's `metadata` property. Profiling CSS-shaped workloads (SPARQL over in-memory rdf-js stores) on WatDiv shows this counting — not actual matching — dominating join-heavy queries: under a bind-join, the engine

1. counts patterns whose metadata is **never consumed** (bound single-pattern sub-operations mediate straight to `ActorQueryOperationSource`, whose `metadata` thunk is never invoked by the bind-join), and
2. **re-counts identical patterns once per outer binding** during recursive re-planning of the remaining join entries — including fully-unbound patterns whose counts cannot change — at O(matching quads) per count in stores such as N3.js (`N3Store._countInIndex`).

This PR makes the metadata computation lazy and caches pattern cardinalities:

- **`deferMetadata` utility** (in `@comunica/utils-metadata`): defers a stream's metadata computation until the property is first requested via `getProperty`. Applied to both `queryBindings` flows of `QuerySourceRdfJs` (`match` and `matchBindings`).
- **Laziness propagation through skolemization**: `skolemizeQuadStream` / `skolemizeBindingsStream` previously registered their metadata-inheritance listener eagerly, which would have forced the source's computation; they now inherit lazily too.
- **Pattern cardinality LRU cache** in `QuerySourceRdfJs` (new `cacheSize` parameter on `ActorQuerySourceIdentifyRdfJs`, default 1024, `0` disables — mirroring the COUNT-query cache of `QuerySourceSparql`). The cache is invalidated whenever the source's reported `size` changes, and is only enabled for sources exposing a numeric `size` (e.g. `Store`/`DatasetCore` implementations).

### Profile evidence (before)

WatDiv scale-10 (1,079,876 quads) in an `n3.Store`, `@comunica/query-sparql` from this monorepo (`d55a644`), Node v22.23.1, `--cpu-prof`:

- WatDiv **C2**: 47.6 s wall, **76.1 % of wall time inside `store.countQuads`** (11,294 calls totalling 36.9 s; instrumented separately). The six fully-unbound predicate patterns of the query were each re-counted 1,240–1,481× (e.g. `?v4 wsdbm:makesPurchase ?v7`, cardinality 15,000: 1,372 counts = 18.1 s).
- Mixed workload (L2,L3,S1,S4,F1,F3,F5,C1,C3): `N3Store._countInIndex` alone = **30.8 % of total self time**, plus 19.7 % GC largely fed by the same churn.

### After

Same C2 query: countQuads drops from 11,294 calls / 36,916 ms to **2,295 calls / 102 ms (0.7 % of wall)**; `store.match` calls are unchanged (11,294), i.e. the actual query evaluation work and results are identical.

### Query-level benchmarks

3 alternating baseline/branch pairs (fresh process per leg, same machine/era; medians of reps; WatDiv scale-10 over `n3.Store`, first template instantiation). Machine is a shared 2-core box, so ratios are the claim, not absolutes:

| Query | base p1 | fix p1 | base p2 | fix p2 | base p3 | fix p3 | speedup |
|---|---:|---:|---:|---:|---:|---:|---:|
| F1 | 168 ms | 107 ms | 169 ms | 115 ms | 171 ms | 151 ms | 1.1–1.6× |
| F3 | 1,851 ms | 436 ms | 1,393 ms | 395 ms | 1,837 ms | 393 ms | **3.5–4.7×** |
| F5 | 1,153 ms | 332 ms | 1,118 ms | 382 ms | 1,488 ms | 355 ms | **2.9–4.2×** |
| C1 | 4,803 ms | 1,318 ms | 3,709 ms | 1,088 ms | 3,445 ms | 851 ms | **3.4–4.1×** |
| C2 | 50,596 ms | 13,907 ms | 47,465 ms | 13,110 ms | 47,737 ms | 13,442 ms | **3.6×** |
| C3 | 6,397 ms | 4,031 ms | 4,639 ms | 3,737 ms | 3,721 ms | 3,457 ms | 1.1–1.6× |

Result counts identical across all templates in all runs (e.g. C3: 48,802 bindings). L/S templates, property paths, trivial selects (~0.8 ms/op engine overhead) and `INSERT`/`DELETE` update workloads show **no measurable change** (within noise, verified with interleaved in-process A/B batches in both leg orders).

### Correctness considerations

- Metadata contents are unchanged; only *when* the counting happens changes. It was already computed asynchronously relative to stream consumption before this PR.
- The cache is keyed on the nullified pattern terms (`termToString`, JSON-encoded to avoid ambiguity) and cleared whenever `source.size` differs from the size at fill time. A mutation that leaves the store at exactly the same size between two queries could serve a stale cardinality until the size next changes; cardinality metadata is planning-advisory, and `cacheSize: 0` opts out. Sources without a synchronous `size` are never cached.
- `setMetadata` no longer mutates `operation.graph` when substituting the union-default-graph dummy (it previously left the dummy variable assigned to the caller's operation object in the `matchBindings` flow).

### Tests

- New unit tests: `deferMetadata` (utils-metadata), cardinality caching/invalidations/laziness/`cacheSize: 0`/fallback counting (actor-query-source-identify-rdfjs), lazy + invalidation-driven metadata inheritance (skolemize utils).
- Changed lib files at 100 % statement/branch/function coverage in per-package runs; affected consumer suites green: `bus-rdf-join`, all `actor-rdf-join-*`, `actor-abstract-path`, `actor-optimize-query-operation-prune-empty-source-operations`, `actor-query-source-identify-hypermedia-none`, `actor-query-source-identify-compositefile`, and the `engines/query-sparql` system suite (123 tests). Lint clean on changed files.

### Notes

Generated by an agent (Claude Fable 5) on @jeswr's behalf — draft for maintainer review. The residual C2 cost (≈13 s) is the bind-join re-*executing* the unbound star-shaped component once per outer binding (`store.match` on unbound patterns 1,372×); that is a join-planning matter, out of scope here.

**Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).
