### PR TITLE
Fix ActorQueryOperationTyped bus indexing by passing operationName in args

### DIFF
--- a/packages/bus-query-operation/lib/ActorQueryOperationTyped.ts
+++ b/packages/bus-query-operation/lib/ActorQueryOperationTyped.ts
@@ -23,7 +23,14 @@ TS = undefined,
   public readonly operationName: string;
 
   protected constructor(args: IActorQueryOperationArgs<TS>, operationName: string) {
-    super(args);
+    // `operationName` must be passed via the args object, and not just assigned below.
+    // `BusQueryOperation` indexes actors on `operationName`, and the indexing happens inside
+    // `Actor`'s constructor (which calls `bus.subscribe(this)`). Only the properties present on
+    // `args` are copied onto the actor before that point, so an assignment after `super(...)`
+    // would come too late, and the actor would be indexed as unidentified.
+    // This mirrors how `ActorFunctionFactoryDedicated` passes `functionNames` via its args.
+    const argsIndexed: IActorQueryOperationArgs<TS> & { operationName: string } = { ...args, operationName };
+    super(argsIndexed);
     this.operationName = operationName;
     if (!this.operationName) {
       throw new Error('A valid "operationName" argument must be provided.');

--- a/packages/bus-query-operation/lib/ActorQueryOperationTyped.ts
+++ b/packages/bus-query-operation/lib/ActorQueryOperationTyped.ts
@@ -23,14 +23,8 @@ TS = undefined,
   public readonly operationName: string;
 
   protected constructor(args: IActorQueryOperationArgs<TS>, operationName: string) {
-    // `operationName` must be passed via the args object, and not just assigned below.
-    // `BusQueryOperation` indexes actors on `operationName`, and the indexing happens inside
-    // `Actor`'s constructor (which calls `bus.subscribe(this)`). Only the properties present on
-    // `args` are copied onto the actor before that point, so an assignment after `super(...)`
-    // would come too late, and the actor would be indexed as unidentified.
-    // This mirrors how `ActorFunctionFactoryDedicated` passes `functionNames` via its args.
-    const argsIndexed: IActorQueryOperationArgs<TS> & { operationName: string } = { ...args, operationName };
-    super(argsIndexed);
+    // Pass via args so the bus can index on it during subscription in Actor's constructor.
+    super(<IActorQueryOperationArgs<TS>>{ ...args, operationName });
     this.operationName = operationName;
     if (!this.operationName) {
       throw new Error('A valid "operationName" argument must be provided.');

--- a/packages/bus-query-operation/test/ActorQueryOperationTyped-test.ts
+++ b/packages/bus-query-operation/test/ActorQueryOperationTyped-test.ts
@@ -1,7 +1,7 @@
 import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import { ActionContext, Bus, passTest } from '@comunica/core';
 import type { IPhysicalQueryPlanLogger } from '@comunica/types';
-import { ActorQueryOperationTyped } from '..';
+import { ActorQueryOperationTyped, BusQueryOperation } from '..';
 import '@comunica/utils-jest';
 
 describe('ActorQueryOperationTyped', () => {
@@ -27,6 +27,32 @@ describe('ActorQueryOperationTyped', () => {
       expect(() => {
         new (<any> ActorQueryOperationTyped)({ name: 'actor', bus }, null);
       }).toThrow(`A valid "operationName" argument must be provided.`);
+    });
+  });
+
+  describe('when subscribed to a BusQueryOperation', () => {
+    // Regression guard: the operation name must already be set on the actor by the time
+    // `Actor`'s constructor subscribes it to the bus. If it is only assigned after `super(...)`,
+    // every actor is indexed as unidentified, and every action gets published to every actor.
+    it('should only be published to for actions of its own operation type', async() => {
+      const busIndexed = new BusQueryOperation({ name: 'bus-indexed' });
+      const actorOp1 = new (<any> ActorQueryOperationTyped)({ name: 'actor-op1', bus: busIndexed }, 'op1');
+      const actorOp2 = new (<any> ActorQueryOperationTyped)({ name: 'actor-op2', bus: busIndexed }, 'op2');
+      actorOp1.testOperation = () => Promise.resolve(passTest({}));
+      actorOp2.testOperation = () => Promise.resolve(passTest({}));
+
+      const replies = busIndexed.publish(<any> { operation: { type: 'op1' }, context: new ActionContext() });
+      await Promise.all(replies.map(reply => reply.reply));
+
+      expect(replies.map(reply => reply.actor.name)).toEqual([ 'actor-op1' ]);
+    });
+
+    it('should expose its operation name to the bus index', () => {
+      const busIndexed = new BusQueryOperation({ name: 'bus-indexed' });
+      const actor = new (<any> ActorQueryOperationTyped)({ name: 'actor-op1', bus: busIndexed }, 'op1');
+      expect(actor.operationName).toBe('op1');
+      expect((<any> busIndexed).actorsIndex).toHaveProperty('op1', [ actor ]);
+      expect((<any> busIndexed).actorsIndex).not.toHaveProperty('_undefined_');
     });
   });
 


### PR DESCRIPTION
## Summary
Fixed a critical bug in `ActorQueryOperationTyped` where the `operationName` property was not being properly indexed by `BusQueryOperation`. This caused all actors to be indexed as unidentified, resulting in every action being published to every actor instead of only matching actors.

## Key Changes
- Modified `ActorQueryOperationTyped` constructor to pass `operationName` through the `args` object to the parent `Actor` constructor, rather than assigning it after `super()` is called
- This ensures the property is available during bus subscription, which happens inside the parent constructor
- Added comprehensive test coverage to verify:
  - Actions are only published to actors with matching operation types
  - The `operationName` property is correctly exposed and indexed by the bus
  - The bus index does not contain undefined entries for unidentified actors

## Implementation Details
The fix mirrors the pattern used in `ActorFunctionFactoryDedicated` for passing indexed properties. The `operationName` must be included in the args object before calling `super()` because `BusQueryOperation` performs actor indexing during the `bus.subscribe(this)` call that happens inside the parent `Actor` constructor. Any property assignment after `super()` would come too late for the indexing mechanism.

https://claude.ai/code/session_01NGYidruWD2uPGrYsbbkWrY