### PR TITLE
Compute SPARQL source metadata lazily, skip count queries for bound operations

### DIFF
--- a/packages/actor-optimize-query-operation-query-source-skolemize/lib/utils.ts
+++ b/packages/actor-optimize-query-operation-query-source-skolemize/lib/utils.ts
@@ -8,6 +8,7 @@ import type {
 } from '@comunica/types';
 import { Algebra, AlgebraFactory, algebraUtils } from '@comunica/utils-algebra';
 import { BlankNodeScoped } from '@comunica/utils-data-factory';
+import { deferMetadata } from '@comunica/utils-metadata';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
 import { mapTermsNested } from 'rdf-terms';
@@ -102,7 +103,8 @@ export function skolemizeQuadStream(
       metadata.state.addInvalidateListener(inheritMetadata);
     });
   }
-  inheritMetadata();
+  // Inherit lazily upon the first request, so that sources can avoid computing unrequested metadata.
+  deferMetadata(ret, inheritMetadata);
   return ret;
 }
 
@@ -125,7 +127,8 @@ export function skolemizeBindingsStream(
       metadata.state.addInvalidateListener(inheritMetadata);
     });
   }
-  inheritMetadata();
+  // Inherit lazily upon the first request, so that sources can avoid computing unrequested metadata.
+  deferMetadata(ret, inheritMetadata);
   return ret;
 }
 

--- a/packages/actor-optimize-query-operation-query-source-skolemize/test/utils-test.ts
+++ b/packages/actor-optimize-query-operation-query-source-skolemize/test/utils-test.ts
@@ -1,0 +1,79 @@
+import { BindingsFactory } from '@comunica/utils-bindings-factory';
+import { MetadataValidationState } from '@comunica/utils-metadata';
+import type * as RDF from '@rdfjs/types';
+import { ArrayIterator } from 'asynciterator';
+import { DataFactory } from 'rdf-data-factory';
+import { skolemizeBindingsStream, skolemizeQuadStream } from '../lib';
+
+const DF = new DataFactory();
+const BF = new BindingsFactory(DF);
+
+describe('utils', () => {
+  describe('skolemizeQuadStream', () => {
+    let inner: ArrayIterator<RDF.Quad>;
+    beforeEach(() => {
+      inner = new ArrayIterator([
+        DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.blankNode('o')),
+      ], { autoStart: false });
+    });
+
+    it('should inherit metadata lazily upon the first request', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeQuadStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+    });
+
+    it('should re-inherit metadata upon invalidation', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeQuadStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+
+      inner.setProperty('metadata', {
+        state: new MetadataValidationState(),
+        cardinality: { type: 'exact', value: 2 },
+      });
+      state.invalidate();
+      await new Promise(resolve => setImmediate(resolve));
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+    });
+  });
+
+  describe('skolemizeBindingsStream', () => {
+    let inner: ArrayIterator<RDF.Bindings>;
+    beforeEach(() => {
+      inner = new ArrayIterator<RDF.Bindings>([
+        <RDF.Bindings> BF.fromRecord({ a: DF.blankNode('a0') }),
+      ], { autoStart: false });
+    });
+
+    it('should inherit metadata lazily upon the first request', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeBindingsStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+    });
+
+    it('should re-inherit metadata upon invalidation', async() => {
+      const state = new MetadataValidationState();
+      inner.setProperty('metadata', { state, cardinality: { type: 'exact', value: 1 }});
+      const out = skolemizeBindingsStream(DF, inner, '0');
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+
+      inner.setProperty('metadata', {
+        state: new MetadataValidationState(),
+        cardinality: { type: 'exact', value: 2 },
+      });
+      state.invalidate();
+      await new Promise(resolve => setImmediate(resolve));
+      await expect(new Promise(resolve => out.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+    });
+  });
+});

--- a/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/lib/QuerySourceSparql.ts
@@ -18,7 +18,7 @@ import type {
 import type { AlgebraFactory } from '@comunica/utils-algebra';
 import { Algebra, algebraUtils, isKnownOperation } from '@comunica/utils-algebra';
 import type { BindingsFactory } from '@comunica/utils-bindings-factory';
-import { MetadataValidationState } from '@comunica/utils-metadata';
+import { deferMetadata, MetadataValidationState } from '@comunica/utils-metadata';
 import { estimateCardinality } from '@comunica/utils-query-operation';
 import type * as RDF from '@rdfjs/types';
 import type { AsyncIterator } from 'asynciterator';
@@ -205,7 +205,12 @@ export class QuerySourceSparql implements IQuerySource {
 
       return this.queryBindingsRemote(this.url, selectQuery, variables, context, undefVariables);
     }, { autoStart: false });
-    this.attachMetadata(bindings, context, operationPromise);
+    // Only attach metadata upon the first request,
+    // so that count queries are avoided when the metadata is never consumed.
+    deferMetadata(
+      bindings,
+      () => this.attachMetadata(bindings, context, operationPromise, Boolean(options?.joinBindings)),
+    );
 
     return bindings;
   }
@@ -217,7 +222,12 @@ export class QuerySourceSparql implements IQuerySource {
       const rawStream = await this.endpointFetcher.fetchTriples(this.url, query);
       return rawStream;
     })(), { autoStart: false, maxBufferSize: Number.POSITIVE_INFINITY });
-    this.attachMetadata(quads, context, Promise.resolve((<Algebra.Operation & { input: any }>operation).input));
+    // Only attach metadata upon the first request,
+    // so that count queries are avoided when the metadata is never consumed.
+    deferMetadata(
+      quads,
+      () => this.attachMetadata(quads, context, Promise.resolve((<Algebra.Operation & { input: any }>operation).input)),
+    );
     return quads;
   }
 
@@ -244,6 +254,7 @@ export class QuerySourceSparql implements IQuerySource {
     target: AsyncIterator<any>,
     context: IActionContext,
     operationPromise: Promise<Algebra.Operation>,
+    boundOperation = false,
   ): void {
     // Emit metadata containing the estimated count
     let variablesCount: MetadataVariable[] = [];
@@ -252,13 +263,21 @@ export class QuerySourceSparql implements IQuerySource {
       try {
         const operation = await operationPromise;
         const variablesScoped = algebraUtils.inScopeVariables(operation);
-        const countQuery = await this.operationToNormalizedCountQuery(operation);
 
         const undefVariables = QuerySourceSparql.getOperationUndefs(operation);
         variablesCount = variablesScoped.map(variable => ({
           variable,
           canBeUndef: undefVariables.some(undefVariable => undefVariable.equals(variable)),
         }));
+
+        // Don't send count queries for operations bound within a join,
+        // as the join has already been planned based on the unbound operation's cardinality,
+        // and an exact per-chunk count would cost an additional endpoint request per bound chunk.
+        if (boundOperation) {
+          return resolve({ type: 'estimate', value: Number.POSITIVE_INFINITY, dataset: this.url });
+        }
+
+        const countQuery = await this.operationToNormalizedCountQuery(operation);
 
         const cachedCardinality = this.cache?.get(countQuery);
         if (cachedCardinality) {

--- a/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
+++ b/packages/actor-query-source-identify-hypermedia-sparql/test/QuerySourceSparql-test.ts
@@ -165,11 +165,12 @@ describe('QuerySourceSparql', () => {
 
   describe('queryBindings', () => {
     it('should return data', async() => {
-      await expect(source.queryBindings(AF.createPattern(
+      const stream = source.queryBindings(AF.createPattern(
         iriS,
         DF.variable('p'),
         iriO,
-      ), ctx))
+      ), ctx);
+      await expect(stream)
         .toEqualBindingsStream([
           BF.fromRecord({
             p: DF.namedNode('p1'),
@@ -181,6 +182,7 @@ describe('QuerySourceSparql', () => {
             p: DF.namedNode('p3'),
           }),
         ]);
+      await new Promise(resolve => stream.getProperty('metadata', resolve));
 
       expect(mediatorHttp.mediate).toHaveBeenCalledTimes(2);
       expect(mediatorHttp.mediate).toHaveBeenCalledWith({
@@ -194,13 +196,13 @@ describe('QuerySourceSparql', () => {
       });
     });
 
-    it('should return data with local cardinality estimation', async() => {
-      jest.spyOn(source, 'estimateOperationCardinality').mockResolvedValue({
-        type: 'estimate',
-        value: 1,
-        dataset: url,
-      });
-      await expect(source.queryBindings(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), ctx))
+    it('should not send a count query when the metadata is never requested', async() => {
+      const stream = source.queryBindings(AF.createPattern(
+        iriS,
+        DF.variable('p'),
+        iriO,
+      ), ctx);
+      await expect(stream)
         .toEqualBindingsStream([
           BF.fromRecord({
             p: DF.namedNode('p1'),
@@ -212,6 +214,37 @@ describe('QuerySourceSparql', () => {
             p: DF.namedNode('p3'),
           }),
         ]);
+
+      expect(mediatorHttp.mediate).toHaveBeenCalledTimes(1);
+      expect(lastQuery).toBe(`query=${encodeURIComponent(`SELECT ?p WHERE { <${testUrl('s')}> ?p <${testUrl('o')}> . }`).replaceAll('%20', '+')}`);
+    });
+
+    it('should return data with local cardinality estimation', async() => {
+      jest.spyOn(source, 'estimateOperationCardinality').mockResolvedValue({
+        type: 'estimate',
+        value: 1,
+        dataset: url,
+      });
+      const stream = source.queryBindings(
+        AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')),
+        ctx,
+      );
+      await expect(stream)
+        .toEqualBindingsStream([
+          BF.fromRecord({
+            p: DF.namedNode('p1'),
+          }),
+          BF.fromRecord({
+            p: DF.namedNode('p2'),
+          }),
+          BF.fromRecord({
+            p: DF.namedNode('p3'),
+          }),
+        ]);
+      await expect(new Promise(resolve => stream.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({
+          cardinality: { type: 'estimate', value: 1, dataset: url },
+        }));
 
       expect(mediatorHttp.mediate).toHaveBeenCalledTimes(1);
     });
@@ -1020,6 +1053,79 @@ describe('QuerySourceSparql', () => {
         .rejects.toThrow(new Error('Some stream error'));
     });
 
+    it('should emit metadata for non-pattern operations', async() => {
+      const stream = source.queryBindings(AF.createJoin([
+        AF.createPattern(iriS, DF.variable('p'), iriO),
+        AF.createPattern(iriS, DF.variable('p2'), iriO),
+      ]), ctx);
+      await expect(new Promise(resolve => stream.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({
+          cardinality: { type: 'exact', value: 3, dataset: url },
+        }));
+      expect(lastQuery).toContain('COUNT');
+    });
+
+    it('should emit metadata for patterns with non-variable terms', async() => {
+      const stream = source.queryBindings(AF.createPattern(
+        iriS,
+        iriP,
+        DF.variable('o'),
+      ), ctx);
+      await expect(new Promise(resolve => stream.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({
+          cardinality: { type: 'exact', value: 3, dataset: url },
+        }));
+      expect(lastQuery).toContain('COUNT');
+      expect(lastQuery).toContain(encodeURIComponent(`<${testUrl('p')}>`));
+    });
+
+    it('should emit metadata with infinity count for erroring count results', async() => {
+      const thisMediator: any = {
+        mediate: jest.fn((action: any) => {
+          const query: string = action.init.method === 'GET' ? action.input : action.init.body.toString();
+          if (isCountQuery(query)) {
+            const errorBody = new Readable();
+            errorBody._read = () => setImmediate(() => errorBody.emit('error', new Error('Count stream error')));
+            return {
+              headers: new Headers({ 'Content-Type': 'application/sparql-results+json' }),
+              body: errorBody,
+              ok: true,
+            };
+          }
+          return mediatorHttp.mediate(action);
+        }),
+      };
+      const thisSource = new QuerySourceSparql(
+        url,
+        url,
+        ctx,
+        thisMediator,
+        mediatorQuerySerialize,
+        'values',
+        DF,
+        AF,
+        BF,
+        false,
+        64,
+        10,
+        true,
+        true,
+        0,
+        false,
+
+        {},
+      );
+      const stream = thisSource.queryBindings(AF.createPattern(
+        iriS,
+        DF.variable('p'),
+        iriO,
+      ), ctx);
+      await expect(new Promise(resolve => stream.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({
+          cardinality: { type: 'estimate', value: Number.POSITIVE_INFINITY, dataset: url },
+        }));
+    });
+
     it('should emit metadata with infinity count for invalid count results', async() => {
       const thisMediator: any = {
         mediate(action: any) {
@@ -1275,7 +1381,11 @@ describe('QuerySourceSparql', () => {
         {},
       );
 
-      await expect(source.queryBindings(AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')), ctx))
+      const stream = source.queryBindings(
+        AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')),
+        ctx,
+      );
+      await expect(stream)
         .toEqualBindingsStream([
           BF.fromRecord({
             p: DF.namedNode('p1'),
@@ -1287,6 +1397,7 @@ describe('QuerySourceSparql', () => {
             p: DF.namedNode('p3'),
           }),
         ]);
+      await new Promise(resolve => stream.getProperty('metadata', resolve));
 
       expect(mediatorHttp.mediate).toHaveBeenCalledTimes(2);
       expect(mediatorHttp.mediate).toHaveBeenCalledWith({
@@ -1342,7 +1453,9 @@ describe('QuerySourceSparql', () => {
       it('should perform an url encoded HTTP POST request when acceptPost includes the url-encoded type', async() => {
         source = getSource([ 'application/x-www-form-urlencoded', 'application/sparql-query' ]);
 
-        await expect(source.queryBindings(operationIn, ctx)).toEqualBindingsStream(expectedResult);
+        const stream = source.queryBindings(operationIn, ctx);
+        await expect(stream).toEqualBindingsStream(expectedResult);
+        await new Promise(resolve => stream.getProperty('metadata', resolve));
 
         expect(mediatorHttp.mediate).toHaveBeenCalledTimes(2);
         expect(mediatorHttp.mediate).toHaveBeenCalledWith({
@@ -1359,7 +1472,9 @@ describe('QuerySourceSparql', () => {
       it('should perform a direct HTTP POST request when acceptPost doesn\'t include the url-encoded type', async() => {
         source = getSource([ 'application/sparql-query' ]);
 
-        await expect(source.queryBindings(operationIn, ctx)).toEqualBindingsStream(expectedResult);
+        const stream = source.queryBindings(operationIn, ctx);
+        await expect(stream).toEqualBindingsStream(expectedResult);
+        await new Promise(resolve => stream.getProperty('metadata', resolve));
 
         expect(mediatorHttp.mediate).toHaveBeenCalledTimes(2);
         expect(mediatorHttp.mediate).toHaveBeenCalledWith({
@@ -1375,7 +1490,7 @@ describe('QuerySourceSparql', () => {
     });
 
     it('should return data when joining bindings', async() => {
-      await expect(source.queryBindings(
+      const stream = source.queryBindings(
         AF.createPattern(iriS, DF.variable('p'), iriO),
         ctx,
         {
@@ -1384,7 +1499,8 @@ describe('QuerySourceSparql', () => {
             metadata: <any> { variables: []},
           },
         },
-      ))
+      );
+      await expect(stream)
         .toEqualBindingsStream([
           BF.fromRecord({
             p: DF.namedNode('p1'),
@@ -1396,12 +1512,17 @@ describe('QuerySourceSparql', () => {
             p: DF.namedNode('p3'),
           }),
         ]);
-      expect(lastQuery).toBe(`query=SELECT+%28+COUNT%28+*+%29+AS+%3Fcount+%29+WHERE+%7B+VALUES%28+%29%7B+%7D%3Chttps%3A%2F%2Fex%2Fs%3E+%3Fp+%3Chttps%3A%2F%2Fex%2Fo%3E+.+%7D`);
+      // Bound operations don't send count queries, so their metadata cardinality is an estimate.
+      await expect(new Promise(resolve => stream.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({
+          cardinality: { type: 'estimate', value: Number.POSITIVE_INFINITY, dataset: url },
+        }));
+      expect(mediatorHttp.mediate).toHaveBeenCalledTimes(1);
 
       expect(mediatorHttp.mediate).toHaveBeenCalledWith({
         context: ctx,
         init: {
-          body: new URLSearchParams({ query: `SELECT ( COUNT( * ) AS ?count ) WHERE { VALUES( ){ }<${testUrl('s')}> ?p <${testUrl('o')}> . }` }),
+          body: new URLSearchParams({ query: `SELECT ?p WHERE { VALUES( ){ }<${testUrl('s')}> ?p <${testUrl('o')}> . }` }),
           headers: expect.anything(),
           method: 'POST',
         },
@@ -1410,7 +1531,7 @@ describe('QuerySourceSparql', () => {
     });
 
     it('ignores queryString for joinBindings', async() => {
-      await expect(source.queryBindings(
+      const stream = source.queryBindings(
         AF.createPattern(iriS, DF.variable('p'), iriO),
         ctx.set(KeysInitQuery.queryString, 'abc'), // This must be ignored
         {
@@ -1419,7 +1540,8 @@ describe('QuerySourceSparql', () => {
             metadata: <any> { variables: []},
           },
         },
-      ))
+      );
+      await expect(stream)
         .toEqualBindingsStream([
           BF.fromRecord({
             p: DF.namedNode('p1'),
@@ -1431,12 +1553,13 @@ describe('QuerySourceSparql', () => {
             p: DF.namedNode('p3'),
           }),
         ]);
-      expect(lastQuery).toBe(`query=SELECT+%28+COUNT%28+*+%29+AS+%3Fcount+%29+WHERE+%7B+VALUES%28+%29%7B+%7D%3Chttps%3A%2F%2Fex%2Fs%3E+%3Fp+%3Chttps%3A%2F%2Fex%2Fo%3E+.+%7D`);
+      await new Promise(resolve => stream.getProperty('metadata', resolve));
+      expect(lastQuery).toBe(`query=SELECT+%3Fp+WHERE+%7B+VALUES%28+%29%7B+%7D%3Chttps%3A%2F%2Fex%2Fs%3E+%3Fp+%3Chttps%3A%2F%2Fex%2Fo%3E+.+%7D`);
 
       expect(mediatorHttp.mediate).toHaveBeenCalledWith({
         context: ctx.set(KeysInitQuery.queryString, 'abc'),
         init: {
-          body: new URLSearchParams({ query: `SELECT ( COUNT( * ) AS ?count ) WHERE { VALUES( ){ }<${testUrl('s')}> ?p <${testUrl('o')}> . }` }),
+          body: new URLSearchParams({ query: `SELECT ?p WHERE { VALUES( ){ }<${testUrl('s')}> ?p <${testUrl('o')}> . }` }),
           headers: expect.anything(),
           method: 'POST',
         },
@@ -1562,12 +1685,13 @@ describe('QuerySourceSparql', () => {
     });
 
     it('should not pass the original queryString if queryFormat is not sparql', async() => {
-      await expect(source.queryBindings(
+      const stream = source.queryBindings(
         AF.createPattern(DF.namedNode('s'), DF.variable('p'), DF.namedNode('o')),
         ctx
           .set(KeysInitQuery.queryString, 'abc')
           .set(KeysInitQuery.queryFormat, { language: 'graphql', version: '1.0' }),
-      ))
+      );
+      await expect(stream)
         .toEqualBindingsStream([
           BF.fromRecord({
             p: DF.namedNode('p1'),
@@ -1579,6 +1703,7 @@ describe('QuerySourceSparql', () => {
             p: DF.namedNode('p3'),
           }),
         ]);
+      await new Promise(resolve => stream.getProperty('metadata', resolve));
 
       expect(mediatorHttp.mediate).toHaveBeenCalledWith({
         context: ctx

--- a/packages/actor-query-source-identify-rdfjs/lib/ActorQuerySourceIdentifyRdfJs.ts
+++ b/packages/actor-query-source-identify-rdfjs/lib/ActorQuerySourceIdentifyRdfJs.ts
@@ -18,10 +18,12 @@ import { QuerySourceRdfJs } from './QuerySourceRdfJs';
  */
 export class ActorQuerySourceIdentifyRdfJs extends ActorQuerySourceIdentify {
   public readonly mediatorMergeBindingsContext: MediatorMergeBindingsContext;
+  public readonly cacheSize: number;
 
   public constructor(args: IActorQuerySourceIdentifyRdfJsArgs) {
     super(args);
     this.mediatorMergeBindingsContext = args.mediatorMergeBindingsContext;
+    this.cacheSize = args.cacheSize;
   }
 
   public async test(action: IActionQuerySourceIdentify): Promise<TestResult<IActorTest>> {
@@ -43,6 +45,7 @@ export class ActorQuerySourceIdentifyRdfJs extends ActorQuerySourceIdentify {
           <RDF.Source | RDF.DatasetCore> action.querySourceUnidentified.value,
           dataFactory,
           await BindingsFactory.create(this.mediatorMergeBindingsContext, action.context, dataFactory),
+          this.cacheSize,
         ),
         context: action.querySourceUnidentified.context ?? new ActionContext(),
       },
@@ -55,4 +58,10 @@ export interface IActorQuerySourceIdentifyRdfJsArgs extends IActorQuerySourceIde
    * A mediator for creating binding context merge handlers
    */
   mediatorMergeBindingsContext: MediatorMergeBindingsContext;
+  /**
+   * The maximum number of entries in the pattern cardinality cache, set to 0 to disable.
+   * @range {integer}
+   * @default {1024}
+   */
+  cacheSize: number;
 }

--- a/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
+++ b/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
@@ -10,9 +10,11 @@ import type {
 } from '@comunica/types';
 import { Algebra, AlgebraFactory, isKnownOperation, TypesComunica } from '@comunica/utils-algebra';
 import type { BindingsFactory } from '@comunica/utils-bindings-factory';
-import { MetadataValidationState } from '@comunica/utils-metadata';
+import { deferMetadata, MetadataValidationState } from '@comunica/utils-metadata';
 import type * as RDF from '@rdfjs/types';
 import { ArrayIterator, AsyncIterator, wrap as wrapAsyncIterator } from 'asynciterator';
+import { LRUCache } from 'lru-cache';
+import { termToString } from 'rdf-string';
 import { filterTermsNested, someTerms, someTermsNested, uniqTerms } from 'rdf-terms';
 import type { IRdfJsSourceExtended } from './IRdfJsSourceExtended';
 
@@ -23,16 +25,23 @@ export class QuerySourceRdfJs implements IQuerySource {
   private readonly dataFactory: ComunicaDataFactory;
   private readonly bindingsFactory: BindingsFactory;
   private readonly dummyDefaultGraph: RDF.Variable;
+  private readonly cardinalityCache: LRUCache<string, number> | undefined;
+  private cardinalityCacheStoreSize: number | undefined;
 
   public constructor(
     source: RDF.Source | RDF.DatasetCore,
     dataFactory: ComunicaDataFactory,
     bindingsFactory: BindingsFactory,
+    cacheSize = 1_024,
   ) {
     this.source = source;
     this.referenceValue = source;
     this.dataFactory = dataFactory;
     this.bindingsFactory = bindingsFactory;
+    // Only enable cardinality caching if cache invalidation can be based on the source's size.
+    this.cardinalityCache = cacheSize > 0 && typeof (<RDF.DatasetCore> source).size === 'number' ?
+      new LRUCache({ max: cacheSize }) :
+      undefined;
     const AF = new AlgebraFactory(<RDF.DataFactory> this.dataFactory);
     let selectorShape: FragmentSelectorShape = {
       type: 'operation',
@@ -92,6 +101,21 @@ export class QuerySourceRdfJs implements IQuerySource {
   public static hasDuplicateVariables(pattern: RDF.BaseQuad): boolean {
     const variables = filterTermsNested(pattern, term => term.termType === 'Variable');
     return variables.length > 1 && uniqTerms(variables).length < variables.length;
+  }
+
+  /**
+   * Get the cardinality cache, after invalidating it if the source's size has changed.
+   * Sources without a synchronously accessible size never have a cache.
+   */
+  protected getValidatedCardinalityCache(): LRUCache<string, number> | undefined {
+    if (this.cardinalityCache) {
+      const size = (<RDF.DatasetCore> this.source).size;
+      if (size !== this.cardinalityCacheStoreSize) {
+        this.cardinalityCache.clear();
+        this.cardinalityCacheStoreSize = size;
+      }
+    }
+    return this.cardinalityCache;
   }
 
   public async getSelectorShape(): Promise<FragmentSelectorShape> {
@@ -196,11 +220,15 @@ export class QuerySourceRdfJs implements IQuerySource {
         operation.graph = this.dataFactory.defaultGraph();
       }
 
-      // Determine metadata
+      // Determine metadata lazily upon the first request,
+      // so that expensive cardinality counting is avoided when the metadata is never consumed.
       if (!it.getProperty('metadata')) {
         const variables = getVariables(operation).map(variable => ({ variable, canBeUndef: false }));
-        this.setMetadata(it, operation, context, forceEstimateCardinality, { variables })
-          .catch(error => it.destroy(error));
+        const target = it;
+        deferMetadata(target, () => {
+          this.setMetadata(target, operation, context, forceEstimateCardinality, { variables })
+            .catch(error => target.destroy(error));
+        });
       }
 
       return it;
@@ -225,24 +253,30 @@ export class QuerySourceRdfJs implements IQuerySource {
       it = filterMatchingQuotedQuads(operation, it);
     }
 
-    // Determine metadata
-    if (!it.getProperty('metadata')) {
-      this.setMetadata(it, operation, context)
-        .catch(error => it.destroy(error));
-    }
-
     // Restore graph for determining variable metadata
     if (operation.graph.equals(this.dummyDefaultGraph)) {
       operation.graph = this.dataFactory.defaultGraph();
     }
 
-    return quadsToBindings(
+    const bindings = quadsToBindings(
       it,
       operation,
       this.dataFactory,
       this.bindingsFactory,
       Boolean(context.get(KeysQueryOperation.unionDefaultGraph)),
     );
+
+    // Determine metadata lazily upon the first request,
+    // so that expensive cardinality counting is avoided when the metadata is never consumed.
+    // Metadata assigned to the quads iterator is propagated to the bindings stream by `quadsToBindings`.
+    if (!it.getProperty('metadata')) {
+      deferMetadata(bindings, () => {
+        this.setMetadata(it, operation, context)
+          .catch(error => it.destroy(error));
+      });
+    }
+
+    return bindings;
   }
 
   protected async setMetadata(
@@ -257,41 +291,48 @@ export class QuerySourceRdfJs implements IQuerySource {
 
     // Check if we're running in union default graph mode
     const unionDefaultGraph = Boolean(context.get(KeysQueryOperation.unionDefaultGraph));
-    if (operation.graph.termType === 'DefaultGraph' && unionDefaultGraph) {
-      operation.graph = this.dummyDefaultGraph;
+    let graph: RDF.Term = operation.graph;
+    if (graph.termType === 'DefaultGraph' && unionDefaultGraph) {
+      graph = this.dummyDefaultGraph;
     }
 
-    let cardinality: number;
-    if ('countQuads' in this.source && this.source.countQuads) {
-      // If the source provides a dedicated method for determining cardinality, use that.
-      cardinality = await this.source.countQuads(
-        QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.graph, quotedTripleFiltering),
-      );
-    } else {
-      // Otherwise, fallback to a sub-optimal alternative where we just call match again to count the quads.
-      // WARNING: we can NOT reuse the original data stream here,
-      // because we may lose data elements due to things happening async.
-      let i = 0;
-      cardinality = await new Promise((resolve, reject) => {
-        let matches = this.source.match(
-          QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering),
-          QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering),
-          QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering),
-          QuerySourceRdfJs.nullifyVariables(operation.graph, quotedTripleFiltering),
-        );
+    const subject = QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering);
+    const predicate = QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering);
+    const object = QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering);
+    const graphNullified = QuerySourceRdfJs.nullifyVariables(graph, quotedTripleFiltering);
 
-        // If it's not a stream, turn it into one
-        if (typeof (<any> matches).on !== 'function') {
-          matches = <RDF.Stream>(new ArrayIterator(<RDF.DatasetCore> matches, { autoStart: false }));
-        }
+    // Cardinalities of identical patterns are cached,
+    // as query plans (such as bind-joins) may request them many times.
+    // The cache is invalidated when the source's size changes.
+    const cache = this.getValidatedCardinalityCache();
+    const cacheKey = cache ?
+      JSON.stringify([ subject, predicate, object, graphNullified ]
+        .map(term => term ? termToString(term) : null)) :
+      undefined;
+    let cardinality: number | undefined = cache?.get(cacheKey!);
+    if (cardinality === undefined) {
+      if ('countQuads' in this.source && this.source.countQuads) {
+        // If the source provides a dedicated method for determining cardinality, use that.
+        cardinality = await this.source.countQuads(subject, predicate, object, graphNullified);
+      } else {
+        // Otherwise, fallback to a sub-optimal alternative where we just call match again to count the quads.
+        // WARNING: we can NOT reuse the original data stream here,
+        // because we may lose data elements due to things happening async.
+        let i = 0;
+        cardinality = await new Promise((resolve, reject) => {
+          let matches = this.source.match(subject, predicate, object, graphNullified);
 
-        (<RDF.Stream>matches).on('error', reject);
-        (<RDF.Stream>matches).on('end', () => resolve(i));
-        (<RDF.Stream>matches).on('data', () => i++);
-      });
+          // If it's not a stream, turn it into one
+          if (typeof (<any> matches).on !== 'function') {
+            matches = <RDF.Stream>(new ArrayIterator(<RDF.DatasetCore> matches, { autoStart: false }));
+          }
+
+          (<RDF.Stream>matches).on('error', reject);
+          (<RDF.Stream>matches).on('end', () => resolve(i));
+          (<RDF.Stream>matches).on('data', () => i++);
+        });
+      }
+      cache?.set(cacheKey!, cardinality);
     }
 
     // If `match` would require filtering afterwards, our count will be an over-estimate.

--- a/packages/actor-query-source-identify-rdfjs/package.json
+++ b/packages/actor-query-source-identify-rdfjs/package.json
@@ -51,6 +51,8 @@
     "@comunica/utils-metadata": "^5.2.3",
     "@rdfjs/types": "*",
     "asynciterator": "^3.10.0",
+    "lru-cache": "^11.2.2",
+    "rdf-string": "^2.0.1",
     "rdf-terms": "^2.0.0"
   }
 }

--- a/packages/actor-query-source-identify-rdfjs/test/ActorQuerySourceIdentifyRdfJs-test.ts
+++ b/packages/actor-query-source-identify-rdfjs/test/ActorQuerySourceIdentifyRdfJs-test.ts
@@ -44,7 +44,7 @@ describe('ActorQuerySourceIdentifyRdfJs', () => {
     let dataset: RDF.DatasetCore;
 
     beforeEach(() => {
-      actor = new ActorQuerySourceIdentifyRdfJs({ name: 'actor', bus, mediatorMergeBindingsContext });
+      actor = new ActorQuerySourceIdentifyRdfJs({ name: 'actor', bus, mediatorMergeBindingsContext, cacheSize: 100 });
       source = { match: () => <any> null };
 
       // Mock of empty dataset

--- a/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
+++ b/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
@@ -1075,4 +1075,150 @@ describe('QuerySourceRdfJs', () => {
         .toThrow(`queryVoid is not implemented in QuerySourceRdfJs`);
     });
   });
+
+  describe('cardinality metadata', () => {
+    let pattern: any;
+    beforeEach(() => {
+      store = new Store();
+      store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+      store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+      source = new QuerySourceRdfJs(store, DF, BF);
+      pattern = AF.createPattern(DF.variable('s'), DF.namedNode('p'), DF.variable('o'));
+    });
+
+    it('should not count quads if the metadata is never requested', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data = source.queryBindings(pattern, ctx);
+      await arrayifyStream(data);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should count quads once the metadata is requested', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      await arrayifyStream(data);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should serve repeated counts of the same pattern from the cache', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      for (let i = 0; i < 3; i++) {
+        const data = source.queryBindings(pattern, ctx);
+        await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+          .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      }
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should count different patterns separately', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data1 = source.queryBindings(pattern, ctx);
+      await new Promise(resolve => data1.getProperty('metadata', resolve));
+      const data2 = source.queryBindings(AF.createPattern(
+        DF.variable('s'),
+        DF.variable('p'),
+        DF.variable('o'),
+      ), ctx);
+      await expect(new Promise(resolve => data2.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should invalidate the cache when the store size changes', async() => {
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data1 = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data1.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.namedNode('o3')));
+      const data2 = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data2.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 3 }}));
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache when cacheSize is 0', async() => {
+      source = new QuerySourceRdfJs(store, DF, BF, 0);
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      for (let i = 0; i < 2; i++) {
+        const data = source.queryBindings(pattern, ctx);
+        await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+          .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      }
+      expect(spy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should count by matching for sources without countQuads and without size', async() => {
+      const match = jest.fn(() => new ArrayIterator([
+        DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')),
+      ], { autoStart: false }));
+      source = new QuerySourceRdfJs(<any> { match }, DF, BF);
+      for (let i = 0; i < 2; i++) {
+        const data = source.queryBindings(pattern, ctx);
+        await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+          .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+      }
+      // Twice per request: once for matching, once for counting; and no caching without a source size.
+      expect(match).toHaveBeenCalledTimes(4);
+    });
+
+    it('should count by iterating for sources returning non-stream matches', async() => {
+      const quads = [ DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')) ];
+      let calls = 0;
+      source = new QuerySourceRdfJs(<any> {
+        // Return an iterator for the data request, and a non-stream iterable for the count request.
+        match: () => calls++ === 0 ? new ArrayIterator(quads, { autoStart: false }) : <any> quads,
+      }, DF, BF);
+      const data = source.queryBindings(pattern, ctx);
+      await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 1 }}));
+    });
+
+    it('should compute metadata lazily for matchBindings sources', async() => {
+      (<any> store).matchBindings = () => new ArrayIterator([], { autoStart: false });
+      const spy = jest.spyOn(<Store> store, 'countQuads');
+      const data = source.queryBindings(pattern, ctx);
+      await arrayifyStream(data);
+      expect(spy).not.toHaveBeenCalled();
+      await expect(new Promise(resolve => data.getProperty('metadata', resolve))).resolves
+        .toEqual(expect.objectContaining({ cardinality: { type: 'exact', value: 2 }}));
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should destroy the stream when lazy metadata computation fails for matchBindings sources', async() => {
+      (<any> store).matchBindings = () => new ArrayIterator([], { autoStart: false });
+      jest.spyOn(<Store> store, 'countQuads').mockImplementation(() => {
+        throw new Error('countQuads error in QuerySourceRdfJs-test');
+      });
+      const data = source.queryBindings(pattern, ctx);
+      data.getProperty('metadata', () => {
+        // Metadata will never be set.
+      });
+      await expect(new Promise((resolve, reject) => {
+        data.on('error', reject);
+        data.on('end', resolve);
+        data.on('data', () => {
+          // Consume data.
+        });
+      })).rejects.toThrow('countQuads error in QuerySourceRdfJs-test');
+    });
+
+    it('should destroy the stream when lazy metadata computation fails for match sources', async() => {
+      jest.spyOn(<Store> store, 'countQuads').mockImplementation(() => {
+        throw new Error('countQuads error in QuerySourceRdfJs-test');
+      });
+      const data = source.queryBindings(pattern, ctx);
+      data.getProperty('metadata', () => {
+        // Metadata will never be set.
+      });
+      await expect(new Promise((resolve, reject) => {
+        data.on('error', reject);
+        data.on('end', resolve);
+        data.on('data', () => {
+          // Consume data.
+        });
+      })).rejects.toThrow('countQuads error in QuerySourceRdfJs-test');
+    });
+  });
 });

--- a/packages/utils-metadata/lib/Utils.ts
+++ b/packages/utils-metadata/lib/Utils.ts
@@ -51,6 +51,35 @@ export function validateMetadataBindings(metadataRaw: Record<string, any>): Meta
 }
 
 /**
+ * Defer the computation of the 'metadata' property of a stream
+ * until the property is requested for the first time via `getProperty`.
+ *
+ * This avoids computing metadata (which may for example require expensive cardinality counting)
+ * for streams of which the metadata is never consumed,
+ * such as bindings streams of bound operations within a bind-join.
+ *
+ * @param data The stream to defer the metadata computation of.
+ * @param compute A callback that computes the metadata,
+ *                and eventually assigns it via `data.setProperty('metadata', ...)`.
+ *                It is invoked at most once,
+ *                synchronously upon the first `getProperty` call involving 'metadata'.
+ */
+export function deferMetadata(data: AsyncIterator<any>, compute: () => void): void {
+  // eslint-disable-next-line ts/unbound-method
+  const originalGetProperty = data.getProperty;
+  let pending = true;
+  data.getProperty = function<P>(this: AsyncIterator<any>, propertyName: string, listener?: (value: P) => void):
+  P | undefined {
+    if (pending && propertyName === 'metadata') {
+      pending = false;
+      this.getProperty = originalGetProperty;
+      compute();
+    }
+    return <P | undefined> originalGetProperty.call(this, propertyName, <((value: any) => void) | undefined> listener);
+  };
+}
+
+/**
  * Convert a metadata callback to a lazy callback where the response value is cached.
  * @param {() => Promise<IMetadata>} metadata A metadata callback
  * @return {() => Promise<{[p: string]: any}>} The callback where the response will be cached.

--- a/packages/utils-metadata/test/Utils-test.ts
+++ b/packages/utils-metadata/test/Utils-test.ts
@@ -1,6 +1,6 @@
 import type * as RDF from '@rdfjs/types';
 import { ArrayIterator } from 'asynciterator';
-import { cachifyMetadata, getMetadataBindings, getMetadataQuads, MetadataValidationState } from '../lib';
+import { cachifyMetadata, deferMetadata, getMetadataBindings, getMetadataQuads, MetadataValidationState } from '../lib';
 
 describe('Utils', () => {
   describe('getMetadataQuads', () => {
@@ -86,6 +86,42 @@ describe('Utils', () => {
       const it = new ArrayIterator<RDF.Bindings>([], { autoStart: false });
       setImmediate(() => it.setProperty('metadata', {}));
       await expect(getMetadataBindings(it)()).rejects.toThrow(`Invalid metadata: missing cardinality in {}`);
+    });
+  });
+
+  describe('deferMetadata', () => {
+    let iterator: ArrayIterator<number>;
+    beforeEach(() => {
+      iterator = new ArrayIterator([ 1, 2, 3 ], { autoStart: false });
+    });
+
+    it('should not compute if the metadata property is never requested', () => {
+      const compute = jest.fn();
+      deferMetadata(iterator, compute);
+      iterator.setProperty('other', 123);
+      expect(iterator.getProperty('other')).toBe(123);
+      expect(compute).not.toHaveBeenCalled();
+    });
+
+    it('should compute once upon the first metadata request', () => {
+      const compute = jest.fn(() => iterator.setProperty('metadata', 'META'));
+      deferMetadata(iterator, compute);
+      expect(iterator.getProperty('metadata')).toBe('META');
+      expect(iterator.getProperty('metadata')).toBe('META');
+      expect(compute).toHaveBeenCalledTimes(1);
+    });
+
+    it('should compute once upon the first metadata request with a listener', async() => {
+      const compute = jest.fn();
+      deferMetadata(iterator, compute);
+      const listener = jest.fn();
+      iterator.getProperty('metadata', listener);
+      iterator.getProperty('metadata', listener);
+      expect(compute).toHaveBeenCalledTimes(1);
+      iterator.setProperty('metadata', 'META');
+      await new Promise(resolve => setImmediate(resolve));
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledWith('META');
     });
   });
 


### PR DESCRIPTION
### Summary

Follow-up to #1725, applying the same lazy-metadata principle to `QuerySourceSparql` (**stacked on #1725** — it uses the `deferMetadata` utility introduced there; the last commit is this PR's own diff).

Two changes in `QuerySourceSparql`:

1. **Lazy metadata attachment**: `attachMetadata` (which issues a `SELECT (COUNT(*) ...)` request to the endpoint) now runs upon the first request of the stream's `metadata` property instead of on every `queryBindings`/`queryQuads` call. Count queries are avoided entirely when the metadata is never consumed.
2. **No count queries for bound operations**: sub-operations evaluated with `joinBindings` (the chunked `VALUES` pushdowns issued by `ActorRdfJoinMultiBindSource`) no longer send a COUNT query, and report `{ type: 'estimate', value: ∞ }` instead — the same convention already used when `cardinalityCountQueries` is disabled or the count times out. Rationale: the join was already planned on the *unbound* operation's cardinality; the per-chunk exact COUNT costs one extra endpoint request per bound chunk, and (verified by tracing) its only consumer in the default config is the hypermedia metadata accumulator, whose per-iterator metadata read is structural (link traversal) rather than cardinality-driven.

### Measured (end-to-end, default `@comunica/query-sparql` config)

Two local HTTP SPARQL endpoints (in-process, backed by an unmodified engine over rdf-js stores, constant across legs), federated join `?s <urn:bought> ?m . ?m <urn:item> ?o` across 300 links (~19 bound chunks of the default block size), fresh engine per leg, 2 alternating pairs:

| leg | data requests | COUNT requests | total | results |
|---|---:|---:|---:|---:|
| master (`d55a644`) | 20 | 23 | 43 | 300 |
| this PR | 20 | **4** | **24** | 300 |

**44 % fewer endpoint requests**; the 4 remaining COUNTs are genuinely consumed (per-pattern source selection by `ActorOptimizeQueryOperationPruneEmptySourceOperations` and join planning). Results identical in all runs. Wall-clock on the (noisy, shared 2-core) measurement box was not treated as evidence; the request counts are deterministic across runs.

Single-endpoint whole-query pushdown (scenario A) issues no COUNT on master either (the count path is not reached for non-pattern root operations), so no change there — noted for honesty.

### Why not defer in the hypermedia layer too

`LinkedRdfSourcesAsyncRdfIterator` requests every sub-iterator's metadata eagerly, but that read is load-bearing: metadata carries the next-page links and gates traversal termination (`startIteratorsForNextUrls`). Making that lazy would require a way for sources to declare "no next links" — a design-level change we did not attempt here. This PR removes the wasted *endpoint requests* behind that read instead.

### Tests

- All 98 tests in `actor-query-source-identify-hypermedia-sparql` green; `QuerySourceSparql.ts` coverage at parity with master (99.49 % stmts / 98.55 % branch; the only uncovered line pre-dates this PR).
- New/updated tests: laziness (no COUNT when metadata unread), estimate metadata for `joinBindings` operations, count-response error path, non-pattern and non-variable-term count normalization, local-cardinality-estimation path now asserts the estimated metadata.
- `engines/query-sparql` system suite (123 tests) green. Lint clean.

### Notes

Generated by an agent (Claude Fable 5) on @jeswr's behalf — draft for maintainer review. If maintainers prefer the bound-operation count skip behind a flag (e.g. alongside `cardinalityCountQueries`), that is a small follow-up — kept flag-free here to minimize config surface.

**Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).
