### PR TITLE
Increase Jest timeout for the Components.js instantiation tests

### DIFF
--- a/engines/query-sparql/test/Mediators-test.ts
+++ b/engines/query-sparql/test/Mediators-test.ts
@@ -76,6 +76,10 @@ import { Algebra, AlgebraFactory } from '@comunica/utils-algebra';
 import { DataFactory } from 'rdf-data-factory';
 import { QueryEngineFactory } from '../lib';
 
+// Instantiating the runner from the Components.js config requires a scan of the whole module tree,
+// which can take a while on slower CI machines, so the default timeout is not enough here.
+jest.setTimeout(60_000);
+
 const queryEngineFactory = new QueryEngineFactory();
 const DF = new DataFactory();
 const AF = new AlgebraFactory(DF);

--- a/packages/actor-init-query/test/QueryEngineFactoryBase-test.ts
+++ b/packages/actor-init-query/test/QueryEngineFactoryBase-test.ts
@@ -2,7 +2,9 @@ import * as Path from 'node:path';
 import { QueryEngineBase } from '../lib/QueryEngineBase';
 import { QueryEngineFactoryBase } from '../lib/QueryEngineFactoryBase';
 
-jest.setTimeout(30_000);
+// Every test in this file instantiates a full engine from the Components.js config,
+// which requires a scan of the whole module tree, and can take a while on slower CI machines.
+jest.setTimeout(60_000);
 
 describe('QueryEngineFactoryBase', () => {
   let factory: QueryEngineFactoryBase<any>;


### PR DESCRIPTION
## What is failing

[Run 32371022963, job `Jest tests (macos-latest, 26.x)`](https://github.com/comunica/comunica/actions/runs/32371022963/job/96431375437):

```
FAIL packages/actor-init-query/test/QueryEngineFactoryBase-test.ts (154.833 s)
  ● QueryEngineFactoryBase › create › with instanceUri option

    thrown: "Exceeded timeout of 30000 ms for a test."
```

## Why

Nothing is specific to Node 26 or to macOS — it is a timeout margin that has quietly shrunk to zero, and the slowest runner in the matrix is simply the one that trips it.

Every test in `QueryEngineFactoryBase-test` calls `factory.create()`, which goes through `instantiateComponent` → `ComponentsManager.build`. That walks the entire `node_modules` tree, reads every `package.json`, and parses every `components.jsonld` context — for a 314-package monorepo that is a lot of I/O, and it happens once per test, seven times over.

Measurements on an idle machine (nothing else running, warm cache):

| | |
|---|---|
| A single `instantiateComponent` of the default config | **9.0 s** |
| First (cold) test in `QueryEngineFactoryBase-test` | **28.8 s** — against a 30 s limit |
| Remaining six tests | ~10 s each |

So the suite is already at ~96% of its budget on the *best* case. CI is worse on two counts: Jest runs several workers in parallel, all competing for the same disk, and the whole macOS/Node-26 job in that run was ~1.6× slower than its siblings (356 s vs. 217 s for macOS/Node-24 on the same commit). That is enough to push a ~20 s test over 30 s, which is exactly what happened.

This is the same failure that `QueryEngineFactory-test` hit in 4b9f9d2 ("Increase Jest timeout from 30s to 60s for QueryEngineFactory"). This PR applies the same treatment to the two remaining suites of that kind.

## Changes

* `packages/actor-init-query/test/QueryEngineFactoryBase-test.ts`: 30 s → 60 s. This is the suite that actually failed; it instantiates an engine in every one of its seven tests.
* `engines/query-sparql/test/Mediators-test.ts`: adds an explicit 60 s timeout. It instantiates the runner in `beforeAll` and was relying on the 20 s global default from `jest.config.ts` — the narrowest margin of the three. Its 28 individual tests all run in 1–9 ms, so the suite time is essentially that one hook. Running it alongside a *single* other suite locally already takes it from 15 s to 24 s, and the Windows jobs in the failing run reported 22–28 s for it.

The global `testTimeout` is deliberately left at 20 s, so the ~6300 fast unit tests keep a tight bound and a genuine hang still fails quickly.

## Verification

* Both suites pass locally, and the full suite passes via the pre-commit hook: `Test Suites: 3 skipped, 478 passed, 478 of 481 total`.
* `eslint` is clean on both files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNFY3NYfVE6QG6jeZeNrM1)_