### PR TITLE
Add regression test for blank node deskolemization in DELETE/INSERT WHERE

### DIFF
--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -2923,6 +2923,46 @@ CONSTRUCT {
           .toBe(0);
       });
 
+      // https://github.com/comunica/comunica/issues/1057
+      it('with delete insert where over blank nodes on a single source', async() => {
+        // Prepare store
+        const store = new Store();
+        store.addQuads([
+          DF.quad(DF.namedNode('ex:field'), DF.namedNode('ex:option'), DF.blankNode('b1')),
+          DF.quad(DF.blankNode('b1'), DF.namedNode('ex:first'), DF.namedNode('ex:One')),
+          DF.quad(DF.blankNode('b1'), DF.namedNode('ex:rest'), DF.blankNode('b2')),
+          DF.quad(DF.blankNode('b2'), DF.namedNode('ex:first'), DF.namedNode('ex:Two')),
+        ]);
+        expect(store.size).toBe(4);
+
+        // Execute query
+        const result = <RDF.QueryVoid> await engine.query(`DELETE { ?s <ex:first> ?o }
+        INSERT { ?s <ex:firstNew> ?o }
+        WHERE { ?s <ex:first> ?o }`, {
+          sources: [ store ],
+        });
+        await result.execute();
+
+        // Check store contents: the skolemized blank nodes must have been deskolemized again,
+        // so that the original quads are deleted, and the new quads reuse the original labels.
+        expect(store.size).toBe(4);
+        expect(store
+          .countQuads(DF.blankNode('b1'), DF.namedNode('ex:first'), DF.namedNode('ex:One'), DF.defaultGraph()))
+          .toBe(0);
+        expect(store
+          .countQuads(DF.blankNode('b2'), DF.namedNode('ex:first'), DF.namedNode('ex:Two'), DF.defaultGraph()))
+          .toBe(0);
+        expect(store
+          .countQuads(DF.blankNode('b1'), DF.namedNode('ex:firstNew'), DF.namedNode('ex:One'), DF.defaultGraph()))
+          .toBe(1);
+        expect(store
+          .countQuads(DF.blankNode('b2'), DF.namedNode('ex:firstNew'), DF.namedNode('ex:Two'), DF.defaultGraph()))
+          .toBe(1);
+        // The skolemized labels must not leak into the destination
+        expect(store.countQuads(DF.blankNode('bc_0_b1'), null, null, null)).toBe(0);
+        expect(store.countQuads(DF.blankNode('bc_0_b2'), null, null, null)).toBe(0);
+      });
+
       it('with variable delete', async() => {
         // Prepare store
         const store = new Store();


### PR DESCRIPTION
Closes #1057

## Background

[#1057](https://github.com/comunica/comunica/issues/1057) reported two things:

1. `SELECT` returns blank nodes labelled `bc_0_…` instead of their original label.
2. As a consequence, a `DELETE`-`INSERT`-`WHERE` over those blank nodes did not update anything.

**(1) is intended behaviour**, not a bug — per-source blank node scoping is what keeps blank node semantics intact across documents, and it is already asserted by the existing `handle blank nodes with DESCRIBE queries` tests. jeswr's [explanation on the issue](https://github.com/comunica/comunica/issues/1057#issuecomment-1238849347) still applies.

**(2) was a real bug and no longer reproduces on `master`.** In Comunica 2.x, `sourceIds` was only populated lazily by `FederatedQuadSource` while resolving quad patterns, so the lookup in `deskolemize()` could come up empty. Since the query source rewrite, source ids are assigned eagerly in `ActorOptimizeQueryOperationQuerySourceSkolemize`, so the deskolemization on the way to the destination now finds its id and works.

Verified against the issue's original reproduction (an `rdflib`-parsed store with an RDF list of blank nodes, queried with `sources: [store]`): the update applies correctly.

## Changes

Adds a system test pinning that behaviour, since nothing currently covers it. It runs a `DELETE { ?s <ex:first> ?o } INSERT { ?s <ex:firstNew> ?o } WHERE { ?s <ex:first> ?o }` over a store containing a blank node list and asserts that:

- the original quads are deleted (they were not, before — the delete stream carried skolemized terms that matched nothing);
- the inserted quads reuse the original blank node labels;
- no `bc_0_*` labels leak into the destination store.

No production code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRtFXm1gq9aatHUN8KRfuF)_