### PR TITLE
Avoid intermediate array allocation in BusIndexed.publish

### DIFF
--- a/packages/core/lib/BusIndexed.ts
+++ b/packages/core/lib/BusIndexed.ts
@@ -71,7 +71,22 @@ export class BusIndexed<A extends Actor<I, T, O, any>, I extends IAction, T exte
   public override publish(action: I): IActorReply<A, I, T, O>[] {
     const actionId = this.getActionIdentifier(action);
     if (actionId) {
-      const actors = [ ...this.actorsIndex[actionId] || [], ...this.actorsIndex._undefined_ || [] ];
+      const indexMatches = this.actorsIndex[actionId];
+      const undefMatches = this.actorsIndex._undefined_;
+      // Avoid concatenating the two actor lists when at most one of them is non-empty (the common case),
+      // as the concatenation would otherwise allocate an intermediate array on this hot path.
+      // `map` is only ever called on the index lists directly, never mutating them.
+      let actors: A[];
+      if (!indexMatches || indexMatches.length === 0) {
+        if (!undefMatches) {
+          return [];
+        }
+        actors = undefMatches;
+      } else if (!undefMatches || undefMatches.length === 0) {
+        actors = indexMatches;
+      } else {
+        actors = [ ...indexMatches, ...undefMatches ];
+      }
       return actors.map((actor: A): IActorReply<A, I, T, O> => ({ actor, reply: actor.test(action) }));
     }
     return super.publish(action);


### PR DESCRIPTION
### Summary

`BusIndexed.publish` — invoked on **every actor mediation in every query** — built its actor list as `[ ...this.actorsIndex[actionId] || [], ...this.actorsIndex._undefined_ || [] ]`, allocating and copying an intermediate array before `.map` allocates the reply array.

Profiling shows one of the two buckets is almost always empty:

- On the busiest bus in a query, **`bus-query-operation`** (~557 publishes for WatDiv F3), the action-id bucket is empty and all **~34** actors sit in `_undefined_` — so the spread copies all 34 actors needlessly on every publish (~19k needless element copies for F3 alone).
- Media-type buses (rdf-parse/serialize) hit the mirror case: all actors identified, `_undefined_` empty.

Both-non-empty happens only for buses that mix identified and unidentified actors *and* receive a matching action id — rare on the query hot path.

This maps directly over the single non-empty bucket when the other is empty, falling back to concatenation only when both buckets are non-empty. `.map` returns a fresh array and never mutates the index lists; the both-non-empty and no-action-id cases are behaviourally unchanged (including the pre-existing `actionId === '_undefined_'` aliasing).

### Measurement

**Isolated microbenchmark** (34-actor bus, index-empty / `_undefined_`-nonempty case — the `bus-query-operation` shape; 2M publishes, 6 alternating base/fix reps, `--expose-gc`, shared 2-core box):

| | ns/op (median) |
|---|---:|
| master (`d55a644`) | 2508 |
| this PR | **2075** |

→ **1.21×** on the publish call itself (~17 % fewer ns/op; the 34 `actor.test()` calls are included in both, so the machinery-only reduction is proportionally larger).

**Query level**: comunica's mediation is a small share of whole-query CPU (n3-store operations + GC dominate a WatDiv profile at ~72 %), so the effect is within this box's noise. Across 3 alternating separate-process pairs, the mediation-sensitive trivial-select path (`SELECT * WHERE { ?s ?p ?o }`, per-op) was directionally faster on the branch (base medians 692/725/692 µs vs branch 677/629/679 µs) and no measured path regressed. The honest claim is: **a proven isolated reduction in per-publish CPU and allocation on a code path universal to all mediations, with reduced GC pressure**, not a headline query-level speedup.

Results are identical (this is a pure allocation/ordering-preserving refactor).

### Tests

All 188 `@comunica/core` tests pass unchanged (the existing `BusIndexed` suite already covers index-only, `_undefined_`-only, both, and no-action-id publish cases). `BusIndexed.ts` branch coverage 94.44 % → 95.65 % (the sole remaining uncovered branch pre-dates this PR). Lint clean.

### Notes

Generated by an agent (Claude Fable 5) on @jeswr's behalf — draft for maintainer review. Independent of #1725/#1726 (branched from master).

**Review timing:** This draft was prepared with Claude; I (@jeswr) will personally review it before it progresses. I'm currently batching a lot of work in flight, so expect active review Wednesday–Friday (8–10 July).
