### PR TITLE
Added new rdf parser and rdf writer actors

### DIFF
--- a/packages/actor-rdf-parse-rdf-parser-ts/README.md
+++ b/packages/actor-rdf-parse-rdf-parser-ts/README.md
@@ -1,0 +1,62 @@
+# Comunica rdf-parser.ts RDF Parse Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-rdf-parse-rdf-parser-ts.svg)](https://www.npmjs.com/package/@comunica/actor-rdf-parse-rdf-parser-ts)
+
+An [RDF Parse](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-parse) actor that handles
+Turtle, TriG, N-Quads, and N-Triples using [rdf-parser.ts](https://www.npmjs.com/package/rdf-parser-ts).
+
+This actor does not handle N3 rules/formulas. Use `@comunica/actor-rdf-parse-n3` when `text/n3` support is required.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica),
+and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
+
+[Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
+
+## Parser performance
+
+The table below compares this actor with `@comunica/actor-rdf-parse-n3` on parser-only synthetic inputs,
+without executing a SPARQL query. The benchmark invokes each actor's `runHandle` method and consumes the resulting quad stream.
+
+Environment: Linux, Node.js 25.9.0, 1,000,000 quads/triples per run, 5 measured runs after 1 warmup,
+`node --expose-gc`. The table reports median wall-clock time.
+
+| Media type | N3.js actor | rdf-parser.ts actor | Speedup |
+| --- | ---: | ---: | ---: |
+| `application/n-triples` | 1.110s (900,632 quads/s) | 1.111s (900,100 quads/s) | 1.00x |
+| `application/n-quads` | 1.563s (639,792 quads/s) | 1.288s (776,689 quads/s) | 1.21x |
+| `text/turtle` | 1.648s (606,939 quads/s) | 1.441s (693,910 quads/s) | 1.14x |
+
+These numbers are indicative local measurements. End-to-end Comunica query performance can differ because query planning,
+source access, iterator scheduling, and result materialization may dominate parser cost.
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-rdf-parse-rdf-parser-ts
+```
+
+## Configure
+
+After installing, this package can be added to your engine's configuration as follows:
+```text
+{
+  "@context": [
+    ...
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-parse-rdf-parser-ts/^5.0.0/components/context.jsonld"
+  ],
+  "actors": [
+    ...
+    {
+      "@id": "urn:comunica:default:rdf-parse/actors#rdf-parser-ts",
+      "@type": "ActorRdfParseRdfParserTs",
+      "priorityScale": 1.0
+    }
+  ]
+}
+```
+
+It can be configured next to `@comunica/actor-rdf-parse-n3`; content negotiation priorities decide which actor is selected for overlapping RDF media types.
+
+### Config Parameters
+
+* `priorityScale`: An optional priority for this parser, used for content negotiation, defaults to `1`.

--- a/packages/actor-rdf-parse-rdf-parser-ts/lib/ActorRdfParseRdfParserTs.ts
+++ b/packages/actor-rdf-parse-rdf-parser-ts/lib/ActorRdfParseRdfParserTs.ts
@@ -1,0 +1,50 @@
+import type { IActionRdfParse, IActorRdfParseFixedMediaTypesArgs, IActorRdfParseOutput } from '@comunica/bus-rdf-parse';
+import { ActorRdfParseFixedMediaTypes } from '@comunica/bus-rdf-parse';
+import { KeysInitQuery } from '@comunica/context-entries';
+import type { ComunicaDataFactory, IActionContext } from '@comunica/types';
+import { StreamParser } from 'rdf-parser-ts';
+import type { Readable } from 'readable-stream';
+
+/**
+ * An rdf-parser.ts RDF Parse actor that listens on the 'rdf-parse' bus.
+ *
+ * It is able to parse Turtle, TriG, N-Quads, and N-Triples.
+ */
+export class ActorRdfParseRdfParserTs extends ActorRdfParseFixedMediaTypes {
+  /**
+   * @param args -
+   *   \ @defaultNested {{
+   *       "application/n-quads": 1.0,
+   *       "application/trig": 0.95,
+   *       "application/n-triples": 0.8,
+   *       "text/turtle": 0.6
+   *     }} mediaTypePriorities
+   *   \ @defaultNested {{
+   *       "application/n-quads": "http://www.w3.org/ns/formats/N-Quads",
+   *       "application/trig": "http://www.w3.org/ns/formats/TriG",
+   *       "application/n-triples": "http://www.w3.org/ns/formats/N-Triples",
+   *       "text/turtle": "http://www.w3.org/ns/formats/Turtle"
+   *     }} mediaTypeFormats
+   */
+  public constructor(args: IActorRdfParseFixedMediaTypesArgs) {
+    super(args);
+  }
+
+  public async runHandle(action: IActionRdfParse, mediaType: string, _context: IActionContext):
+  Promise<IActorRdfParseOutput> {
+    const dataFactory: ComunicaDataFactory = action.context.getSafe(KeysInitQuery.dataFactory);
+    action.data.on('error', error => data.emit('error', error));
+    const data = <Readable><any>action.data.pipe(new StreamParser({
+      factory: dataFactory,
+      baseIRI: action.metadata?.baseIRI,
+      format: `${mediaType}*`,
+    }));
+    return {
+      data,
+      metadata: {
+        triples: mediaType === 'text/turtle' ||
+        mediaType === 'application/n-triples',
+      },
+    };
+  }
+}

--- a/packages/actor-rdf-parse-rdf-parser-ts/lib/index.ts
+++ b/packages/actor-rdf-parse-rdf-parser-ts/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './ActorRdfParseRdfParserTs';

--- a/packages/actor-rdf-parse-rdf-parser-ts/package.json
+++ b/packages/actor-rdf-parse-rdf-parser-ts/package.json
@@ -38,6 +38,6 @@
     "@comunica/bus-rdf-parse": "^5.2.3",
     "@comunica/context-entries": "^5.2.3",
     "@comunica/types": "^5.2.3",
-    "rdf-parser-ts": "^0.3.0"
+    "rdf-parser-ts": "^0.3.1"
   }
 }

--- a/packages/actor-rdf-parse-rdf-parser-ts/package.json
+++ b/packages/actor-rdf-parse-rdf-parser-ts/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@comunica/actor-rdf-parse-rdf-parser-ts",
+  "version": "5.2.3",
+  "description": "An rdf-parser.ts RDF Parse actor",
+  "lsd:module": true,
+  "license": "MIT",
+  "homepage": "https://github.com/comunica/actor-rdf-parse-rdf-parser-ts#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/comunica/comunica.git",
+    "directory": "packages/actor-rdf-parse-rdf-parser-ts"
+  },
+  "bugs": {
+    "url": "https://github.com/comunica/actor-rdf-parse-rdf-parser-ts/issues"
+  },
+  "keywords": [
+    "comunica",
+    "runner"
+  ],
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "typings": "lib/index",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.js.map"
+  ],
+  "scripts": {
+    "build": "yarn run build:ts && yarn run build:components",
+    "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
+    "build:components": "componentsjs-generator"
+  },
+  "dependencies": {
+    "@comunica/bus-rdf-parse": "^5.2.3",
+    "@comunica/context-entries": "^5.2.3",
+    "@comunica/types": "^5.2.3",
+    "rdf-parser-ts": "^0.3.0"
+  }
+}

--- a/packages/actor-rdf-parse-rdf-parser-ts/test/ActorRdfParseRdfParserTs-test.ts
+++ b/packages/actor-rdf-parse-rdf-parser-ts/test/ActorRdfParseRdfParserTs-test.ts
@@ -1,0 +1,227 @@
+import { Readable } from 'node:stream';
+import { ActorRdfParseFixedMediaTypes } from '@comunica/bus-rdf-parse';
+import { KeysInitQuery } from '@comunica/context-entries';
+import { ActionContext, Bus } from '@comunica/core';
+import type { IActionContext } from '@comunica/types';
+import arrayifyStream from 'arrayify-stream';
+import { DataFactory } from 'rdf-data-factory';
+import { ActorRdfParseRdfParserTs } from '../lib/ActorRdfParseRdfParserTs';
+import '@comunica/utils-jest';
+
+const DF = new DataFactory();
+
+describe('ActorRdfParseRdfParserTs', () => {
+  let bus: any;
+  let context: IActionContext;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+    context = new ActionContext({ [KeysInitQuery.dataFactory.name]: DF });
+  });
+
+  describe('The ActorRdfParseRdfParserTs module', () => {
+    it('should be a function', () => {
+      expect(ActorRdfParseRdfParserTs).toBeInstanceOf(Function);
+    });
+
+    it('should be a ActorRdfParseRdfParserTs constructor', () => {
+      expect(new (<any>ActorRdfParseRdfParserTs)({ name: 'actor', bus, mediaTypePriorities: {}}))
+        .toBeInstanceOf(ActorRdfParseRdfParserTs);
+      expect(new (<any>ActorRdfParseRdfParserTs)({ name: 'actor', bus, mediaTypePriorities: {}}))
+        .toBeInstanceOf(ActorRdfParseFixedMediaTypes);
+    });
+
+    it('should not be able to create new ActorRdfParseRdfParserTs objects without \'new\'', () => {
+      expect(() => {
+        (<any>ActorRdfParseRdfParserTs)();
+      }).toThrow(`Class constructor ActorRdfParseRdfParserTs cannot be invoked without 'new'`);
+    });
+
+    it('should not throw an error when constructed with required arguments', () => {
+      expect(() => {
+        new ActorRdfParseRdfParserTs(
+          { name: 'actor', bus, mediaTypePriorities: {}, mediaTypeFormats: {}},
+        );
+      }).toBeTruthy();
+    });
+
+    it('when constructed with optional mediaTypePriorities should set the mediaTypePriorities', () => {
+      expect(new ActorRdfParseRdfParserTs(
+        { name: 'actor', bus, mediaTypePriorities: {}, mediaTypeFormats: {}},
+      ).mediaTypePriorities).toEqual({});
+    });
+
+    it('should not throw an error when constructed with optional priorityScale', () => {
+      expect(() => {
+        new ActorRdfParseRdfParserTs(
+          { name: 'actor', bus, mediaTypePriorities: {}, mediaTypeFormats: {}, priorityScale: 0.5 },
+        );
+      }).toBeTruthy();
+    });
+
+    it('when constructed with optional priorityScale should set the priorityScale', () => {
+      expect(new ActorRdfParseRdfParserTs(
+        { name: 'actor', bus, mediaTypePriorities: {}, mediaTypeFormats: {}, priorityScale: 0.5 },
+      ).priorityScale)
+        .toBe(0.5);
+    });
+
+    it('when constructed with optional priorityScale should scale the priorities', () => {
+      expect(new ActorRdfParseRdfParserTs(
+        { name: 'actor', bus, mediaTypePriorities: { A: 2, B: 1, C: 0 }, mediaTypeFormats: {}, priorityScale: 0.5 },
+      )
+        .mediaTypePriorities).toEqual({
+        A: 1,
+        B: 0.5,
+        C: 0,
+      });
+    });
+  });
+
+  describe('An ActorRdfParseRdfParserTs instance', () => {
+    let actor: ActorRdfParseRdfParserTs;
+    let input: Readable;
+    let inputQuoted: Readable;
+    let inputError: Readable;
+
+    beforeEach(() => {
+      actor = new ActorRdfParseRdfParserTs({
+        bus,
+        mediaTypePriorities: {
+          'application/trig': 1,
+          'application/n-quads': 0.7,
+          'text/turtle': 0.6,
+          'application/n-triples': 0.3,
+        },
+        mediaTypeFormats: {},
+        name: 'actor',
+      });
+    });
+
+    describe('for parsing', () => {
+      beforeEach(() => {
+        input = Readable.from([ `
+          <a> <b> <c>.
+          <d> <e> <f>.
+      ` ]);
+        inputQuoted = Readable.from([ `
+          << <a> <b> <c> >> <b> <c>.
+          <d> <e> <f>.
+      ` ]);
+        inputError = new Readable();
+        inputError._read = () => inputError.emit('error', new Error('ParseRdfParserTs'));
+      });
+
+      it('should test on TriG', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'application/trig', context }))
+          .resolves.toPassTest({ handle: true });
+      });
+
+      it('should test on N-Quads', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'application/n-quads', context }))
+          .resolves.toPassTest({ handle: true });
+      });
+
+      it('should test on Turtle', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'text/turtle', context }))
+          .resolves.toPassTest({ handle: true });
+      });
+
+      it('should test on Turtle with quoted triples', async() => {
+        await expect(actor
+          .test({ handle: { data: inputQuoted, context }, handleMediaType: 'text/turtle', context }))
+          .resolves.toPassTest({ handle: true });
+      });
+
+      it('should test on N-Triples', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'application/n-triples', context }))
+          .resolves.toPassTest({ handle: true });
+      });
+
+      it('should not test on N3', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'text/n3', context }))
+          .resolves.toFailTest(`Unrecognized media type: text/n3`);
+      });
+
+      it('should not test on JSON-LD', async() => {
+        await expect(actor
+          .test({ handle: { data: input, context }, handleMediaType: 'application/ld+json', context }))
+          .resolves.toFailTest(`Unrecognized media type: application/ld+json`);
+      });
+
+      it('should run on text/turtle', async() => {
+        await actor.run({
+          handle: { data: input, metadata: { baseIRI: '' }, context },
+          handleMediaType: 'text/turtle',
+          context,
+        })
+          .then(async(output: any) => await expect(arrayifyStream(output.handle.data)).resolves.toHaveLength(2));
+      });
+
+      it('should run on application/trig', async() => {
+        await actor.run({
+          handle: { data: input, metadata: { baseIRI: '' }, context },
+          handleMediaType: 'application/trig',
+          context,
+        })
+          .then(async(output: any) => await expect(arrayifyStream(output.handle.data)).resolves.toHaveLength(2));
+      });
+
+      it('should forward stream errors', async() => {
+        await expect(arrayifyStream((<any>(await actor.run(
+          { handle: { data: inputError, context }, handleMediaType: 'application/trig', context },
+        )))
+          .handle.data)).rejects.toBeTruthy();
+      });
+
+      it('should not perform an out-of-band version check', async() => {
+        await actor.run({
+          handle: { data: input, metadata: { baseIRI: '', version: '1.2-invalid' }, context },
+          handleMediaType: 'application/trig',
+          context,
+        })
+          .then(async(output: any) => await expect(arrayifyStream(output.handle.data)).resolves.toHaveLength(2));
+      });
+    });
+
+    describe('for parsing with quads', () => {
+      beforeEach(() => {
+        input = Readable.from([ `
+          <http://example.org/a> <http://example.org/b> <http://example.org/c>.
+          <http://example.org/d> <http://example.org/e> <http://example.org/f> <http://example.org/g>.
+      ` ]);
+      });
+
+      it('should run on N-Quads', async() => {
+        await actor.run({
+          handle: { data: input, metadata: { baseIRI: '' }, context },
+          handleMediaType: 'application/n-quads',
+          context,
+        })
+          .then(async(output: any) => await expect(arrayifyStream(output.handle.data)).resolves.toHaveLength(2));
+      });
+    });
+
+    describe('for getting media types', () => {
+      it('should test', async() => {
+        await expect(actor.test({ mediaTypes: true, context })).resolves.toPassTest({ mediaTypes: true });
+      });
+
+      it('should run', async() => {
+        await expect(actor.run({ mediaTypes: true, context })).resolves.toEqual({
+          mediaTypes: {
+            'application/trig': 1,
+            'application/n-quads': 0.7,
+            'text/turtle': 0.6,
+            'application/n-triples': 0.3,
+          },
+        });
+      });
+    });
+  });
+});

--- a/packages/actor-rdf-serialize-rdf-writer-ts/README.md
+++ b/packages/actor-rdf-serialize-rdf-writer-ts/README.md
@@ -1,0 +1,45 @@
+# Comunica rdf-writer.ts RDF Serialize Actor
+
+[![npm version](https://badge.fury.io/js/%40comunica%2Factor-rdf-serialize-rdf-writer-ts.svg)](https://www.npmjs.com/package/@comunica/actor-rdf-serialize-rdf-writer-ts)
+
+An [RDF Serialize](https://github.com/comunica/comunica/tree/master/packages/bus-rdf-serialize) actor that handles
+Turtle, TriG, N-Quads, and N-Triples using [rdf-writer.ts](https://www.npmjs.com/package/rdf-writer-ts).
+
+This actor does not handle N3 rules/formulas. Use `@comunica/actor-rdf-serialize-n3` when `text/n3` support is required.
+
+This module is part of the [Comunica framework](https://github.com/comunica/comunica),
+and should only be used by [developers that want to build their own query engine](https://comunica.dev/docs/modify/).
+
+[Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
+
+## Install
+
+```bash
+$ yarn add @comunica/actor-rdf-serialize-rdf-writer-ts
+```
+
+## Configure
+
+After installing, this package can be added to your engine's configuration as follows:
+```text
+{
+  "@context": [
+    ...
+    "https://linkedsoftwaredependencies.org/bundles/npm/@comunica/actor-rdf-serialize-rdf-writer-ts/^5.0.0/components/context.jsonld"
+  ],
+  "actors": [
+    ...
+    {
+      "@id": "urn:comunica:default:rdf-serialize/actors#rdf-writer-ts",
+      "@type": "ActorRdfSerializeRdfWriterTs",
+      "priorityScale": 1.0
+    }
+  ]
+}
+```
+
+It can be configured next to `@comunica/actor-rdf-serialize-n3`; content negotiation priorities decide which actor is selected for overlapping RDF media types.
+
+### Config Parameters
+
+* `priorityScale`: An optional priority for this serializer, used for content negotiation, defaults to `1`.

--- a/packages/actor-rdf-serialize-rdf-writer-ts/lib/ActorRdfSerializeRdfWriterTs.ts
+++ b/packages/actor-rdf-serialize-rdf-writer-ts/lib/ActorRdfSerializeRdfWriterTs.ts
@@ -1,0 +1,52 @@
+import type {
+  IActionRdfSerialize,
+  IActorRdfSerializeFixedMediaTypesArgs,
+  IActorRdfSerializeOutput,
+} from '@comunica/bus-rdf-serialize';
+import {
+  ActorRdfSerializeFixedMediaTypes,
+} from '@comunica/bus-rdf-serialize';
+import { KeysRdfSerialize } from '@comunica/context-entries';
+import { StreamWriter } from 'rdf-writer-ts';
+
+/**
+ * A comunica rdf-writer.ts RDF Serialize Actor.
+ */
+export class ActorRdfSerializeRdfWriterTs extends ActorRdfSerializeFixedMediaTypes {
+  /**
+   * @param args -
+   *   \ @defaultNested {{
+   *       "application/n-quads": 1.0,
+   *       "application/trig": 0.95,
+   *       "application/n-triples": 0.8,
+   *       "text/turtle": 0.6
+   *     }} mediaTypePriorities
+   *   \ @defaultNested {{
+   *       "application/n-quads": "http://www.w3.org/ns/formats/N-Quads",
+   *       "application/trig": "http://www.w3.org/ns/formats/TriG",
+   *       "application/n-triples": "http://www.w3.org/ns/formats/N-Triples",
+   *       "text/turtle": "http://www.w3.org/ns/formats/Turtle"
+   *     }} mediaTypeFormats
+   */
+  public constructor(args: IActorRdfSerializeFixedMediaTypesArgs) {
+    super(args);
+  }
+
+  public async runHandle(action: IActionRdfSerialize, mediaType: string):
+  Promise<IActorRdfSerializeOutput> {
+    const writer = new StreamWriter({
+      format: mediaType,
+      prefixes: action.context.get(KeysRdfSerialize.rdfSerializationPrefixes),
+    });
+    let data: NodeJS.ReadableStream;
+    if ('pipe' in action.quadStream) {
+      // Prefer piping if possible, to maintain backpressure
+      action.quadStream.on('error', error => writer.emit('error', error));
+      data = (<any> action.quadStream).pipe(writer);
+    } else {
+      data = <any> writer.import(<any> action.quadStream);
+    }
+    return { data, triples: mediaType === 'text/turtle' ||
+      mediaType === 'application/n-triples' };
+  }
+}

--- a/packages/actor-rdf-serialize-rdf-writer-ts/lib/index.ts
+++ b/packages/actor-rdf-serialize-rdf-writer-ts/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './ActorRdfSerializeRdfWriterTs';

--- a/packages/actor-rdf-serialize-rdf-writer-ts/package.json
+++ b/packages/actor-rdf-serialize-rdf-writer-ts/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@comunica/actor-rdf-serialize-rdf-writer-ts",
+  "version": "5.2.3",
+  "description": "An rdf-writer.ts RDF Serialize actor",
+  "lsd:module": true,
+  "license": "MIT",
+  "homepage": "https://github.com/comunica/actor-rdf-serialize-rdf-writer-ts#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/comunica/comunica.git",
+    "directory": "packages/actor-rdf-serialize-rdf-writer-ts"
+  },
+  "bugs": {
+    "url": "https://github.com/comunica/actor-rdf-serialize-rdf-writer-ts/issues"
+  },
+  "keywords": [
+    "comunica",
+    "actor",
+    "rdf-serialize",
+    "rdf-writer-ts"
+  ],
+  "sideEffects": false,
+  "main": "lib/index.js",
+  "typings": "lib/index",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "components",
+    "lib/**/*.d.ts",
+    "lib/**/*.js",
+    "lib/**/*.js.map"
+  ],
+  "scripts": {
+    "build": "yarn run build:ts && yarn run build:components",
+    "build:ts": "node \"../../node_modules/typescript/bin/tsc\"",
+    "build:components": "componentsjs-generator"
+  },
+  "dependencies": {
+    "@comunica/bus-rdf-serialize": "^5.2.3",
+    "@comunica/context-entries": "^5.2.3",
+    "rdf-writer-ts": "^0.1.0"
+  }
+}

--- a/packages/actor-rdf-serialize-rdf-writer-ts/package.json
+++ b/packages/actor-rdf-serialize-rdf-writer-ts/package.json
@@ -39,6 +39,6 @@
   "dependencies": {
     "@comunica/bus-rdf-serialize": "^5.2.3",
     "@comunica/context-entries": "^5.2.3",
-    "rdf-writer-ts": "^0.1.0"
+    "rdf-writer-ts": "^0.1.1"
   }
 }

--- a/packages/actor-rdf-serialize-rdf-writer-ts/test/ActorRdfSerializeRdfWriterTs-test.ts
+++ b/packages/actor-rdf-serialize-rdf-writer-ts/test/ActorRdfSerializeRdfWriterTs-test.ts
@@ -1,0 +1,214 @@
+import { Readable } from 'node:stream';
+import { KeysRdfSerialize } from '@comunica/context-entries';
+import { ActionContext, Bus } from '@comunica/core';
+import type { IActionContext } from '@comunica/types';
+import { stringify as stringifyStream } from '@jeswr/stream-to-string';
+import type * as RDF from '@rdfjs/types';
+import { ArrayIterator } from 'asynciterator';
+import type { AsyncIterator } from 'asynciterator';
+import { streamifyArray } from 'streamify-array';
+import { ActorRdfSerializeRdfWriterTs } from '../lib/ActorRdfSerializeRdfWriterTs';
+import '@comunica/utils-jest';
+
+const quad = require('rdf-quad');
+
+describe('ActorRdfSerializeRdfWriterTs', () => {
+  let bus: any;
+  let context: IActionContext;
+
+  beforeEach(() => {
+    bus = new Bus({ name: 'bus' });
+    context = new ActionContext();
+  });
+
+  describe('The ActorRdfSerializeRdfWriterTs module', () => {
+    it('should be a function', () => {
+      expect(ActorRdfSerializeRdfWriterTs).toBeInstanceOf(Function);
+    });
+
+    it('should be a ActorRdfSerializeRdfWriterTs constructor', () => {
+      expect(new (<any> ActorRdfSerializeRdfWriterTs)({ name: 'actor', bus }))
+        .toBeInstanceOf(ActorRdfSerializeRdfWriterTs);
+    });
+
+    it('should not be able to create new ActorRdfSerializeRdfWriterTs objects without \'new\'', () => {
+      expect(() => {
+        (<any> ActorRdfSerializeRdfWriterTs)();
+      }).toThrow(`Class constructor ActorRdfSerializeRdfWriterTs cannot be invoked without 'new'`);
+    });
+  });
+
+  describe('An ActorRdfSerializeRdfWriterTs instance', () => {
+    let actor: ActorRdfSerializeRdfWriterTs;
+    let quadStream: () => RDF.Stream & AsyncIterator<RDF.Quad>;
+    let quadStreamQuoted: () => RDF.Stream & AsyncIterator<RDF.Quad>;
+    let quadStreamPipeable: any;
+    let quadsError: any;
+
+    beforeEach(() => {
+      actor = new ActorRdfSerializeRdfWriterTs({ bus, mediaTypePriorities: {
+        'application/trig': 1,
+        'text/turtle': 1,
+        'application/n-triples': 0.8,
+        'application/n-quads': 0.7,
+      }, mediaTypeFormats: {}, name: 'actor' });
+    });
+
+    describe('for serializing', () => {
+      beforeEach(() => {
+        quadStream = () => new ArrayIterator([
+          quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
+          quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
+        ], { autoStart: false });
+        quadStreamPipeable = streamifyArray([
+          quad('http://example.org/a', 'http://example.org/b', 'http://example.org/c'),
+          quad('http://example.org/a', 'http://example.org/d', 'http://example.org/e'),
+        ]);
+        quadStreamQuoted = () => new ArrayIterator([
+          quad('<<ex:s1 ex:p1 ex:o1>>', 'http://example.org/b', 'http://example.org/c'),
+          quad('<<ex:s1 ex:p1 ex:o1>>', 'http://example.org/d', 'http://example.org/e'),
+        ], { autoStart: false });
+        quadsError = new Readable();
+        quadsError._read = () => quadsError.emit('error', new Error('SerializeRdfWriterTs'));
+      });
+
+      describe('quad stream tests', () => {
+        let stream: RDF.Stream & AsyncIterator<RDF.Quad>;
+        beforeEach(() => {
+          stream = quadStream();
+        });
+        afterEach(() => {
+          stream.destroy();
+        });
+
+        it('should test on application/trig', async() => {
+          await expect(actor.test({
+            handle: { quadStream: stream, context },
+            handleMediaType: 'application/trig',
+            context,
+          }))
+            .resolves.toPassTest({ handle: true });
+        });
+
+        it('should test on text/turtle', async() => {
+          await expect(actor.test({
+            handle: { quadStream: stream, context },
+            handleMediaType: 'text/turtle',
+            context,
+          }))
+            .resolves.toPassTest({ handle: true });
+        });
+
+        it('should not test on text/n3', async() => {
+          await expect(actor.test({
+            handle: { quadStream: stream, context },
+            handleMediaType: 'text/n3',
+            context,
+          }))
+            .resolves.toFailTest(`Unrecognized media type: text/n3`);
+        });
+
+        it('should not test on application/json', async() => {
+          await expect(actor.test({
+            handle: { quadStream: stream, context },
+            handleMediaType: 'application/json',
+            context,
+          }))
+            .resolves.toFailTest(`Unrecognized media type: application/json`);
+        });
+      });
+
+      it('should run', async() => {
+        const output: any = await actor
+          .run({ handle: { quadStream: quadStream(), context }, handleMediaType: 'text/turtle', context });
+        await expect(stringifyStream(output.handle.data)).resolves.toBe(
+          `<http://example.org/a> <http://example.org/b> <http://example.org/c>;
+    <http://example.org/d> <http://example.org/e>.
+`,
+        );
+      });
+
+      it('should run with prefixes', async() => {
+        const output: any = await actor
+          .run({
+            handle: {
+              quadStream: quadStream(),
+              context: context.set(KeysRdfSerialize.rdfSerializationPrefixes, { ex: 'http://example.org/' }),
+            },
+            handleMediaType: 'text/turtle',
+            context,
+          });
+        await expect(stringifyStream(output.handle.data)).resolves.toBe(
+          `@prefix ex: <http://example.org/>.
+
+ex:a ex:b ex:c;
+    ex:d ex:e.
+`,
+        );
+      });
+
+      it('should run on a pipeable stream', async() => {
+        const output: any = await actor
+          .run({ handle: { quadStream: quadStreamPipeable, context }, handleMediaType: 'text/turtle', context });
+        await expect(stringifyStream(output.handle.data)).resolves.toBe(
+          `<http://example.org/a> <http://example.org/b> <http://example.org/c>;
+    <http://example.org/d> <http://example.org/e>.
+`,
+        );
+      });
+
+      it('should run on triple terms', async() => {
+        const output: any = await actor
+          .run({ handle: { quadStream: quadStreamQuoted(), context }, handleMediaType: 'text/turtle', context });
+        await expect(stringifyStream(output.handle.data)).resolves.toBe(
+          `<<(<ex:s1> <ex:p1> <ex:o1>)>> <http://example.org/b> <http://example.org/c>;
+    <http://example.org/d> <http://example.org/e>.
+`,
+        );
+      });
+
+      it('should run and output triples for text/turtle', async() => {
+        expect((<any> (await actor.run({
+          handle: { quadStream: quadStream(), context },
+          handleMediaType: 'text/turtle',
+          context,
+        })))
+          .handle.triples).toBeTruthy();
+      });
+
+      it('should run and output triples for application/n-triples', async() => {
+        expect((<any> (await actor
+          .run({ handle: { quadStream: quadStream(), context }, handleMediaType: 'application/n-triples', context })))
+          .handle.triples).toBeTruthy();
+      });
+
+      it('should run and output non-triples for application/trig', async() => {
+        expect((<any> (await actor
+          .run({ handle: { quadStream: quadStream(), context }, handleMediaType: 'application/trig', context })))
+          .handle.triples).toBeFalsy();
+      });
+
+      it('should forward stream errors', async() => {
+        await expect(stringifyStream((<any> (await actor.run(
+          { handle: { quadStream: quadsError, context }, handleMediaType: 'application/trig', context },
+        )))
+          .handle.data)).rejects.toBeTruthy();
+      });
+    });
+
+    describe('for getting media types', () => {
+      it('should test', async() => {
+        await expect(actor.test({ mediaTypes: true, context })).resolves.toPassTest({ mediaTypes: true });
+      });
+
+      it('should run', async() => {
+        await expect(actor.run({ mediaTypes: true, context })).resolves.toEqual({ mediaTypes: {
+          'application/trig': 1,
+          'text/turtle': 1,
+          'application/n-triples': 0.8,
+          'application/n-quads': 0.7,
+        }});
+      });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12814,10 +12814,10 @@ rdf-parse@^4.0.0:
     readable-stream "^4.5.2"
     stream-to-string "^1.2.1"
 
-rdf-parser-ts@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/rdf-parser-ts/-/rdf-parser-ts-0.3.0.tgz#3b7bac0f411b95153b18ce038f38388d2cf4c04b"
-  integrity sha512-ME5k7u9CNoOEOnPra/3Wcy7XUpjLFJb/yAdjRESQ+d6wDl2ICMMxWqjrywSFig/gELbr9ByGtWFGHEdRHOuCxw==
+rdf-parser-ts@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/rdf-parser-ts/-/rdf-parser-ts-0.3.1.tgz#2727856694ef7a845fa2764f5693437d7cdfeff6"
+  integrity sha512-hIul0LAVc2LgMCnkjEZmdjLwmgfXs94AMU7ZmMgouCQU9fakALVR8nA7fwp7ExWuaS2+ao1+3wPplE7y+p4yRQ==
   dependencies:
     "@rdfjs/types" "^2.0.1"
     n3 "^2.0.1"
@@ -12979,10 +12979,10 @@ rdf-test-suite@^2.2.0:
     stream-to-string "^1.1.0"
     streamify-string "^1.0.1"
 
-rdf-writer-ts@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/rdf-writer-ts/-/rdf-writer-ts-0.1.0.tgz#1e9045650222ab98bb10aec027255be3f90ebd72"
-  integrity sha512-Tvvn8BTFrPuUb9ml8reSR1VIUBMfBdv4Wyh1KMHGIDv2Qb7mtha7OgOrK/AqgGpzTPge0uAkqw6/IWSoFdvCXA==
+rdf-writer-ts@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/rdf-writer-ts/-/rdf-writer-ts-0.1.1.tgz#f6e7702a1ac8bc781f3ba16e55e57dfd281f0c72"
+  integrity sha512-eHQ2aSKmWum+9y91hxtY3Tbyb70uZGqFRMYP6RX94fGC9dcglIlUSqWJpwd3FCmBB1ILyayfIB65pBIxpSaSwg==
   dependencies:
     "@rdfjs/types" "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,7 +2490,7 @@
     qs "^6.10.1"
     url-parse "^1.5.3"
 
-"@rdfjs/types@*", "@rdfjs/types@^2.0.0":
+"@rdfjs/types@*", "@rdfjs/types@^2.0.0", "@rdfjs/types@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@rdfjs/types/-/types-2.0.1.tgz#f10b50ceffff00b961c4265e60ac9f74550251da"
   integrity sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA==
@@ -11065,6 +11065,14 @@ n3@^2.0.0:
     buffer "^6.0.3"
     readable-stream "^4.0.0"
 
+n3@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-2.1.1.tgz#448bce3bf952685ca9f3949b2623b71e4876b153"
+  integrity sha512-kqg8ers6Lc+uAmHeS+ycd3b8mC4x8wr8V8Fi6+w7l4hX6b0KZ5bT05Tf49qM2mujwaqZT3+08zcgtXgfxivbVQ==
+  dependencies:
+    buffer "^6.0.3"
+    readable-stream "^4.0.0"
+
 n3@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/n3/-/n3-2.1.0.tgz#cebe207fe8a5d8c339582ff242bd5c7e657dac87"
@@ -12806,6 +12814,14 @@ rdf-parse@^4.0.0:
     readable-stream "^4.5.2"
     stream-to-string "^1.2.1"
 
+rdf-parser-ts@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rdf-parser-ts/-/rdf-parser-ts-0.3.0.tgz#3b7bac0f411b95153b18ce038f38388d2cf4c04b"
+  integrity sha512-ME5k7u9CNoOEOnPra/3Wcy7XUpjLFJb/yAdjRESQ+d6wDl2ICMMxWqjrywSFig/gELbr9ByGtWFGHEdRHOuCxw==
+  dependencies:
+    "@rdfjs/types" "^2.0.1"
+    n3 "^2.0.1"
+
 rdf-quad@^1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/rdf-quad/-/rdf-quad-1.5.0.tgz"
@@ -12962,6 +12978,13 @@ rdf-test-suite@^2.2.0:
     sparqlxml-parse "^3.0.0"
     stream-to-string "^1.1.0"
     streamify-string "^1.0.1"
+
+rdf-writer-ts@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rdf-writer-ts/-/rdf-writer-ts-0.1.0.tgz#1e9045650222ab98bb10aec027255be3f90ebd72"
+  integrity sha512-Tvvn8BTFrPuUb9ml8reSR1VIUBMfBdv4Wyh1KMHGIDv2Qb7mtha7OgOrK/AqgGpzTPge0uAkqw6/IWSoFdvCXA==
+  dependencies:
+    "@rdfjs/types" "^2.0.1"
 
 rdfa-streaming-parser@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Comunica today uses N3.js for parsing and serializing Turtle, TriG, N-Triples and N-Quads. N3.js scope however is bigger than just that. This pull request proposes to instead use a dedicated parser and writer that only does this. This ensures the bundle size is smaller. On performance tests, the RDF1.2 compliant parser outperforms N3.js between 1x and 2x. 