### PR TITLE
Two measured query-engine optimisations: −49% on benchmark-watdiv-file, −8% on benchmark-bsbm-file

### DIFF
--- a/packages/actor-query-process-sequential/lib/ActorQueryProcessSequential.ts
+++ b/packages/actor-query-process-sequential/lib/ActorQueryProcessSequential.ts
@@ -107,6 +107,9 @@ export class ActorQueryProcessSequential extends ActorQueryProcess implements IQ
   }
 
   public async optimize(operation: Algebra.Operation, context: IActionContext): Promise<IQueryProcessSequentialOutput> {
+    // Open a scope that is unique to this query execution, for caches that must not outlive it
+    context = context.set(KeysInitQuery.queryExecutionScope, {});
+
     // Save initial query in context
     context = context.set(KeysInitQuery.query, operation);
 

--- a/packages/actor-query-process-sequential/test/ActorQueryProcessSequential-test.ts
+++ b/packages/actor-query-process-sequential/test/ActorQueryProcessSequential-test.ts
@@ -109,6 +109,7 @@ describe('ActorQueryProcessSequential', () => {
           context: ctx,
         });
         expect((<any> result).context).toEqual(new ActionContext({ [KeysInitQuery.dataFactory.name]: DF })
+          .set(KeysInitQuery.queryExecutionScope, {})
           .set(KeysInitQuery.query, AF.createJoin([
             op,
           ], false)));
@@ -124,6 +125,7 @@ describe('ActorQueryProcessSequential', () => {
         expect(mediatorOptimizeQueryOperation.mediate).toHaveBeenCalledWith({
           operation: op,
           context: new ActionContext({ [KeysInitQuery.dataFactory.name]: DF })
+            .set(KeysInitQuery.queryExecutionScope, {})
             .set(KeysInitQuery.query, op),
         });
         expect(mediatorQueryOperation.mediate).toHaveBeenCalledWith({
@@ -131,6 +133,7 @@ describe('ActorQueryProcessSequential', () => {
             op,
           ], false),
           context: new ActionContext({ [KeysInitQuery.dataFactory.name]: DF })
+            .set(KeysInitQuery.queryExecutionScope, {})
             .set(KeysInitQuery.query, AF.createJoin([
               op,
             ], false)),
@@ -252,6 +255,7 @@ describe('ActorQueryProcessSequential', () => {
 
         const output = await actor.optimize(op, ctx);
         expect(output.context).toEqual(new ActionContext({ [KeysInitQuery.dataFactory.name]: DF })
+          .set(KeysInitQuery.queryExecutionScope, {})
           .set(KeysInitQuery.query, AF.createJoin([
             op,
           ], false)));
@@ -262,6 +266,7 @@ describe('ActorQueryProcessSequential', () => {
         expect(mediatorOptimizeQueryOperation.mediate).toHaveBeenCalledWith({
           operation: op,
           context: new ActionContext({ [KeysInitQuery.dataFactory.name]: DF })
+            .set(KeysInitQuery.queryExecutionScope, {})
             .set(KeysInitQuery.query, op),
         });
       });

--- a/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
+++ b/packages/actor-query-source-identify-rdfjs/lib/QuerySourceRdfJs.ts
@@ -1,5 +1,5 @@
 import { filterMatchingQuotedQuads, getVariables, quadsToBindings } from '@comunica/bus-query-source-identify';
-import { KeysQueryOperation } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import type {
   BindingsStream,
   ComunicaDataFactory,
@@ -23,6 +23,12 @@ export class QuerySourceRdfJs implements IQuerySource {
   private readonly dataFactory: ComunicaDataFactory;
   private readonly bindingsFactory: BindingsFactory;
   private readonly dummyDefaultGraph: RDF.Variable;
+  /**
+   * Cardinalities of patterns that have already been counted during a query execution.
+   * Keyed on the query execution scope from the context, so that entries are dropped as soon as that
+   * execution is garbage-collected, and are never reused across query executions.
+   */
+  private readonly cardinalityCache = new WeakMap<object, Map<string, number>>();
 
   public constructor(
     source: RDF.Source | RDF.DatasetCore,
@@ -246,6 +252,84 @@ export class QuerySourceRdfJs implements IQuerySource {
     );
   }
 
+  /**
+   * Check whether counting the given (already nullified) quad pattern is expensive enough to be worth caching.
+   *
+   * Patterns with at most one wildcard are answered by a direct index lookup, so counting them is cheap.
+   * In bind joins those are the materialized patterns, which differ for every binding, so caching them
+   * would only add lookup and storage cost.
+   * Patterns with more wildcards require an index walk proportional to their cardinality, and are exactly
+   * the patterns that a bind join re-evaluates unchanged once per binding.
+   * @param terms The quad pattern terms, where undefined represents a wildcard.
+   */
+  public static isCardinalityCacheable(...terms: (RDF.Term | undefined)[]): boolean {
+    let wildcards = 0;
+    for (const term of terms) {
+      if (!term) {
+        wildcards++;
+        if (wildcards >= 2) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Obtain the cardinality cache for the query execution that the given context belongs to.
+   * Returns undefined if the context carries no query execution scope, in which case nothing is cached.
+   * @param context The action context.
+   */
+  protected getCardinalityCache(context: IActionContext): Map<string, number> | undefined {
+    const scope = context.get(KeysInitQuery.queryExecutionScope);
+    if (!scope) {
+      return undefined;
+    }
+    let cache = this.cardinalityCache.get(scope);
+    if (!cache) {
+      cache = new Map();
+      this.cardinalityCache.set(scope, cache);
+    }
+    return cache;
+  }
+
+  /**
+   * Determine a cardinality cache key for the given (already nullified) quad pattern terms.
+   * Returns undefined for patterns that must not be cached, i.e. those containing quoted triples,
+   * as those are matched structurally rather than by value.
+   * @param terms The quad pattern terms, where undefined represents a wildcard.
+   */
+  public static getCardinalityCacheKey(...terms: (RDF.Term | undefined)[]): string | undefined {
+    let key = '';
+    for (const term of terms) {
+      if (!term) {
+        key += '?|';
+        continue;
+      }
+      switch (term.termType) {
+        case 'NamedNode':
+          key += `n${term.value}|`;
+          break;
+        case 'BlankNode':
+          key += `b${term.value}|`;
+          break;
+        case 'Literal':
+          key += `l${term.language}^${term.datatype.value}^${term.value}|`;
+          break;
+        case 'DefaultGraph':
+          key += 'd|';
+          break;
+        case 'Variable':
+          key += `v${term.value}|`;
+          break;
+        default:
+          // Quoted triples are matched structurally, so patterns containing them are never cached.
+          return undefined;
+      }
+    }
+    return key;
+  }
+
   protected async setMetadata(
     it: AsyncIterator<any>,
     operation: Algebra.Pattern,
@@ -265,12 +349,25 @@ export class QuerySourceRdfJs implements IQuerySource {
     let cardinality: number;
     if ('countQuads' in this.source && this.source.countQuads) {
       // If the source provides a dedicated method for determining cardinality, use that.
-      cardinality = await this.source.countQuads(
-        QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering),
-        QuerySourceRdfJs.nullifyVariables(operation.graph, quotedTripleFiltering),
-      );
+      // Bind joins re-evaluate the same patterns once per binding, so identical counts are reused
+      // within a query execution instead of being recomputed over the source.
+      const subject = QuerySourceRdfJs.nullifyVariables(operation.subject, quotedTripleFiltering);
+      const predicate = QuerySourceRdfJs.nullifyVariables(operation.predicate, quotedTripleFiltering);
+      const object = QuerySourceRdfJs.nullifyVariables(operation.object, quotedTripleFiltering);
+      const graph = QuerySourceRdfJs.nullifyVariables(operation.graph, quotedTripleFiltering);
+      const cache = QuerySourceRdfJs.isCardinalityCacheable(subject, predicate, object, graph) ?
+        this.getCardinalityCache(context) :
+        undefined;
+      const cacheKey = cache && QuerySourceRdfJs.getCardinalityCacheKey(subject, predicate, object, graph);
+      const cached = cacheKey === undefined ? undefined : cache!.get(cacheKey);
+      if (cached === undefined) {
+        cardinality = await this.source.countQuads(subject, predicate, object, graph);
+        if (cacheKey !== undefined) {
+          cache!.set(cacheKey, cardinality);
+        }
+      } else {
+        cardinality = cached;
+      }
     } else {
       // Otherwise, fallback to a sub-optimal alternative where we just call match again to count the quads.
       // WARNING: we can NOT reuse the original data stream here,

--- a/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
+++ b/packages/actor-query-source-identify-rdfjs/test/QuerySourceRdfJs-test.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'node:stream';
-import { KeysQueryOperation } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
 import { AlgebraFactory, TypesComunica } from '@comunica/utils-algebra';
@@ -1040,6 +1040,104 @@ describe('QuerySourceRdfJs', () => {
             requestTime: 0,
           });
       });
+    });
+  });
+
+  describe('cardinality caching', () => {
+    const pattern = AF.createPattern(DF.variable('s'), DF.namedNode('p'), DF.variable('o'));
+
+    async function cardinalityOf(data: any): Promise<number> {
+      const metadata: any = await new Promise(resolve => data.getProperty('metadata', resolve));
+      return metadata.cardinality.value;
+    }
+
+    beforeEach(() => {
+      store.addQuad(DF.quad(DF.namedNode('s1'), DF.namedNode('p'), DF.namedNode('o1')));
+      store.addQuad(DF.quad(DF.namedNode('s2'), DF.namedNode('p'), DF.namedNode('o2')));
+    });
+
+    it('should not count the same pattern twice within one query execution', async() => {
+      const countQuads = jest.spyOn(<any> store, 'countQuads');
+      const scoped = new ActionContext({ [KeysInitQuery.queryExecutionScope.name]: {}});
+
+      await expect(cardinalityOf(source.queryBindings(pattern, scoped))).resolves.toBe(2);
+      await expect(cardinalityOf(source.queryBindings(pattern, scoped))).resolves.toBe(2);
+
+      expect(countQuads).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not reuse counts across query executions', async() => {
+      const countQuads = jest.spyOn(<any> store, 'countQuads');
+
+      await expect(cardinalityOf(source.queryBindings(
+        pattern,
+        new ActionContext({ [KeysInitQuery.queryExecutionScope.name]: {}}),
+      ))).resolves.toBe(2);
+      store.addQuad(DF.quad(DF.namedNode('s3'), DF.namedNode('p'), DF.namedNode('o3')));
+      await expect(cardinalityOf(source.queryBindings(
+        pattern,
+        new ActionContext({ [KeysInitQuery.queryExecutionScope.name]: {}}),
+      ))).resolves.toBe(3);
+
+      expect(countQuads).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache without a query execution scope in the context', async() => {
+      const countQuads = jest.spyOn(<any> store, 'countQuads');
+
+      await expect(cardinalityOf(source.queryBindings(pattern, ctx))).resolves.toBe(2);
+      await expect(cardinalityOf(source.queryBindings(pattern, ctx))).resolves.toBe(2);
+
+      expect(countQuads).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not cache patterns that are cheap to count', async() => {
+      const countQuads = jest.spyOn(<any> store, 'countQuads');
+      const scoped = new ActionContext({ [KeysInitQuery.queryExecutionScope.name]: {}});
+      const bound = AF.createPattern(DF.namedNode('s1'), DF.namedNode('p'), DF.variable('o'));
+
+      await expect(cardinalityOf(source.queryBindings(bound, scoped))).resolves.toBe(1);
+      await expect(cardinalityOf(source.queryBindings(bound, scoped))).resolves.toBe(1);
+
+      expect(countQuads).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('isCardinalityCacheable', () => {
+    it('should be true for patterns with at least two wildcards', () => {
+      expect(QuerySourceRdfJs.isCardinalityCacheable(undefined, DF.namedNode('p'), undefined, DF.defaultGraph()))
+        .toBe(true);
+      expect(QuerySourceRdfJs.isCardinalityCacheable(undefined, undefined, undefined, undefined)).toBe(true);
+    });
+
+    it('should be false for patterns with at most one wildcard', () => {
+      expect(QuerySourceRdfJs.isCardinalityCacheable(DF.namedNode('s'), DF.namedNode('p'), undefined, DF
+        .defaultGraph())).toBe(false);
+      expect(QuerySourceRdfJs.isCardinalityCacheable(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o'), DF
+        .defaultGraph())).toBe(false);
+    });
+  });
+
+  describe('getCardinalityCacheKey', () => {
+    it('should distinguish terms of different types and values', () => {
+      const keys = [
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.namedNode('a')),
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.namedNode('b')),
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.blankNode('a')),
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.literal('a')),
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.literal('a', 'en')),
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.literal('a', DF.namedNode('http://ex.org/dt'))),
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.defaultGraph()),
+        QuerySourceRdfJs.getCardinalityCacheKey(DF.variable('a')),
+        QuerySourceRdfJs.getCardinalityCacheKey(undefined),
+      ];
+      expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('should not produce a key for patterns containing quoted triples', () => {
+      expect(QuerySourceRdfJs.getCardinalityCacheKey(
+        DF.quad(DF.namedNode('s'), DF.namedNode('p'), DF.namedNode('o')),
+      )).toBeUndefined();
     });
   });
 

--- a/packages/actor-rdf-metadata-accumulate-cardinality/lib/ActorRdfMetadataAccumulateCardinality.ts
+++ b/packages/actor-rdf-metadata-accumulate-cardinality/lib/ActorRdfMetadataAccumulateCardinality.ts
@@ -26,8 +26,12 @@ export class ActorRdfMetadataAccumulateCardinality extends ActorRdfMetadataAccum
       return { metadata: { cardinality: { type: 'exact', value: 0 }}};
     }
 
-    // Otherwise, attempt to update existing value
-    const cardinality: QueryResultCardinality = { ...action.accumulatedMetadata.cardinality };
+    // Otherwise, attempt to update existing value.
+    // Sources that report no cardinality of their own accumulate from the same value as `initialize`,
+    // which is the identity of the summation below.
+    const cardinality: QueryResultCardinality = action.accumulatedMetadata.cardinality ?
+        { ...action.accumulatedMetadata.cardinality } :
+        { type: 'exact', value: 0 };
 
     if (cardinality.dataset) {
       // If the accumulated cardinality refers to that of the full default graph (applicable for SPARQL endpoints)

--- a/packages/actor-rdf-metadata-accumulate-cardinality/test/ActorRdfMetadataAccumulateCardinality-test.ts
+++ b/packages/actor-rdf-metadata-accumulate-cardinality/test/ActorRdfMetadataAccumulateCardinality-test.ts
@@ -40,6 +40,17 @@ describe('ActorRdfMetadataAccumulateCardinality', () => {
         })).resolves.toEqual({ metadata: { cardinality: { type: 'exact', value: 5 }}});
       });
 
+      it('should handle appending onto metadata without a cardinality', async() => {
+        // Sources that report no cardinality of their own accumulate from the same value as
+        // `initialize`, so an exact appending cardinality stays exact
+        await expect(actor.run({
+          context,
+          mode: 'append',
+          accumulatedMetadata: <any> {},
+          appendingMetadata: <any> { cardinality: { type: 'exact', value: 3 }},
+        })).resolves.toEqual({ metadata: { cardinality: { type: 'exact', value: 3 }}});
+      });
+
       it('should handle appending with estimate cardinalities', async() => {
         await expect(actor.run({
           context,

--- a/packages/actor-rdf-metadata-extract-hydra-count/lib/ActorRdfMetadataExtractHydraCount.ts
+++ b/packages/actor-rdf-metadata-extract-hydra-count/lib/ActorRdfMetadataExtractHydraCount.ts
@@ -43,9 +43,12 @@ export class ActorRdfMetadataExtractHydraCount extends ActorRdfMetadataExtract
         }
       });
 
-      // If no value has been found, assume infinity.
+      // If no value has been found, report no cardinality at all.
+      // Reporting an estimate of zero instead would be wrong twice over: it claims a count that was
+      // never found, and because accumulating an estimate with anything yields an estimate, it makes
+      // every cardinality accumulated on top of it an estimate as well, even when they are exact.
       action.metadata.on('end', () => {
-        resolve({ metadata: { cardinality: { type: 'estimate', value: 0 }}});
+        resolve({ metadata: {}});
       });
     });
   }

--- a/packages/actor-rdf-metadata-extract-hydra-count/test/ActorRdfMetadataExtractHydraCount-test.ts
+++ b/packages/actor-rdf-metadata-extract-hydra-count/test/ActorRdfMetadataExtractHydraCount-test.ts
@@ -64,8 +64,10 @@ describe('ActorRdfMetadataExtractHydraCount', () => {
     });
 
     it('should run on a stream where count is not given', async() => {
+      // No cardinality at all, rather than an invented estimate of zero, which would make every
+      // cardinality accumulated on top of this source an estimate as well.
       await expect(actor.run({ url: '', metadata: inputNone, requestTime: 0, context })).resolves
-        .toEqual({ metadata: { cardinality: { type: 'estimate', value: 0 }}});
+        .toEqual({ metadata: {}});
     });
   });
 });

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -255,6 +255,12 @@ export const KeysInitQuery = {
    */
   invalidateCache: new ActionContextKey<boolean>('@comunica/actor-init-query:invalidateCache'),
   /**
+   * An opaque object that is unique to a single query execution.
+   * Actors can use it as a key into a `WeakMap` to hold state that may be reused within one query execution,
+   * but must never be reused across query executions, such as cached source cardinalities.
+   */
+  queryExecutionScope: new ActionContextKey<object>('@comunica/actor-init-query:queryExecutionScope'),
+  /**
    * The data factory for creating terms and quads.
    */
   dataFactory: new ActionContextKey<ComunicaDataFactory>('@comunica/actor-init-query:dataFactory'),


### PR DESCRIPTION
Two query-engine optimisations, one per commit, each measured on the standard `performance/`
benchmarks under a slot-balanced Latin square. Neither changes query semantics.

**Everything below is re-measured against `a36cfef`.** The four commits merged to master since
this PR was opened — in particular `764ce28` (join cardinality capping), `a36cfef` (multi-smallest
costing) and `fdaf691` (asyncjoin) — change query plans and join performance, so the previously
reported figures were void and have been replaced, not carried over. This PR was also reduced from
four commits to two in response to review; see [What changed after review](#what-changed-after-review).

## Headline

| benchmark | commit 1 | commits 1+2 | noise floor | correctness |
|---|---|---|---|---|
| `benchmark-watdiv-file` | −41.77% | **−48.54%** | ±0.83% (n=8 master, sd 1.20pp) | 244,585 results, hashes identical, 0 errors (16 runs) |
| `benchmark-bsbm-file` | −7.74% | **−7.52%** | see note on bimodality | per-query result counts identical, 0 timeouts (32 runs) |
| `benchmark-watdiv-tpf` | +1.62% (sd 1.90pp) | −0.21% (sd 1.49pp) | ±0.9% (n=6 master) | 244,585 results, hashes identical, `httpRequests` 129,318, 0/100 queries differ (12 runs) |
| `benchmark-bsbm-tpf` | not measured | not measured | — | `jbr prepare` fails with a Docker HTTP 500 here |

95% CI on `watdiv-file` (n=4): commit 1 [−43.27%, −40.28%], commits 1+2 [−50.19%, −46.89%].

These compound with the recent master work rather than overlapping it: master itself got **34.2%
faster** on `watdiv-file` over that period (43,528 → 28,629 ms), and this branch takes it to
14,732 ms.

## Per-change verdict

| # | Commit | `watdiv-file` | `bsbm-file` | `watdiv-tpf` | Verdict |
|---|---|---|---|---|---|
| 1 | Reuse pattern cardinalities within a query execution over RDF/JS sources | **−41.77%** | **−7.74%** | **not exercised** — different source type | **Directly mergeable** |
| 2 | Report no cardinality when a source has none, instead of an estimated zero | **≈−11.5%** on top of #1 | exercised, no measurable benefit | **not exercised** — TPF fragments carry counts | **Directly mergeable** — also a bug fix |

"Not exercised" means the code never runs, confirmed on the benchmark rather than assumed. It is
kept distinct from "exercised, no benefit", which is commit 2 on BSBM: the code runs and does its
job, but BSBM's joins rarely contain an empty entry, so there is little for it to do.

## 1. Repeated cardinality counting (`QuerySourceRdfJs`)

`setMetadata` determines a cardinality for every pattern evaluation, either through `countQuads`
or, for sources that do not provide it, by running `match` a second time and counting every quad.
A bind join re-evaluates its remaining patterns once per binding, and patterns that do not contain
the bound variable are re-evaluated completely unchanged. `RdfStore.countQuads` walks the index and
costs O(cardinality), so the patterns that recur are also the expensive ones to count.

Instrumenting WatDiv C2 — a query that returns **zero results** — gives `countQuads calls: 11294`,
taking `2120 ms` of the query's `3117 ms` (**68.0%**). Six distinct patterns account for most of
them, each counted ~1,400 times with identical arguments:

| calls | pattern |
|---|---|
| 1481 | `? schema:jobTitle ?` |
| 1481 | `? foaf:homepage ?` |
| 1417 | `? rev:totalVotes ?` |
| 1372 | `? wsdbm:makesPurchase ?` |
| 1240 | `? wsdbm:purchaseFor ?` |
| 1240 | `? rev:hasReview ?` |

The cache is scoped to a single query execution via a new `KeysInitQuery.queryExecutionScope`
context entry that `ActorQueryProcessSequential.optimize` opens per execution, held in a `WeakMap`
keyed on that scope. It is deliberately **not** keyed on the query algebra: a caller may pass the
same algebra object to more than one execution, and a cardinality must never survive across them.

**Only patterns with ≥2 wildcards are cached.** Fewer wildcards means a direct index lookup, which
is cheap to count, and in a bind join those are the *materialized* patterns, which differ for every
binding. This gate is not cosmetic — caching unconditionally **regressed C3 by +8.8%**.

### Scope: which sources benefit

Raised in review, and worth stating precisely.

* **Any RDF/JS-backed source benefits with no changes**, since the redundancy is in how
  `QuerySourceRdfJs` derives cardinality. Sources without `countQuads` benefit *more*, because
  their fallback is a second full `match` scan.
* **HDT needs no changes and would not benefit.** `QuerySourceHdt` implements `IQuerySource`
  directly, bypassing `QuerySourceRdfJs`, and `HdtIterator` takes `totalCount` and `hasExactCount`
  from the same `searchTriples` call that returns the data. The count is a by-product, so there is
  nothing redundant to cache.
* **`QuerySourceSparql` and `QuerySourceQpf` do not benefit.** Their equivalent redundancy is an
  HTTP COUNT query or fragment request. Covering those would mean memoising *metadata* per
  (source, operation) per query execution in a source-agnostic layer — a larger change with stream
  and invalidation implications, better raised as its own issue.

## 2. A missing count reported as an estimated zero

`ActorRdfMetadataExtractHydraCount` resolved with `{ type: 'estimate', value: 0 }` when the
dereferenced document contained no count predicate — contradicting its own comment:

```ts
// If no value has been found, assume infinity.
action.metadata.on('end', () => {
  resolve({ metadata: { cardinality: { type: 'estimate', value: 0 }}});
});
```

That value is wrong twice over: it claims a count that was never found, and because accumulating an
estimate with anything yields an estimate, it makes **every cardinality accumulated on top of it an
estimate as well**. Any file without a hydra count is such a document, so on that path the estimate
spread to everything. `QuerySourceRdfJs` reports an exact cardinality per pattern, but accumulating
it onto the source produced an estimate:

```
acc={estimate,0} + app={exact,11030} -> {estimate,11030}
```

Instrumented on WatDiv: **62,760 zero cardinalities reached the join operation and not one was
exact**. `ActorQueryOperationJoin` only short-circuits to an empty result for an *exact* zero, so
that check never fired once, and 3,994 joins per C3 execution were mediated in full only to be
handed back an empty stream by `ActorRdfJoinMultiEmpty`.

The extractor now reports no cardinality in that case, and `ActorRdfMetadataAccumulateCardinality`
treats a missing accumulated cardinality as the same value `initialize` produces, which is the
identity of its summation. Accumulation then preserves exactness. Verified on current master:

| C3 | pristine `a36cfef` | with this commit |
|---|---|---|
| accumulated cardinality | `{estimate, 11030}` | **`{exact, 11030}`** |
| rdf-join mediations | 4,527 | **533** |
| `ActorRdfJoinMultiEmpty` selected | 3,994 | **0** |

**Nothing is relaxed by this.** The emptiness test still requires an exact cardinality, so a source
reporting an estimated zero because it has not seen all its data yet — one still discovering links,
for instance — is unaffected. Exact cardinalities should also help join planning generally.

Note this is orthogonal to `764ce28`: that caps *join-output* cardinalities, whereas the mislabelled
estimate originates in the *source-level* seed, which is why the mechanism above is unchanged on
current master.

## Method

* **Latin square** over `{master, variant…, master}` per cycle, variant order rotated between cycles
  so slot bias cancels. 16 runs for `watdiv-file`, 32 for `bsbm-file`, 12 for `watdiv-tpf`.
* **Per-cycle normalisation**: each variant is measured against the mean of the two master runs *in
  its own cycle*, never a global baseline.
* **Every run verified.** Output is deleted before each run, a missing output file is a hard
  failure, and each runner now checks the Docker daemon before starting. The daemon was reaped three
  times during this work and those guards aborted the affected campaigns before they produced a
  single run, rather than yielding partial data.
* **BSBM is bimodal here**, with roughly one run in eight taking ~1.7× as long. Two campaigns were
  run; each contained exactly one such cycle, on a *different* variant (campaign 1 on commit 2,
  campaign 2 on commit 1, the latter showing Q8 at +77.7%). The reported figures are therefore
  **medians over the 8 pooled cycles**, not means. A single campaign would have supported either
  "commit 2 regresses BSBM" or "commit 1 does"; neither survives pooling.
* BSBM was run at `runs: 40` rather than the default `runs: 10`, whose ~21% standard deviation makes
  it useless. That is a local measurement config and is **not** part of this PR.
* Sizing never comes from a micro-harness. A warm in-process harness was used to *find and diagnose*
  pathologies; every number above comes from `performance/`.

## What changed after review

### Removed: "Build the `BusIndexed` actor index lazily"

Redundant. `60dabd3` fixes the same root cause by passing `operationName` through args, so it is set
before `Actor`'s constructor subscribes. On master's build, WatDiv C3: `index keys=27,
_undefined_=1, 28,500 actor tests for 24,428 dispatches` — identical to what the removed commit
achieved. `ActorFunctionFactory` is also healthy (91 index keys, 1 unindexed).

### Removed: "Short-circuit empty joins for sources that report estimated cardinalities"

Replaced by commit 2. Relaxing the `exact` requirement treated the symptom; the cause was the
invented estimated zero. Fixing that makes the existing exact-only check fire on its own.

For the record: relaxing it would not have *introduced* estimate-zero-means-empty behaviour, because
`ActorRdfJoinMultiEmpty.test` already accepts a zero of any type and is selected 3,994 times per C3
execution on master. That pre-existing behaviour may be worth a look for link traversal independently
of this PR.

### Removed: "Stop evaluating a join's entries once one of them is empty"

**Measured as a regression and dropped.** Review asked whether it would serialise requests that are
currently parallel. It does:

| | `watdiv-file` | `watdiv-tpf` |
|---|---|---|
| effect | −6.32% | **+8.59%** (sd 0.92pp vs 0.71pp master noise) |

Wrong-way in all three TPF cycles. The `httpRequests` oracle shows why: **128,609 on all 15 runs of
all variants**, so on TPF the short-circuit never fired once — TPF reports hydra estimates, and the
emptiness test requires exact — while the extra sequential round was still paid. A bounded variant
was tried first (first entry alone, rest in parallel, capping the added round trips at one, giving
1.50 rounds per join instead of 2.06); it regressed TPF identically. Dropped.

## Negative results

1. **Bypassing the skolemisation stream wrapper** — **−9%/−11% on C3 and −6%/−19% on C2** on the
   file-source path. Not shipped: the cost is the extra `AsyncIterator` layer per source call, and a
   source cannot know in advance whether it will emit blank nodes. This also explains #1754's null
   result for `Bindings#map` — optimising the transform cannot help, only removing the layer can.
2. **Memoising the selector-shape acceptance check** in `ActorQueryOperationSource.test`. A promising
   ceiling probe turned out to be measuring the surrounding async hop: `doesShapeAcceptOperation` has
   a **self time of 7–9 ms out of ~1,400 ms (0.6%)**. Killed on mechanism, without spending benchmark
   time on it.
3. **Skipping the two whole-operation tree walks per pattern evaluation** — `deskolemizeOperation`
   and the CONSTRUCT-detecting `visitOperation`. Ceiling probe over the full 100-query set:
   **+4.8% and +0.7%**, i.e. no win at all.
4. **Bypassing the metadata-accumulate mediation** (20,737 mediations and 62,211 actor tests per C3
   execution). Interleaved probe: −1%, −6.7%, **+6.3%**. An earlier revision of this PR claimed
   ≈−12% here; that was a bad measurement and is withdrawn.
5. **Memoising `ActorRdfJoin.getMetadatas` and `overlappingVariables` per action.** Sound when keyed
   on the action object rather than the mutated `entries` array. **No gain at all** —
   `getMetadataBindings` already applies `cachifyMetadata`.
6. **Memoising the join-entries sort per mediation.** Bypassing the bus entirely — an upper bound on
   what memoisation could recover — measured −23% on C2 once and then **nothing** on three
   interleaved repetitions. The first reading was an outlier baseline.
7. **Batching the projection's per-variable `delete`s**: removing them entirely measures −0.5%.
8. **Fusing the bind join's per-binding `TransformIterator` with its `.transform({map})`; tightening
   `MediatorCombineUnion`**: each within noise individually.

## What is still on the table

* The skolemisation wrapper is the largest single remaining item, needing a source-level "can this
  source emit blank nodes" capability that survives updates before it can be removed soundly.
* Source-agnostic metadata memoisation, which would extend commit 1's benefit to SPARQL endpoints
  and QPF sources.
* Commit 2 is consistently ~3pp weaker than commit 1 alone on BSBM Q5, offset by being much stronger
  on Q7. The net is neutral, but if Q5 matters on its own it may be worth understanding why exact
  cardinalities change its plan.
* Unrelated to this PR, but noticed while running the suites: `master` currently fails 8 SPARQL spec
  tests (456/464), all `dawg-dataset-*` FROM / FROM NAMED. Verified pre-existing by running the
  suite on a pristine `master` checkout.
* `benchmark-bsbm-tpf` was not measured: `jbr prepare` fails with a Docker HTTP 500 in this
  environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016R9BxgU89DzMMi7eJ9y7NJ