### PR TITLE
Seven query-engine optimisations, measured per change on the performance/ benchmarks

### DIFF
--- a/packages/actor-expression-evaluator-factory-default/lib/ActorExpressionEvaluatorFactoryDefault.ts
+++ b/packages/actor-expression-evaluator-factory-default/lib/ActorExpressionEvaluatorFactoryDefault.ts
@@ -7,8 +7,9 @@ import { ActorExpressionEvaluatorFactory } from '@comunica/bus-expression-evalua
 import { KeysInitQuery } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { passTestVoid } from '@comunica/core';
+import type { ISuperTypeProvider } from '@comunica/types';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
-import { prepareEvaluatorActionContext } from '@comunica/utils-expression-evaluator';
+import { createSuperTypeProvider, prepareEvaluatorActionContext } from '@comunica/utils-expression-evaluator';
 import { AlgebraTransformer } from './AlgebraTransformer';
 import { ExpressionEvaluator } from './ExpressionEvaluator';
 
@@ -16,8 +17,15 @@ import { ExpressionEvaluator } from './ExpressionEvaluator';
  * A comunica Default Expression Evaluator Factory Actor.
  */
 export class ActorExpressionEvaluatorFactoryDefault extends ActorExpressionEvaluatorFactory {
+  /**
+   * The super type provider handed to every evaluator that does not get one from the context.
+   * It holds a type cache, so it is created once per actor instead of once per evaluator.
+   */
+  private readonly defaultSuperTypeProvider: ISuperTypeProvider;
+
   public constructor(args: IActorExpressionEvaluatorFactoryArgs) {
     super(args);
+    this.defaultSuperTypeProvider = createSuperTypeProvider();
   }
 
   public async test(_action: IActionExpressionEvaluatorFactory): Promise<TestResult<IActorTest>> {
@@ -25,7 +33,7 @@ export class ActorExpressionEvaluatorFactoryDefault extends ActorExpressionEvalu
   }
 
   public async run(action: IActionExpressionEvaluatorFactory): Promise<IActorExpressionEvaluatorFactoryOutput> {
-    const fullContext = prepareEvaluatorActionContext(action.context);
+    const fullContext = prepareEvaluatorActionContext(action.context, this.defaultSuperTypeProvider);
     return new ExpressionEvaluator(
       fullContext,
       await new AlgebraTransformer(

--- a/packages/actor-expression-evaluator-factory-default/lib/InternalEvaluator.ts
+++ b/packages/actor-expression-evaluator-factory-default/lib/InternalEvaluator.ts
@@ -26,6 +26,14 @@ export class InternalEvaluator {
         [ExpressionType.Aggregate]: (_expr, _mapping) => this.evalAggregate(),
       };
 
+  /**
+   * Lazily initialized values that are constant for this evaluator,
+   * but are resolved per evaluation in the hot path otherwise.
+   */
+  private dataFactory: ComunicaDataFactory | undefined;
+  private algebraFactory: AlgebraFactory | undefined;
+  private readonly variableTerms: Record<string, RDF.Variable> = {};
+
   public constructor(
     public readonly context: IActionContext,
     mediatorFunctionFactory: MediatorFunctionFactory,
@@ -39,8 +47,13 @@ export class InternalEvaluator {
   }
 
   public async evaluatorExpressionEvaluation(expr: Expression, mapping: RDF.Bindings): Promise<TermExpression> {
-    const evaluator = this.subEvaluators[expr.expressionType];
-    return evaluator.bind(this)(expr, mapping);
+    // `call` instead of `bind`, as the latter allocates a new bound function per expression node per solution.
+    return this.subEvaluators[expr.expressionType].call(this, expr, mapping);
+  }
+
+  private getDataFactory(): ComunicaDataFactory {
+    this.dataFactory ??= this.context.getSafe(KeysInitQuery.dataFactory);
+    return this.dataFactory;
   }
 
   private term(expr: Eval.Term): Eval.Term {
@@ -48,7 +61,12 @@ export class InternalEvaluator {
   }
 
   private variable(expr: Eval.Variable, mapping: RDF.Bindings): Eval.Term {
-    const term = mapping.get(Eval.expressionToVar(this.context.getSafe(KeysInitQuery.dataFactory), expr));
+    // The RDF variable term for an expression never changes, so it is created once instead of per solution.
+    let variable = this.variableTerms[expr.name];
+    if (!variable) {
+      variable = this.variableTerms[expr.name] = Eval.expressionToVar(this.getDataFactory(), expr);
+    }
+    const term = mapping.get(variable);
     if (!term) {
       throw new Eval.UnboundVariableError(expr.name, mapping);
     }
@@ -65,9 +83,13 @@ export class InternalEvaluator {
   }
 
   private async evalExistence(expr: Eval.Existence, mapping: RDF.Bindings): Promise<Eval.Term> {
-    const dataFactory: ComunicaDataFactory = this.context.getSafe(KeysInitQuery.dataFactory);
-    const algebraFactory = new AlgebraFactory(dataFactory);
-    const operation = materializeOperation(expr.expression.input, mapping, algebraFactory, this.bindingsFactory);
+    this.algebraFactory ??= new AlgebraFactory(this.getDataFactory());
+    const operation = materializeOperation(
+      expr.expression.input,
+      mapping,
+      this.algebraFactory,
+      this.bindingsFactory,
+    );
 
     const outputRaw = await this.mediatorQueryOperation.mediate({ operation, context: this.context });
     const output = getSafeBindings(outputRaw);

--- a/packages/actor-query-operation-group/lib/GroupsState.ts
+++ b/packages/actor-query-operation-group/lib/GroupsState.ts
@@ -30,6 +30,17 @@ export class GroupsState {
   //  Without this we could have duplicate work/ override precious work.
   private readonly groupsInitializer: Map<BindingsHash, Promise<IGroup>>;
   private readonly groupVariables: Set<string>;
+  /**
+   * The variables that actually contribute to a group hash,
+   * i.e. the inner variables that are grouped on.
+   * Variables that are not grouped on always hash to the empty string,
+   * so leaving them out produces the exact same hash.
+   */
+  private readonly groupHashVariables: RDF.Variable[];
+  /**
+   * The aggregate variables, indexed for fast iteration on the hot path.
+   */
+  private readonly aggregateVariables: string[];
   private waitCounter: number;
   // Function that resolves the promise given by collectResults
   private waitResolver: ((bindings: Bindings[]) => void) | undefined;
@@ -45,6 +56,8 @@ export class GroupsState {
     this.groups = new Map();
     this.groupsInitializer = new Map();
     this.groupVariables = new Set(this.pattern.variables.map(x => x.value));
+    this.groupHashVariables = variables.filter(variable => this.groupVariables.has(variable.value));
+    this.aggregateVariables = this.pattern.aggregates.map(aggregate => aggregate.variable.value);
     this.waitCounter = 1;
     this.resultHasBeenCalled = false;
   }
@@ -64,47 +77,51 @@ export class GroupsState {
     // We increment the counter and decrement him when put action is performed.
     this.waitCounter++;
 
-    // Select the bindings on which we group
-    const grouper = bindings
-      .filter((_, variable) => this.groupVariables.has(variable.value));
-    const groupHash = this.hashBindings(grouper);
+    // Determine the group these bindings belong to.
+    // The grouping bindings themselves are only needed when a new group is created,
+    // so they are not materialized for every incoming bindings object.
+    const groupHash = this.hashBindings(bindings);
 
     // First member of group -> create new group
-    let groupInitializer: Promise<IGroup> | undefined = this.groupsInitializer.get(groupHash);
-
-    let res: Promise<any>;
+    const groupInitializer: Promise<IGroup> | undefined = this.groupsInitializer.get(groupHash);
     if (groupInitializer) {
-      const groupInitializerDefined = groupInitializer;
-      res = (async() => {
-        const group = await groupInitializerDefined;
-        await Promise.all(this.pattern.aggregates.map(async(aggregate) => {
-          // Distinct handling is done in the aggregator.
-          const variable = aggregate.variable.value;
-          await group.aggregators[variable].putBindings(bindings);
-        }));
-      })().then(async() => {
-        await this.subtractWaitCounterAndCollect();
-      });
-    } else {
-      // Initialize state for all aggregators for new group
-      groupInitializer = (async() => {
-        const aggregators: Record<string, IBindingsAggregator> = {};
-        await Promise.all(this.pattern.aggregates.map(async(aggregate) => {
-          const key = aggregate.variable.value;
-          aggregators[key] = await this.mediatorBindingsAggregatorFactory
-            .mediate({ expr: aggregate, context: this.context });
-          await aggregators[key].putBindings(bindings);
-        }));
-
-        const group = { aggregators, bindings: grouper };
-        this.groups.set(groupHash, group);
-        await this.subtractWaitCounterAndCollect();
-        return group;
-      })();
-      this.groupsInitializer.set(groupHash, groupInitializer);
-      res = groupInitializer;
+      return this.putInGroup(groupInitializer, bindings);
     }
-    return res;
+
+    // Initialize state for all aggregators for new group
+    const newGroupInitializer = this.createGroup(groupHash, bindings);
+    this.groupsInitializer.set(groupHash, newGroupInitializer);
+    return <Promise<any>> newGroupInitializer;
+  }
+
+  private async putInGroup(groupInitializer: Promise<IGroup>, bindings: Bindings): Promise<void> {
+    const group = await groupInitializer;
+    // Distinct handling is done in the aggregator.
+    const { aggregators } = group;
+    if (this.aggregateVariables.length === 1) {
+      await aggregators[this.aggregateVariables[0]].putBindings(bindings);
+    } else {
+      await Promise.all(this.aggregateVariables.map(variable => aggregators[variable].putBindings(bindings)));
+    }
+    await this.subtractWaitCounterAndCollect();
+  }
+
+  private async createGroup(groupHash: BindingsHash, bindings: Bindings): Promise<IGroup> {
+    const aggregators: Record<string, IBindingsAggregator> = {};
+    await Promise.all(this.pattern.aggregates.map(async(aggregate) => {
+      const key = aggregate.variable.value;
+      aggregators[key] = await this.mediatorBindingsAggregatorFactory
+        .mediate({ expr: aggregate, context: this.context });
+      await aggregators[key].putBindings(bindings);
+    }));
+
+    const group = {
+      aggregators,
+      bindings: bindings.filter((_, variable) => this.groupVariables.has(variable.value)),
+    };
+    this.groups.set(groupHash, group);
+    await this.subtractWaitCounterAndCollect();
+    return group;
   }
 
   private async subtractWaitCounterAndCollect(): Promise<void> {
@@ -183,6 +200,6 @@ export class GroupsState {
    * @param {Bindings} bindings - Bindings to hash
    */
   private hashBindings(bindings: Bindings): BindingsHash {
-    return bindingsToCompactString(bindings, this.variables);
+    return bindingsToCompactString(bindings, this.groupHashVariables);
   }
 }

--- a/packages/actor-query-operation-orderby/lib/SortIterator.ts
+++ b/packages/actor-query-operation-orderby/lib/SortIterator.ts
@@ -6,6 +6,12 @@ export class SortIterator<T> extends TransformIterator<T, T> {
   private readonly windowLength: number;
   private readonly sort: (left: T, right: T) => number;
   private readonly sorted: T[];
+  /**
+   * True if the whole stream is buffered before sorting (no sliding window is applied).
+   * In that case a single O(n log n) sort in `_flush` is used instead of
+   * an O(n²) binary insertion sort in `_read`.
+   */
+  private readonly unbounded: boolean;
 
   public constructor(source: AsyncIterator<T>, sort: (left: T, right: T) => number, options?: any) {
     super(source, options);
@@ -13,6 +19,7 @@ export class SortIterator<T> extends TransformIterator<T, T> {
     // The `window` parameter indicates the length of the sliding window to apply sorting
     const window: number = options && options.window;
     this.windowLength = Number.isFinite(window) && window > 0 ? window : Number.POSITIVE_INFINITY;
+    this.unbounded = this.windowLength === Number.POSITIVE_INFINITY;
     this.sort = sort;
     this.sorted = [];
   }
@@ -20,6 +27,18 @@ export class SortIterator<T> extends TransformIterator<T, T> {
   // Reads the smallest item in the current sorting window
   public override _read(count: number, done: () => void): void {
     let item;
+    // Without a sliding window, no item can be emitted before the source ends anyway,
+    // so we just buffer everything here and sort once in `_flush`.
+    if (this.unbounded) {
+      item = this.source!.read();
+      while (item !== null) {
+        this.sorted.push(item);
+        item = this.source!.read();
+      }
+      done();
+      return;
+    }
+
     let { length } = this.sorted;
     // Try to read items until we reach the desired window length
     while (length !== this.windowLength) {
@@ -56,6 +75,16 @@ export class SortIterator<T> extends TransformIterator<T, T> {
 
   // Flushes remaining data after the source has ended
   public override _flush(done: () => void): void {
+    if (this.unbounded) {
+      this.sorted.sort(this.sort);
+      for (const item of this.sorted) {
+        this._push(item);
+      }
+      this.sorted.length = 0;
+      done();
+      return;
+    }
+
     let { length } = this.sorted;
     while (length--) {
       this._push(this.sorted.pop()!);

--- a/packages/actor-query-operation-orderby/test/SortIterator-test.ts
+++ b/packages/actor-query-operation-orderby/test/SortIterator-test.ts
@@ -1,0 +1,68 @@
+import arrayifyStream from 'arrayify-stream';
+import { ArrayIterator } from 'asynciterator';
+import { SortIterator } from '../lib/SortIterator';
+
+const ascending = (left: number, right: number): number => left - right;
+
+describe('SortIterator', () => {
+  describe('without a window', () => {
+    it('should sort an empty stream', async() => {
+      const source = new ArrayIterator<number>([], { autoStart: false });
+      await expect(arrayifyStream(new SortIterator<number>(source, ascending))).resolves.toEqual([]);
+    });
+
+    it('should sort a stream', async() => {
+      const source = new ArrayIterator([ 3, 1, 4, 1, 5, 9, 2, 6 ], { autoStart: false });
+      await expect(arrayifyStream(new SortIterator<number>(source, ascending)))
+        .resolves.toEqual([ 1, 1, 2, 3, 4, 5, 6, 9 ]);
+    });
+
+    it('should be stable, so that a previous sort is preserved for equal elements', async() => {
+      // Sort on the first element only; the second element records the original stream order.
+      const source = new ArrayIterator<[number, string]>(
+        [[ 1, 'a' ], [ 0, 'b' ], [ 1, 'c' ], [ 0, 'd' ], [ 1, 'e' ]],
+        { autoStart: false },
+      );
+      const iterator = new SortIterator<[number, string]>(source, (left, right) => left[0] - right[0]);
+      await expect(arrayifyStream(iterator)).resolves.toEqual([
+        [ 0, 'b' ],
+        [ 0, 'd' ],
+        [ 1, 'a' ],
+        [ 1, 'c' ],
+        [ 1, 'e' ],
+      ]);
+    });
+
+    it('should ignore non-finite windows', async() => {
+      const source = new ArrayIterator([ 3, 1, 2 ], { autoStart: false });
+      await expect(arrayifyStream(new SortIterator<number>(source, ascending, { window: Number.POSITIVE_INFINITY })))
+        .resolves.toEqual([ 1, 2, 3 ]);
+    });
+
+    it('should ignore non-positive windows', async() => {
+      const source = new ArrayIterator([ 3, 1, 2 ], { autoStart: false });
+      await expect(arrayifyStream(new SortIterator<number>(source, ascending, { window: 0 })))
+        .resolves.toEqual([ 1, 2, 3 ]);
+    });
+  });
+
+  describe('with a window', () => {
+    it('should sort within the window', async() => {
+      const source = new ArrayIterator([ 5, 4, 3, 2, 1 ], { autoStart: false });
+      await expect(arrayifyStream(new SortIterator<number>(source, ascending, { window: 3 })))
+        .resolves.toEqual([ 3, 2, 1, 4, 5 ]);
+    });
+
+    it('should handle equal elements within the window', async() => {
+      const source = new ArrayIterator([ 2, 2, 1, 3, 2 ], { autoStart: false });
+      await expect(arrayifyStream(new SortIterator<number>(source, ascending, { window: 4 })))
+        .resolves.toEqual([ 1, 2, 2, 2, 3 ]);
+    });
+
+    it('should fully sort when the window exceeds the stream length', async() => {
+      const source = new ArrayIterator([ 3, 1, 4, 1, 5 ], { autoStart: false });
+      await expect(arrayifyStream(new SortIterator<number>(source, ascending, { window: 100 })))
+        .resolves.toEqual([ 1, 1, 3, 4, 5 ]);
+    });
+  });
+});

--- a/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
+++ b/packages/actor-query-operation-project/lib/ActorQueryOperationProject.ts
@@ -12,7 +12,7 @@ import type {
   IQueryOperationResultBindings,
   MetadataVariable,
 } from '@comunica/types';
-import { Algebra } from '@comunica/utils-algebra';
+import { Algebra, algebraUtils } from '@comunica/utils-algebra';
 import { BlankNodeBindingsScoped } from '@comunica/utils-data-factory';
 import { getSafeBindings } from '@comunica/utils-query-operation';
 import type * as RDF from '@rdfjs/types';
@@ -23,6 +23,33 @@ import type * as RDF from '@rdfjs/types';
 export class ActorQueryOperationProject extends ActorQueryOperationTypedMediated<Algebra.Project> {
   public constructor(args: IActorQueryOperationTypedMediatedArgs) {
     super(args, Algebra.Types.PROJECT);
+  }
+
+  /**
+   * Determine if the given operation could produce {@link BlankNodeBindingsScoped} terms.
+   * These are only created by the BNODE() function, so any operation that does not contain
+   * a BNODE() (or a custom, named function that could delegate to it) can never emit them.
+   * @param operation The operation to inspect.
+   */
+  public static canCreateScopedBlankNodes(operation: Algebra.Operation): boolean {
+    let possible = false;
+    algebraUtils.visitOperationSub(operation, {}, {
+      [Algebra.Types.EXPRESSION]: {
+        [Algebra.ExpressionTypes.OPERATOR]: { preVisitor: (expression) => {
+          if (expression.operator === 'bnode') {
+            possible = true;
+            return { shortcut: true };
+          }
+          return {};
+        } },
+        // Custom functions are opaque, so we conservatively assume they may return a scoped blank node.
+        [Algebra.ExpressionTypes.NAMED]: { preVisitor: () => {
+          possible = true;
+          return { shortcut: true };
+        } },
+      },
+    });
+    return possible;
   }
 
   public async testOperation(_operation: Algebra.Project, _context: IActionContext): Promise<TestResult<IActorTest>> {
@@ -70,22 +97,27 @@ export class ActorQueryOperationProject extends ActorQueryOperationTypedMediated
     // Make sure that blank nodes with same labels are not reused over different bindings, as required by SPARQL 1.1.
     // Required for the BNODE() function: https://www.w3.org/TR/sparql11-query/#func-bnode
     // When we have a scoped blank node, make sure the skolemized value is maintained.
-    let blankNodeCounter = 0;
-    bindingsStream = bindingsStream.map((bindings: Bindings) => {
-      blankNodeCounter++;
-      const scopedBlankNodesCache = new Map<string, RDF.BlankNode>();
-      return bindings.map((term) => {
-        if (term instanceof BlankNodeBindingsScoped) {
-          let scopedBlankNode = scopedBlankNodesCache.get(term.value);
-          if (!scopedBlankNode) {
-            scopedBlankNode = dataFactory.blankNode(`${term.value}${blankNodeCounter}`);
-            scopedBlankNodesCache.set(term.value, scopedBlankNode);
+    // Only scoped blank nodes need this rewrite, and those can only originate from BNODE()
+    // (or a custom function), so the whole (allocation-heavy) stage is skipped
+    // for the vast majority of queries, which can not produce them.
+    if (ActorQueryOperationProject.canCreateScopedBlankNodes(operation.input)) {
+      let blankNodeCounter = 0;
+      bindingsStream = bindingsStream.map((bindings: Bindings) => {
+        blankNodeCounter++;
+        const scopedBlankNodesCache = new Map<string, RDF.BlankNode>();
+        return bindings.map((term) => {
+          if (term instanceof BlankNodeBindingsScoped) {
+            let scopedBlankNode = scopedBlankNodesCache.get(term.value);
+            if (!scopedBlankNode) {
+              scopedBlankNode = dataFactory.blankNode(`${term.value}${blankNodeCounter}`);
+              scopedBlankNodesCache.set(term.value, scopedBlankNode);
+            }
+            return scopedBlankNode;
           }
-          return scopedBlankNode;
-        }
-        return term;
+          return term;
+        });
       });
-    });
+    }
 
     return {
       type: 'bindings',

--- a/packages/actor-query-operation-project/test/ActorQueryOperationProject-test.ts
+++ b/packages/actor-query-operation-project/test/ActorQueryOperationProject-test.ts
@@ -1,6 +1,7 @@
 import { ActorQueryOperation } from '@comunica/bus-query-operation';
 import { KeysInitQuery } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
+import { AlgebraFactory } from '@comunica/utils-algebra';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { BlankNodeBindingsScoped, BlankNodeScoped } from '@comunica/utils-data-factory';
 import { getSafeBindings } from '@comunica/utils-query-operation';
@@ -11,6 +12,9 @@ import '@comunica/utils-jest';
 
 const DF = new DataFactory();
 const BF = new BindingsFactory(DF);
+const AF = new AlgebraFactory(DF);
+// An input operation that can produce binding-scoped blank nodes: BIND(BNODE() AS ?a)
+const bnodeInput = AF.createExtend(AF.createBgp([]), DF.variable('a'), AF.createOperatorExpression('bnode', []));
 
 describe('ActorQueryOperationProject', () => {
   let bus: any;
@@ -50,6 +54,37 @@ describe('ActorQueryOperationProject', () => {
       expect(() => {
         (<any> ActorQueryOperationProject)();
       }).toThrow(`Class constructor ActorQueryOperationProject cannot be invoked without 'new'`);
+    });
+  });
+
+  describe('canCreateScopedBlankNodes', () => {
+    it('should be false for an operation without expressions', () => {
+      expect(ActorQueryOperationProject.canCreateScopedBlankNodes(AF.createBgp([]))).toBeFalsy();
+    });
+
+    it('should be false for an operation with unrelated expressions', () => {
+      expect(ActorQueryOperationProject.canCreateScopedBlankNodes(AF.createFilter(
+        AF.createBgp([]),
+        AF.createOperatorExpression('strlen', [ AF.createTermExpression(DF.variable('a')) ]),
+      ))).toBeFalsy();
+    });
+
+    it('should be true for an operation with a BNODE() expression', () => {
+      expect(ActorQueryOperationProject.canCreateScopedBlankNodes(bnodeInput)).toBeTruthy();
+    });
+
+    it('should be true for an operation with a nested BNODE() expression', () => {
+      expect(ActorQueryOperationProject.canCreateScopedBlankNodes(AF.createFilter(
+        AF.createBgp([]),
+        AF.createOperatorExpression('isblank', [ AF.createOperatorExpression('bnode', []) ]),
+      ))).toBeTruthy();
+    });
+
+    it('should be true for an operation with a custom named expression', () => {
+      expect(ActorQueryOperationProject.canCreateScopedBlankNodes(AF.createFilter(
+        AF.createBgp([]),
+        AF.createNamedExpression(DF.namedNode('http://example.org/fn'), []),
+      ))).toBeTruthy();
     });
   });
 
@@ -254,7 +289,7 @@ describe('ActorQueryOperationProject', () => {
         type: 'bindings',
       });
       const op: any = {
-        operation: { type: 'project', input: 'in', variables: [ DF.variable('a') ]},
+        operation: { type: 'project', input: bnodeInput, variables: [ DF.variable('a') ]},
         context: new ActionContext({ [KeysInitQuery.dataFactory.name]: DF }),
       };
       const output = getSafeBindings(await actor.run(op, undefined));
@@ -294,7 +329,7 @@ describe('ActorQueryOperationProject', () => {
         type: 'bindings',
       });
       const op: any = {
-        operation: { type: 'project', input: 'in', variables: [ DF.variable('a') ]},
+        operation: { type: 'project', input: bnodeInput, variables: [ DF.variable('a') ]},
         context: new ActionContext({ [KeysInitQuery.dataFactory.name]: DF }),
       };
       const output = getSafeBindings(await actor.run(op, undefined));

--- a/packages/actor-term-comparator-factory-expression-evaluator/lib/ActorTermComparatorFactoryExpressionEvaluator.ts
+++ b/packages/actor-term-comparator-factory-expression-evaluator/lib/ActorTermComparatorFactoryExpressionEvaluator.ts
@@ -15,6 +15,12 @@ import { TermComparatorExpressionEvaluator } from './TermComparatorExpressionEva
  * A comunica Expression Evaluator Based Term Comparator Factory Actor.
  */
 export class ActorTermComparatorFactoryExpressionEvaluator extends ActorTermComparatorFactory {
+  /**
+   * The super type provider handed to every comparator that does not get one from the context.
+   * It holds a type cache, so it is created once per actor instead of once per comparator.
+   */
+  private readonly defaultSuperTypeProvider = Eval.createSuperTypeProvider();
+
   public async test(_action: IActionTermComparatorFactory): Promise<TestResult<IActorTest>> {
     return passTestVoid();
   }
@@ -25,7 +31,7 @@ export class ActorTermComparatorFactoryExpressionEvaluator extends ActorTermComp
    * @param context.context IActionContext
    */
   public async run({ context }: IActionTermComparatorFactory): Promise<IActorTermComparatorFactoryOutput> {
-    context = Eval.prepareEvaluatorActionContext(context)
+    context = Eval.prepareEvaluatorActionContext(context, this.defaultSuperTypeProvider)
       .set(KeysExpressionEvaluator.nonLexicalComparison, true)
       .set(KeysExpressionEvaluator.fullTermComparison, true);
     return new TermComparatorExpressionEvaluator(

--- a/packages/utils-bindings-factory/lib/Bindings.ts
+++ b/packages/utils-bindings-factory/lib/Bindings.ts
@@ -102,8 +102,21 @@ export class Bindings implements RDF.Bindings {
   }
 
   public map(fn: (value: RDF.Term, key: RDF.Variable) => RDF.Term): Bindings {
-    return new Bindings(this.dataFactory, Map<string, RDF.Term>(<any> this.entries
-      .map((value, key) => fn(value, this.dataFactory.variable(key)))), this.contextHolder);
+    // Iterating via `forEach` avoids allocating iterator objects, and the entries map is only
+    // rebuilt for the terms that the mapper actually replaces. Mappers that leave (all of) the
+    // terms untouched -- which is the common case on hot paths such as skolemization --
+    // therefore do not allocate at all.
+    let entries: Map<string, RDF.Term> | undefined;
+    // This is immutable.js's `forEach`, which iterates internally.
+    // A `for...of` would allocate an iterator per call, which is what this method avoids.
+    // eslint-disable-next-line unicorn/no-array-for-each
+    this.entries.forEach((value, key) => {
+      const mapped = fn(value, this.dataFactory.variable(key));
+      if (mapped !== value) {
+        entries = (entries ?? this.entries).set(key, mapped);
+      }
+    });
+    return entries === undefined ? this : new Bindings(this.dataFactory, entries, this.contextHolder);
   }
 
   public merge(other: RDF.Bindings | Bindings): Bindings | undefined {

--- a/packages/utils-bindings-factory/test/Bindings-test.ts
+++ b/packages/utils-bindings-factory/test/Bindings-test.ts
@@ -150,6 +150,22 @@ describe('Bindings', () => {
         expect(cb).toHaveBeenNthCalledWith(2, DF.namedNode('ex:b'), DF.variable('b'));
         expect(cb).toHaveBeenNthCalledWith(3, DF.namedNode('ex:c'), DF.variable('c'));
       });
+
+      it('should return the same bindings if no value is replaced', () => {
+        const cb = jest.fn((value: RDF.Term) => value);
+        const bindingsNew = bindings.map(cb);
+        expect(bindingsNew).toBe(bindings);
+        expect(cb).toHaveBeenCalledTimes(3);
+      });
+
+      it('should only replace the values that the mapper changes', () => {
+        const bindingsNew = bindings.map(value => value.value === 'ex:b' ? DF.namedNode('ex:B') : value);
+        expect(bindingsNew).not.toBe(bindings);
+        expect(bindingsNew.size).toBe(3);
+        expect(bindingsNew.get(DF.variable('a'))).toEqual(DF.namedNode('ex:a'));
+        expect(bindingsNew.get(DF.variable('b'))).toEqual(DF.namedNode('ex:B'));
+        expect(bindingsNew.get(DF.variable('c'))).toEqual(DF.namedNode('ex:c'));
+      });
     });
 
     describe('size', () => {

--- a/packages/utils-expression-evaluator/lib/index.ts
+++ b/packages/utils-expression-evaluator/lib/index.ts
@@ -2,7 +2,7 @@ export { TermTransformer } from './transformers/TermTransformer';
 export {
   OverloadTree,
 } from './functions/OverloadTree';
-export { prepareEvaluatorActionContext } from './util/Context';
+export { prepareEvaluatorActionContext, createSuperTypeProvider } from './util/Context';
 export {
   declare,
   bool,

--- a/packages/utils-expression-evaluator/lib/transformers/TermTransformer.ts
+++ b/packages/utils-expression-evaluator/lib/transformers/TermTransformer.ts
@@ -32,33 +32,42 @@ export class TermTransformer implements ITermTransformer {
    * @param term RDF term to transform into internal representation of a term
    */
   public transformRDFTermUnsafe(term: RDF.Term): E.Term {
-    return <E.Term> this.transformTerm({
-      term,
-      type: Algebra.Types.EXPRESSION,
-      subType: Algebra.ExpressionTypes.TERM,
-    });
+    // This is on the hot path of every expression evaluation,
+    // so the RDF term is dispatched on directly instead of wrapping it in a term expression first.
+    // The wrapping term expression is only materialized for the error message.
+    if (!term) {
+      throw new Err.InvalidExpression({
+        term,
+        type: Algebra.Types.EXPRESSION,
+        subType: Algebra.ExpressionTypes.TERM,
+      });
+    }
+    return <E.Term> this.transformRdfTerm(term);
   }
 
   protected transformTerm(term: Algebra.TermExpression): Expression {
     if (!term.term) {
       throw new Err.InvalidExpression(term);
     }
+    return this.transformRdfTerm(term.term);
+  }
 
-    switch (term.term.termType) {
+  protected transformRdfTerm(term: RDF.Term): Expression {
+    switch (term.termType) {
       case 'Variable':
-        return new E.Variable(RDFString.termToString(term.term));
+        return new E.Variable(RDFString.termToString(term));
       case 'Literal':
-        return this.transformLiteral(term.term);
+        return this.transformLiteral(term);
       case 'NamedNode':
-        return new E.NamedNode(term.term.value);
+        return new E.NamedNode(term.value);
       case 'BlankNode':
-        return new E.BlankNode(term.term.value);
+        return new E.BlankNode(term.value);
       case 'Quad':
         return new E.Quad(
-          this.transformRDFTermUnsafe(term.term.subject),
-          this.transformRDFTermUnsafe(term.term.predicate),
-          this.transformRDFTermUnsafe(term.term.object),
-          this.transformRDFTermUnsafe(term.term.graph),
+          this.transformRDFTermUnsafe(term.subject),
+          this.transformRDFTermUnsafe(term.predicate),
+          this.transformRDFTermUnsafe(term.object),
+          this.transformRDFTermUnsafe(term.graph),
         );
       case 'DefaultGraph':
         return new E.DefaultGraph();

--- a/packages/utils-expression-evaluator/lib/util/Context.ts
+++ b/packages/utils-expression-evaluator/lib/util/Context.ts
@@ -1,10 +1,35 @@
 import { KeysExpressionEvaluator, KeysInitQuery } from '@comunica/context-entries';
-import type { AsyncExtensionFunction, GeneralSuperTypeDict, IActionContext } from '@comunica/types';
+import type {
+  AsyncExtensionFunction,
+  GeneralSuperTypeDict,
+  IActionContext,
+  ISuperTypeProvider,
+} from '@comunica/types';
 import type * as RDF from '@rdfjs/types';
 import { LRUCache } from 'lru-cache';
 import { extractTimeZone } from './DateTimeHelpers';
 
-export function prepareEvaluatorActionContext(orgContext: IActionContext): IActionContext {
+/**
+ * Prepare an action context for use by an expression evaluator.
+ * @param orgContext The context to prepare.
+ * @param defaultSuperTypeProvider A super type provider to fall back on if the context does not define one.
+ *                                 Since this holds a (pure) type cache, callers are encouraged to pass a
+ *                                 long-lived instance instead of letting one be created per evaluator.
+ */
+/**
+ * Create a super type provider with an empty type cache.
+ */
+export function createSuperTypeProvider(): ISuperTypeProvider {
+  return {
+    cache: new LRUCache<string, GeneralSuperTypeDict>({ max: 1_000 }),
+    discoverer: () => 'term',
+  };
+}
+
+export function prepareEvaluatorActionContext(
+  orgContext: IActionContext,
+  defaultSuperTypeProvider?: ISuperTypeProvider,
+): IActionContext {
   let context = orgContext;
 
   // Handle two variants of providing extension functions
@@ -34,10 +59,16 @@ export function prepareEvaluatorActionContext(orgContext: IActionContext): IActi
     extractTimeZone(context.getSafe(KeysInitQuery.queryTimestamp)),
   );
 
-  context = context.setDefault(KeysExpressionEvaluator.superTypeProvider, {
-    cache: new LRUCache<string, GeneralSuperTypeDict>({ max: 1_000 }),
-    discoverer: () => 'term',
-  });
+  // This is deliberately not a `setDefault` call: its argument would be evaluated on every invocation,
+  // allocating (and immediately discarding) a 1000-entry LRU cache even when a provider is already present.
+  // This function runs once per created expression evaluator, of which there is one per aggregator,
+  // so that adds up quickly on aggregation-heavy queries.
+  if (!context.has(KeysExpressionEvaluator.superTypeProvider)) {
+    context = context.set(
+      KeysExpressionEvaluator.superTypeProvider,
+      defaultSuperTypeProvider ?? createSuperTypeProvider(),
+    );
+  }
 
   return context;
 }

--- a/packages/utils-expression-evaluator/test/integration/transformers/TermTransformer-test.ts
+++ b/packages/utils-expression-evaluator/test/integration/transformers/TermTransformer-test.ts
@@ -108,6 +108,12 @@ describe('TermTransformer', () => {
         termTransformer.transformRDFTermUnsafe(null);
       }).toThrow(Err.InvalidExpression);
     });
+
+    it('a term expression without a term', () => {
+      expect(() => {
+        (<any> termTransformer).transformTerm({ type: 'expression', subType: 'term' });
+      }).toThrow(Err.InvalidExpression);
+    });
   });
 
   describe('ordering literals', () => {

--- a/packages/utils-expression-evaluator/test/unit/util/Context-test.ts
+++ b/packages/utils-expression-evaluator/test/unit/util/Context-test.ts
@@ -1,7 +1,7 @@
 import { KeysExpressionEvaluator, KeysInitQuery } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
 import { DataFactory } from 'rdf-data-factory';
-import { prepareEvaluatorActionContext } from '../../../lib';
+import { createSuperTypeProvider, prepareEvaluatorActionContext } from '../../../lib';
 
 const DF = new DataFactory();
 
@@ -10,6 +10,28 @@ describe('prepareEvaluatorActionContext', () => {
     [KeysInitQuery.queryTimestamp.name]: new Date(Date.now()),
     [KeysInitQuery.dataFactory.name]: DF,
     [KeysInitQuery.functionArgumentsCache.name]: {},
+  });
+
+  it('creates a super type provider when the context has none', () => {
+    const prepared = prepareEvaluatorActionContext(baseContext);
+    const provider = prepared.getSafe(KeysExpressionEvaluator.superTypeProvider);
+    expect(provider.cache).toBeDefined();
+    expect(provider.discoverer('http://example.org/unknown')).toBe('term');
+  });
+
+  it('reuses the given default super type provider', () => {
+    const provider = createSuperTypeProvider();
+    const prepared = prepareEvaluatorActionContext(baseContext, provider);
+    expect(prepared.getSafe(KeysExpressionEvaluator.superTypeProvider)).toBe(provider);
+  });
+
+  it('keeps a super type provider that is already in the context', () => {
+    const provider = createSuperTypeProvider();
+    const prepared = prepareEvaluatorActionContext(
+      baseContext.set(KeysExpressionEvaluator.superTypeProvider, provider),
+      createSuperTypeProvider(),
+    );
+    expect(prepared.getSafe(KeysExpressionEvaluator.superTypeProvider)).toBe(provider);
   });
 
   it('sets extensionFunctionCreator from extensionFunctions map', async() => {


### PR DESCRIPTION
Seven independent query-engine optimisations, each committed separately, each now
measured **in isolation** on the `performance/` benchmarks so it is clear which are
directly mergeable and which still need investigation.

None of them change query semantics. One fixes a correctness bug as a side effect
(multi-key `ORDER BY`, see below).

## Headline, stated honestly

**None of these changes measurably speeds up the standard `performance/` benchmarks.**
They are algorithmic and constant-factor improvements to specific operators, and they
show large effects only on workloads that actually exercise those operators.

The earlier "~27% faster overall, up to 5.6×" claim in this PR description came from a
synthetic micro-harness written during the investigation. The standard benchmarks do not
support it, and it has been withdrawn. What replaces it is a per-change table with the
workload each effect needs, and an explicit statement of what could not be measured.

| benchmark | whole branch vs `master` | significance | correctness |
|---|---|---|---|
| `benchmark-watdiv-file` | **+0.50%** | none; ±6% resolution | 0 mismatches, 244,585 results |
| `benchmark-watdiv-tpf` | plans **bit-identical** | `httpRequests` 128,609, 0/100 queries differ | 0 mismatches |
| `benchmark-bsbm-file` | **−1.41%** mean / −2.08% median | none; 95% CI [−4.13%, +1.30%] | 0 mismatches, 10 rounds |

## Per-change verdict

| # | Commit | Measured effect | Workload needed | Verdict |
|---|---|---|---|---|
| 1 | `SortIterator` sorts in O(n log n) instead of O(n²) | **−49.5%** unbounded `ORDER BY`; **−55%** `ORDER BY … LIMIT` | any `ORDER BY` over more than a few thousand rows | **Directly mergeable** — largest effect here, plus a correctness fix |
| 2 | Projections skip per-solution blank-node rescoping they cannot need | **−25.0%** on a 325k-row projection | any query returning many rows | **Directly mergeable** |
| 3 | Expression evaluator stops re-deriving constants per solution | **−17.4%** `FILTER`, **−12.5%** `BIND` | expression-heavy queries | **Directly mergeable** |
| 4 | `Bindings#map` does not rebuild bindings when nothing changes | **−16.3%** alone, but ~**0** on top of #2 — see *Overlap* | skolemisation path only, once #2 is in | **Mergeable, but little added value** |
| 5 | Term transformation dispatches on the RDF term directly | −5.3% on sort-heavy queries; ~0 on `FILTER`/`BIND` | — | **Needs investigation** — at the edge of resolution |
| 6 | `GROUP BY` stops allocating per solution what it needs per group | **−10.6%** on 443k rows → 3,955 groups | aggregate queries | **Mergeable, but see coverage gap** |
| 7 | One shared super type provider instead of one per evaluator | none measurable (−2.1%, +0.9%, +2.6% across three queries) | — | **Needs investigation** — no demonstrated benefit |

## Why the standard benchmarks cannot see most of this

All 20 WatDiv query templates are **pure basic graph patterns**. Grepping the generated
query set:

| feature | occurrences across all 20 WatDiv templates |
|---|---|
| `ORDER BY` | 0 |
| `GROUP BY` / aggregates | 0 |
| `DISTINCT` | 0 |
| `OPTIONAL`, `UNION`, `FILTER`, `BIND` | 0 |
| any function call | 0 |

So WatDiv structurally cannot exercise changes 1, 3, 5, 6 or 7. BSBM does use `ORDER BY`,
`DISTINCT` and `OPTIONAL` — but **neither benchmark contains a single aggregate**, so
change 6 has *no real-workload coverage anywhere*. Its number above comes from a custom
query and should be read as a mechanism demonstration, not workload validation.

This distinction matters for review: "not exercised by this benchmark" is a completely
different signal from "exercised and showed no benefit", and the two are kept separate
throughout.

## Custom benchmark queries

Because of the coverage gap, six templates were added over the same WatDiv dataset, each
aimed at one change. They live alongside the generated queries and run in the same jbr
harness:

| template | query shape | rows | targets |
|---|---|---|---|
| `X1ORDER` | `ORDER BY ?o` over `goodrelations:price` | 24,000 | #1 |
| `X2ORDLIM` | same, `LIMIT 100` | 24,000 scanned | #1 (see finding below) |
| `X3GROUP` | `COUNT`/`MIN`/`MAX` `GROUP BY ?s` over `wsdbm:friendOf` | 443k → 3,955 groups | #6 |
| `X4FILTER` | three chained arithmetic comparisons | 24,000 | #3, #5 |
| `X5BIND` | two chained arithmetic `BIND`s | 24,000 | #3, #4 |
| `X7PROJ` | two-variable projection over `wsdbm:follows` | 325,909 | #2, #4 |

## Method, and two measurement traps found along the way

Seven branches were cut from `master`, each with exactly one commit cherry-picked, and run
round-robin `master → c1 … c7 → master` so two `master` runs bracket every cycle.

**Trap 1 — between-cycle drift.** The machine drifted 2.8% between cycles while
within-cycle `master` runs agreed to 0.04% and 0.17%. Comparing against a global mean
would have attributed that drift to whichever commits happened to run later. All figures
are therefore normalised against the `master` runs from the *same* cycle.

**Trap 2 — slot bias.** Several commits showed tight, sign-consistent effects on queries
they cannot possibly touch: the `GROUP BY` change appeared to speed up `ORDER BY` queries
by 5–6%. A null experiment — running `master` in every slot of a cycle, identical code
throughout — showed why:

| slot | `X7PROJ`, identical code | `X3GROUP`, identical code |
|---|---|---|
| 1 | 1943 ms (baseline) | 9029 ms (baseline) |
| 2 | −3.95% | −0.71% |
| 3 | −7.03% | +0.77% |
| 4 | −7.70% | +0.69% |

Later slots run measurably faster on the streaming query. Consistency across cycles gives
no protection against this, because the bias is constant across cycles too. The affected
comparisons were re-run as a **Latin square**, each variant occupying each slot exactly
once, which cancels it in the mean.

Result counts and hashes were identical across every run of every experiment — 18 matrix
runs plus all in-process runs — with no query errors.

**What the balancing could not remove.** Even slot-balanced, a spurious effect of ~5% can
still appear: change 1 — which touches only sorting — measured **+5.2% on the `BIND`
query**, where it has no mechanism whatsoever. Separately, on the `ORDER BY` query all four
variants came out faster than `master`, which hints at a small systematic offset between
`master` and everything else rather than four independent improvements.

Both observations set the practical threshold at roughly **5%** for these queries. That is
why changes 5 and 7 are reported as unresolved rather than as small wins: their largest
readings (−5.3% and −2.6%) are the same size as effects that demonstrably cannot be real.
Sample sizes are n=5–6 per variant; a reviewer who wants those two settled should ask for
more rounds, not read the sign of the current numbers.

## Overlap: changes 2 and 4 are not additive

Both target the same per-row `bindings.map()` work. `skolemizeBindings`
(`actor-optimize-query-operation-query-source-skolemize/lib/utils.ts:78`) and
`ActorQueryOperationProject:77` are the two callers; change 4 speeds up both, while change
2 deletes the projection call entirely. Measured on `X7PROJ`:

| | effect |
|---|---|
| change 2 alone | **−25.0%** (n=6, slot-balanced) |
| change 4 alone | **−16.3%** (n=6, slot-balanced) |
| both together | **≈−25%** (−28.3% raw, corrected for a −4.5% slot advantage) |
| if they were additive | ≈−37% |

So change 4's remaining value on projections is small once change 2 is in; it earns its
place on the skolemisation path, which change 2 does not touch.

## A correctness fix that came with #1

`ActorQueryOperationOrderBy` sorts once per `ORDER BY` expression, least to most
significant, relying on later passes preserving earlier order. The binary insertion sort
was **not stable**: on a tie it inserted at an arbitrary position within the run of equal
elements, discarding the secondary key.

On `SELECT ?s ?a ?n WHERE { ?s :age ?a. ?s :name ?n } ORDER BY ?a ?n` over 20k solutions,
`master` emits **10,078 out-of-order adjacent pairs**; with this change it emits **0**.
`Array#sort` is stable, so multi-key `ORDER BY` now actually orders on secondary keys.

## Finding: `ORDER BY … LIMIT` does not use the windowed sort path

`X2ORDLIM` was written as a control — `ORDER BY ?o LIMIT 100` should exercise
`SortIterator`'s *windowed* path, which change 1 does not touch, and should therefore have
been flat. It came out **−55%**, the largest effect measured. Comunica does not push the
`LIMIT` into the sort window, so these queries take the unbounded path too.

That makes change 1 broader than intended, and it means the windowed path is close to dead
code for ordinary `ORDER BY … LIMIT` queries. Worth a separate look.

## The join cost model is broken, but the obvious fixes do not fix it

Not addressed in this PR. Documented with measurements so the next attempt does not start
from scratch, or from the wrong conclusion.

Three compounding defects, all confirmed in the source:

1. **The selectivity estimator cannot tell a star join from a cartesian product.**
   `ActorRdfJoinSelectivityVariableCounting` starts every pair at `MAX_PAIRWISE_COST = 82`
   and subtracts single digits, so its dynamic range is ≈0.90–1.00 (a shared subject
   subtracts 2: 80/82 = 0.976 against 82/82 for no shared variable).
2. **`ActorRdfJoinMultiSmallest` costs itself as a cartesian product**
   (`iterations = ∏ cardinalityᵢ`), even though it joins the two smallest entries and
   recurses.
3. **Only the bind family gets a `selectivityModifier`** (1e-4 for
   `MultiBind`/`MultiBindSource`/`MultiSmallestFilterBindings`, 1e-6 for `OptionalBind`),
   applied to its own output estimate. `hash` and `multi-smallest` get no such discount.

For a 4-pattern star of ~20k-row patterns, `multi-smallest` scores 1.6 × 10¹⁷ against
bind's 6.6 × 10⁴ — bind wins by ~12 orders of magnitude. Related: the cost function is
dimensionally inconsistent, combining `iterations` (an item count, often 1e6–1e17) with
`requestTime` (seconds, single digits) at weights of 10 each, so network time cannot
realistically influence plan choice.

Four variants were built and measured. Correctness held throughout — **0/100
result-or-hash mismatches and 244,585 results on every variant, on both benchmarks**.

* **Fixing #2 alone changes nothing at all.** Replacing the product with a sum — a
  ~12-order-of-magnitude drop — changed **0 of 29** local query plans, because bind's flat
  discount dominates regardless. Anyone starting here will measure nothing and may wrongly
  conclude the cost model is fine.
* **Fixing #3 alone does not fix the problem.** Star joins are unchanged: for ≥3 entries
  the competitor is `multi-smallest`, still self-costing as a cartesian product, so bind
  still wins. It also regressed a 4-pattern chain by 2.1× locally and changed **14 of 100
  TPF plans** (S3: 7 → 67 HTTP requests), which is what rejects it.
* **#2 and #3 together do move the headline cases.** Every `bind` and `nested-loop`
  disappears from the star and chain plans (7 of 29 changed), and the chain regression
  inverts, confirming that the two defects compound and neither is fixable alone.
* **Adding the remoteness fix below makes it provably plan-safe remotely.** TPF
  `httpRequests` returns to **128,609 on every one of 100 queries** — bit-identical to
  `master`.

### Why that variant is still not shippable

On `benchmark-watdiv-file` its −14.32% total is one query set carrying everything: **C2
alone drops 88%** while **C3 — the set that actually returns 48,802 results — regresses
33%**, and 18 of 20 sets get slower.

The local micro-harness had said −76.1%. The real WatDiv workload disagrees by roughly a
factor of seven and disagrees in kind — broad regressions where the micro-harness saw
none. **The synthetic queries were biased toward exactly the pathological shape**: uniform
~20k cardinalities, star and chain joins where bind is obviously wrong. Real WatDiv queries
are varied and often highly selective, and there bind joins are frequently the *right*
choice, which is what the crude 1e-4 modifier was encoding.

> A hand-built micro-harness is good for finding and diagnosing a planner pathology. It
> cannot be used to size the benefit of a planner change.

A real fix has to make the *estimates* right so operators compete fairly — chiefly giving
the selectivity heuristic genuine dynamic range — rather than removing or re-gating a
discount that is currently doing useful work by accident.

## A latent bug found on the way

`ActorRdfJoinMultiBind.getJoinCoefficients` decides locality with
`requestItemTimes.some(time => time > 0)`, derived from each metadata's `pageSize`. But
`ActorRdfJoin.constructResultMetadata` propagates neither `pageSize` nor `requestTime`, so
**any join whose inputs are themselves join results reads as local — even in a pure TPF
query**. Since `ActorRdfJoinMultiSmallest.getOutput` feeds join results back in as new
entries, nested joins are the normal case: `isRemoteAccess` is only reliable at the leaves
of the plan tree. On `master` today that means the `minMaxCardinalityRatio` gate's local
`/3` relaxation is applied to nested joins over remote sources.

Propagating `pageSize`/`requestTime` through `constructResultMetadata` fixes it. Measured
in isolation on a branch off `master`: **0 of 29 local plans changed, 0 of 100 TPF plans
changed** (`httpRequests` exactly 128,609), results identical, wall clock within noise on
both benchmarks. That it is not merely inert is established by a controlled pair: two
branches differing by exactly this hunk changed 14/100 and 0/100 TPF plans respectively.

So it is a safe correctness fix with **no demonstrable performance benefit** — worth doing
on its own terms, and a prerequisite for any future locality-aware cost-model work, but not
a speedup. It is **not included in this PR**: it would need unit tests for the added
branches, and it touches shared join infrastructure, so it deserves wider benchmark
coverage than it has had.