### PR TITLE
fixed the failing date-* SPARQL 1.0 spec tests (kinda)

### DIFF
--- a/engines/query-sparql/spec/sparql-engine.js
+++ b/engines/query-sparql/spec/sparql-engine.js
@@ -1,4 +1,2 @@
-process.env.TZ = 'UTC';
-
 const QueryEngine = require('@comunica/query-sparql').QueryEngine;
 module.exports = require('@comunica/actor-init-query/spec/sparql-engine-base.js')(new QueryEngine());

--- a/engines/query-sparql/spec/sparql-engine.js
+++ b/engines/query-sparql/spec/sparql-engine.js
@@ -1,2 +1,4 @@
+process.env.TZ = 'UTC';
+
 const QueryEngine = require('@comunica/query-sparql').QueryEngine;
 module.exports = require('@comunica/actor-init-query/spec/sparql-engine-base.js')(new QueryEngine());

--- a/packages/actor-function-factory-term-equality/lib/TermFunctionEquality.ts
+++ b/packages/actor-function-factory-term-equality/lib/TermFunctionEquality.ts
@@ -41,22 +41,14 @@ export class TermFunctionEquality extends TermFunctionBase {
       // Fall through: a TypeURL.XSD_STRING is never equal to a TypeURL.RDF_LANG_STRING.
         .set([ TypeAlias.SPARQL_STRINGLY, TypeAlias.SPARQL_STRINGLY ], () => () => bool(false))
         .booleanTest(() => (left, right) => left === right)
-        .dateTimeTest(exprEval => (left, right) =>
-          toUTCDate(
-            left,
-            exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
-          ).getTime() === toUTCDate(
-            right,
-            exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
-          ).getTime())
-        .dateTimeAndDateTest(exprEval => (left, right) =>
-          toUTCDate(
-            left,
-            exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
-          ).getTime() === toUTCDate(
-            right,
-            exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
-          ).getTime())
+        .dateTimeTest(exprEval => (left, right) => {
+          const defaultTimeZone = exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone);
+          return toUTCDate(left, defaultTimeZone).getTime() === toUTCDate(right, defaultTimeZone).getTime();
+        })
+        .dateTimeAndDateTest(exprEval => (left, right) => {
+          const defaultTimeZone = exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone);
+          return toUTCDate(left, defaultTimeZone).getTime() === toUTCDate(right, defaultTimeZone).getTime();
+        })
         .copy({
           // https://www.w3.org/TR/xpath-functions/#func-date-equal
           from: [ TypeURL.XSD_DATE_TIME, TypeURL.XSD_DATE_TIME ],

--- a/packages/actor-function-factory-term-equality/lib/TermFunctionEquality.ts
+++ b/packages/actor-function-factory-term-equality/lib/TermFunctionEquality.ts
@@ -2,7 +2,6 @@ import { TermFunctionBase } from '@comunica/bus-function-factory';
 import { KeysExpressionEvaluator, KeysInitQuery } from '@comunica/context-entries';
 import type {
   BooleanLiteral,
-
   DurationLiteral,
   LangStringLiteral,
   Quad,
@@ -46,7 +45,10 @@ export class TermFunctionEquality extends TermFunctionBase {
           toUTCDate(
             left,
             exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
-          ).getTime() === toUTCDate(right, exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone)).getTime())
+          ).getTime() === toUTCDate(
+            right,
+            exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
+          ).getTime())
         .copy({
           // https://www.w3.org/TR/xpath-functions/#func-date-equal
           from: [ TypeURL.XSD_DATE_TIME, TypeURL.XSD_DATE_TIME ],

--- a/packages/actor-function-factory-term-equality/lib/TermFunctionEquality.ts
+++ b/packages/actor-function-factory-term-equality/lib/TermFunctionEquality.ts
@@ -49,6 +49,14 @@ export class TermFunctionEquality extends TermFunctionBase {
             right,
             exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
           ).getTime())
+        .dateTimeAndDateTest(exprEval => (left, right) =>
+          toUTCDate(
+            left,
+            exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
+          ).getTime() === toUTCDate(
+            right,
+            exprEval.context.getSafe(KeysExpressionEvaluator.defaultTimeZone),
+          ).getTime())
         .copy({
           // https://www.w3.org/TR/xpath-functions/#func-date-equal
           from: [ TypeURL.XSD_DATE_TIME, TypeURL.XSD_DATE_TIME ],

--- a/packages/actor-function-factory-term-equality/test/op.equality-test.ts
+++ b/packages/actor-function-factory-term-equality/test/op.equality-test.ts
@@ -122,10 +122,17 @@ describe('evaluation of \'=\'', () => {
     });
   });
 
-  describe('with date operants like', () => {
+  describe('with date operands like (with UTC defaultTimeZone)', () => {
     // Originates from: https://www.w3.org/TR/xpath-functions/#func-date-equal
     runFuncTestTable({
       ...config,
+      config: new ActionContext().set(
+        KeysExpressionEvaluator.defaultTimeZone,
+        {
+          zoneHours: 0,
+          zoneMinutes: 0,
+        },
+      ),
       operation: '=',
       arity: 2,
       notation: Notation.Infix,
@@ -133,11 +140,36 @@ describe('evaluation of \'=\'', () => {
       testTable: `
         '${dateTyped('2004-12-25Z')}' '${dateTyped('2004-12-25+07:00')}' = false
         '${dateTyped('2004-12-25-12:00')}' '${dateTyped('2004-12-26+12:00')}' = true
+        '${dateTyped('2006-08-23Z')}' '${dateTyped('2006-08-23')}' = true
+        '${dateTyped('2006-08-23+00:00')}' '${dateTyped('2006-08-23')}' = true
       `,
     });
   });
 
-  describe('with time operants like', () => {
+  describe('with date operands like (with different defaultTImeZone)', () => {
+    runFuncTestTable({
+      ...config,
+      config: new ActionContext().set(
+        KeysExpressionEvaluator.defaultTimeZone,
+        {
+          zoneHours: 2,
+          zoneMinutes: 0,
+        },
+      ),
+      operation: '=',
+      arity: 2,
+      notation: Notation.Infix,
+      aliases: bool,
+      testTable: `
+        '${dateTyped('2004-12-25Z')}' '${dateTyped('2004-12-25+07:00')}' = false
+        '${dateTyped('2004-12-25-12:00')}' '${dateTyped('2004-12-26+12:00')}' = true
+        '${dateTyped('2006-08-23Z')}' '${dateTyped('2006-08-23')}' = false
+        '${dateTyped('2006-08-23+00:00')}' '${dateTyped('2006-08-23')}' = false
+      `,
+    });
+  });
+
+  describe('with time operands like', () => {
     // Originates from: https://www.w3.org/TR/xpath-functions/#func-time-equal
     runFuncTestTable({
       ...config,

--- a/packages/actor-function-factory-term-equality/test/op.equality-test.ts
+++ b/packages/actor-function-factory-term-equality/test/op.equality-test.ts
@@ -169,6 +169,17 @@ describe('evaluation of \'=\'', () => {
     });
   });
 
+  describe('with mixed dateTime and date operands like', () => {
+    runFuncTestTable({
+      ...config,
+      testTable: `
+        "2006-08-23T09:00:00+01:00"^^xsd:dateTime "2006-08-23"^^xsd:date = false
+        "2006-08-23+00:00"^^xsd:date "2006-08-23T00:00:00+00:00"^^xsd:dateTime = true
+        "2006-08-23T23:00:00-01:00"^^xsd:dateTime "2006-08-24+00:00"^^xsd:date = true
+      `,
+    });
+  });
+
   describe('with time operands like', () => {
     // Originates from: https://www.w3.org/TR/xpath-functions/#func-time-equal
     runFuncTestTable({

--- a/packages/utils-expression-evaluator/lib/functions/Helpers.ts
+++ b/packages/utils-expression-evaluator/lib/functions/Helpers.ts
@@ -18,6 +18,7 @@ import * as E from '../expressions';
 import { NonLexicalLiteral } from '../expressions';
 import * as C from '../util/Consts';
 import { TypeURL } from '../util/Consts';
+import { defaultedDateTimeRepresentation } from '../util/DateTimeHelpers';
 import * as Err from '../util/Errors';
 import { IncompatibleLanguageOperation } from '../util/Errors';
 import type {
@@ -495,6 +496,29 @@ addInvalidHandling = true,
           const result = test(expressionEvaluator)(left.typedValue, right.typedValue);
           return bool(result);
         },
+        addInvalidHandling,
+      );
+  }
+
+  public dateTimeAndDateTest(test: (expressionEvaluator: IInternalEvaluator)
+  => (left: IDateTimeRepresentation, right: IDateTimeRepresentation) => boolean, addInvalidHandling = true): Builder {
+    return this
+      .set(
+        [ C.TypeURL.XSD_DATE_TIME, C.TypeURL.XSD_DATE ],
+        expressionEvaluator => ([ left, right ]: E.DateTimeLiteral[]) =>
+          bool(test(expressionEvaluator)(
+            left.typedValue,
+            defaultedDateTimeRepresentation(right.typedValue),
+          )),
+        addInvalidHandling,
+      )
+      .set(
+        [ C.TypeURL.XSD_DATE, C.TypeURL.XSD_DATE_TIME ],
+        expressionEvaluator => ([ left, right ]: E.DateTimeLiteral[]) =>
+          bool(test(expressionEvaluator)(
+            defaultedDateTimeRepresentation(left.typedValue),
+            right.typedValue,
+          )),
         addInvalidHandling,
       );
   }


### PR DESCRIPTION
part of #1736

There were 2 issues:

*Literals with datatypes `xsd:date` and `xsd:dateTime` are expected to be compared instead of throwing an error.*

The specs for SPARQL 1.0 don't mention anything about this, but there's an [operator extensibility section](https://www.w3.org/TR/rdf-sparql-query/#operatorExtensibility) which it could fall under. I followed the advice from [this email](https://lists.w3.org/Archives/Public/public-sparql-dev/2018OctDec/0010.html) to go with the flow, so I implemented this. The [specs for SPARQL 1.1](https://www.w3.org/TR/sparql11-query/#operatorExtensibility) are the same in that section. The [specs for SPARQL 1.2](https://www.w3.org/TR/sparql12-query/#func-sameValue) say that if the SPARQL processor can determine this equality we don't throw an error, so we get a bit of freedom there, which means this new implementation is still correct under the SPARQL 1.1 and SPARQL 1.2 specs (the spec tests for these versions still succeed as well).

-------

*Comparison between `xsd:date`s with and without a timezone can be undetermined.*

- Comparison between `"2006-08-23Z"^^xsd:date` and `"2006-08-23"^^xsd:date` is undetermined (not equal, not inequal)
- Comparison between `"2001-01-01Z"^^xsd:date` and `"2006-08-23"^^xsd:date` is determined, they're inequal
- Comparison between `"2006-08-23T09:00:00+01:00"^^xsd:dateTime` and `"2006-08-23"^^xsd:date` is determined, they're inequal

The only implementation that I could see that makes this test pass is to compare it twice, once with the lower bound of timezones (-14h) attached to the "unzoned" date and once with the upper bound (+14h), if these comparisons conflict each other, it's undetermined, else it's determined. This works for the first two, but not for the latter, so we'd only do this implementation for the date to date comparison and not the dateTime to date comparison. But this not only is cursed, it's also against the specs: https://www.w3.org/TR/xpath-functions/#comp.datetime says "If either operand to a comparison function on date or time values does not have an (explicit) timezone then, for the purpose of the operation, an implicit timezone, provided by the dynamic context [Section C.2 Dynamic Context Components ](https://www.w3.org/TR/xpath-31/#id-xp-evaluation-context-components)XP31, is assumed to be present as part of the value." (this is for `op:dateTime-equal`, but `op:date-equal` follows the same rules (https://www.w3.org/TR/xpath-functions/#func-date-equal). So that's why I decided to not implement this and leave the test as skipped.
