### PR TITLE
Update rdf-test-suite to v2.3.0 and unskip 3 types of spec tests

### DIFF
--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -60,7 +60,7 @@
     "spec:base-1-0": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-tests/sparql/sparql10/manifest.ttl -c ../../.rdf-test-suite-cache/",
     "spec:base-1-1": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl -c ../../.rdf-test-suite-cache/",
     "spec:base-1-2": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-tests/sparql/sparql12/manifest.ttl -c ../../.rdf-test-suite-cache/",
-    "spec:query-1-0": "yarn run spec:base-1-0 --skip \"(date-[12]|open-eq-|nested-opt-1|dawg-optional|graph-|dataset-|type-promotion-|add-literals|sort-|limit-|offset-|slice-2|reduced-1|blabel|syntax-sparql4)\"",
+    "spec:query-1-0": "yarn run spec:base-1-0 --skip \"(date-[12]|open-eq-|nested-opt-1|dawg-optional|#graph-|dataset-|add-literals|sort-|limit-|offset-|slice-2|blabel|syntax-sparql4)\"",
     "spec:query-1-1": "yarn run spec:base-1-1 -s http://www.w3.org/TR/sparql11-query/ --skip \"(agg-empty-group-count-graph|bindings/manifest#graph)\"",
     "spec:query-1-2": "yarn run spec:base-1-2",
     "spec:update-1-1": "yarn run spec:base-1-1 -s http://www.w3.org/TR/sparql11-update/",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "rdf-data-factory": "^2.0.1",
     "rdf-quad": "^2.0.0",
     "rdf-stores": "^2.1.1",
-    "rdf-test-suite": "^2.2.0",
+    "rdf-test-suite": "^2.3.0",
     "rdf-test-suite-ldf": "^2.0.1",
     "setup-polly-jest": "^0.11.0",
     "streamify-array": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12654,10 +12654,10 @@ rdf-test-suite@^2.1.4:
     stream-to-string "^1.1.0"
     streamify-string "^1.0.1"
 
-rdf-test-suite@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/rdf-test-suite/-/rdf-test-suite-2.2.0.tgz#49bfd899d7ba9a866d4ab23ec8736a2ad43af1c3"
-  integrity sha512-s3U7uaOcwRadM+s43KqKU0NXh2N0teUT42353K/JHmbxZydDIFdqEk7dEpdrieiqCZVZTc+8vc4gIw8tBnt61w==
+rdf-test-suite@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rdf-test-suite/-/rdf-test-suite-2.3.0.tgz#5110aeb65159ffd8d92ab7e1610416a37dcc4304"
+  integrity sha512-2TKniDx9SNJ9Urnl6Otf/k/SmoMheMfSRMESg8EugUAN12/0Ft+yVQxsHLYOL7qMJkawEAYjelWTU8+YP+H8jg==
   dependencies:
     "@types/json-stable-stringify" "^1.0.32"
     "@types/minimist" "^1.2.0"


### PR DESCRIPTION
Part of #1736.

Unskipped dawg-graph-.*, type promotion and reduced tests.