### PR TITLE
Only inject VALUES clauses in filters that use the bound variables

### DIFF
--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -2097,6 +2097,9 @@ WHERE { }
       });
     });
 
+    // Several of these cases mirror https://github.com/bergos/comunica-tests,
+    // which checks the behaviour that shacl-engine (https://github.com/rdf-ext/shacl-engine)
+    // relies on for SHACL pre-binding. Their names are referenced per test below.
     describe('initialBindings', () => {
       let initialBindings: Bindings;
       let sourcesValue1: string;
@@ -2113,6 +2116,7 @@ WHERE { }
           `;
       });
 
+      // Mirrors the pre-binding-005 case.
       it('should consider the initialBindings in the bound function', async() => {
         const context: QueryStringContext = {
           sources: [
@@ -2146,6 +2150,7 @@ WHERE { }
         await expect(bindings).toEqualBindingsStream(expectedResult);
       });
 
+      // Mirrors the pre-binding-006 case, with SELECT * in the sub-query.
       it('should consider the initialBindings in the filter function', async() => {
         const context: QueryStringContext = {
           sources: [
@@ -2179,6 +2184,7 @@ WHERE { }
         await expect(bindings).toEqualBindingsStream(expectedResult);
       });
 
+      // Mirrors the pre-binding-006 case, with an explicit projection in the sub-query.
       it('should consider the initialBindings in the filter function 2', async() => {
         const context: QueryStringContext = {
           sources: [
@@ -2212,6 +2218,7 @@ WHERE { }
         await expect(bindings).toEqualBindingsStream(expectedResult);
       });
 
+      // Mirrors the property-sparql-001 case.
       it('should consider initialBindings which are not projected', async() => {
         const initialBindings = BF.bindings([
           [ DF.variable('predicate'), DF.namedNode('http://example.org/test#predicateEx') ],
@@ -2245,6 +2252,7 @@ WHERE { }
         await expect(bindings).toEqualBindingsStream([]);
       });
 
+      // Mirrors the pre-binding-004 case.
       it('should consider initialBindings in the extend operation', async() => {
         const initialBindings = BF.bindings([
           [ DF.variable('initialBindingsVariable'), DF.namedNode('http://example.org/test#InitialBindingsValue') ],
@@ -2333,6 +2341,47 @@ WHERE { }
         ]);
       });
 
+      // Mirrors the pre-binding-002 case.
+      it('should consider initialBindings in a union of filter-only branches', async() => {
+        const initialBindings = BF.bindings([
+          [ DF.variable('this'), DF.namedNode('http://example.org/test#InvalidResource') ],
+        ]);
+
+        const context: QueryStringContext = {
+          sources: [
+            {
+              type: 'serialized',
+              value: `
+                @prefix ex: <http://example.org/test#> .
+                @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+                ex:ValidResource1 a rdfs:Resource .`,
+              mediaType: 'text/turtle',
+            },
+          ],
+          initialBindings,
+        };
+
+        // Neither branch matches a triple, so $this is only bound via the initial bindings.
+        const bindings = (await engine.queryBindings(`
+        PREFIX ex: <http://example.org/test#>
+
+        SELECT $this WHERE {
+          {
+            FILTER (false) .
+          } UNION {
+            FILTER ($this = ex:InvalidResource) .
+          }
+        }`, context));
+
+        await expect(bindings).toEqualBindingsStream([
+          BF.bindings([
+            [ DF.variable('this'), DF.namedNode('http://example.org/test#InvalidResource') ],
+          ]),
+        ]);
+      });
+
+      // Mirrors the unsupported-sparql-005 case.
       it('should not overwrite initialBindings', async() => {
         const context: QueryStringContext = {
           sources: [

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -2279,6 +2279,60 @@ WHERE { }
         await expect(bindings).toEqualBindingsStream(expectedResult);
       });
 
+      it('should consider initialBindings in filters inside non-matching sub-operations', async() => {
+        // https://github.com/comunica/comunica/issues/1759
+        const initialBindings = BF.bindings([
+          [ DF.variable('subject'), DF.namedNode('http://example.org/test#subjectEx') ],
+        ]);
+
+        const context: QueryStringContext = {
+          sources: [
+            {
+              type: 'serialized',
+              value: `
+                @prefix ex: <http://example.org/test#> .
+
+                ex:subjectEx
+                    ex:name "Subject" ;
+                    ex:broader ex:broaderEx ;
+                .
+                ex:broaderEx
+                    ex:officialName "Official"@en ;
+                .`,
+              mediaType: 'text/turtle',
+            },
+          ],
+          initialBindings,
+        };
+
+        // The filter inside the union branch does not refer to $subject,
+        // so no values clause for it should be injected there.
+        const bindings = (await engine.queryBindings(`
+        PREFIX ex: <http://example.org/test#>
+
+        SELECT $subject ?label WHERE {
+          $subject ex:name ?name .
+          OPTIONAL {
+            $subject ex:broader ?broader .
+            {
+              ?broader ex:officialName ?label .
+              FILTER(LANGMATCHES(LANG(?label), "en"))
+            }
+            UNION
+            {
+              ?broader ex:name ?label .
+            }
+          }
+        }`, context));
+
+        await expect(bindings).toEqualBindingsStream([
+          BF.bindings([
+            [ DF.variable('subject'), DF.namedNode('http://example.org/test#subjectEx') ],
+            [ DF.variable('label'), DF.literal('Official', 'en') ],
+          ]),
+        ]);
+      });
+
       it('should not overwrite initialBindings', async() => {
         const context: QueryStringContext = {
           sources: [

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -5,7 +5,7 @@ import type { BindingsFactory } from '@comunica/utils-bindings-factory';
 import type * as RDF from '@rdfjs/types';
 import type { Variable } from 'rdf-data-factory';
 import { termToString } from 'rdf-string';
-import { mapTermsNested, someTermsNested } from 'rdf-terms';
+import { getTermsNested, mapTermsNested, someTermsNested, uniqTerms } from 'rdf-terms';
 
 /**
  * Materialize a term with the given binding.
@@ -167,8 +167,17 @@ export function materializeOperation(
           return filterOp;
         }
 
-        // Make a values clause using all the variables from originalBindings.
-        const values: Algebra.Operation[] = createValuesFromBindings(algebraFactory, originalBindings);
+        // Make a values clause for the variables from originalBindings that occur inside this filter operation.
+        // Bound variables that don't occur here don't have to be re-injected,
+        // since they are joined in at the operations that do refer to them,
+        // and at the projection of the query.
+        // Injecting them everywhere is semantically harmless,
+        // but can significantly degrade the plans of (remote) query engines.
+        const values: Algebra.Operation[] = createValuesFromBindings(
+          algebraFactory,
+          originalBindings,
+          getOperationVariables(filterOp),
+        );
 
         // Recursively materialize the filter expression
         const recursionResultExpression: Algebra.Expression = <Algebra.Expression> materializeOperation(
@@ -188,7 +197,9 @@ export function materializeOperation(
           options,
         );
 
-        recursionResultInput = algebraFactory.createJoin([ ...values, recursionResultInput ]);
+        if (values.length > 0) {
+          recursionResultInput = algebraFactory.createJoin([ ...values, recursionResultInput ]);
+        }
 
         return algebraFactory.createFilter(recursionResultInput, recursionResultExpression);
       },
@@ -330,4 +341,53 @@ function createValuesFromBindings(
   }
 
   return values;
+}
+
+/**
+ * Get all variables that occur inside the given operation.
+ * Contrary to {@link algebraUtils.inScopeVariables}, this also considers variables that are not in scope,
+ * such as variables inside expressions and sub-queries.
+ * @param operation An algebra operation.
+ * @returns The variables occurring inside the given operation.
+ */
+function getOperationVariables(operation: Algebra.Operation): RDF.Variable[] {
+  const variables: RDF.Variable[] = [];
+  collectVariables(operation, variables);
+  return uniqTerms(variables);
+}
+
+/**
+ * Recursively collect all variables inside the given algebra value into the given array.
+ * @param value Part of an algebra operation, which can be an operation, an RDF term, an array, or any other value.
+ * @param variables The array to append the discovered variables to.
+ */
+function collectVariables(value: unknown, variables: RDF.Variable[]): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectVariables(entry, variables);
+    }
+    return;
+  }
+  if (typeof value !== 'object' || value === null) {
+    return;
+  }
+  if ('termType' in value) {
+    const term = <RDF.Term> value;
+    if (term.termType === 'Variable') {
+      variables.push(term);
+    } else if (term.termType === 'Quad') {
+      for (const subTerm of getTermsNested(term)) {
+        if (subTerm.termType === 'Variable') {
+          variables.push(subTerm);
+        }
+      }
+    }
+    return;
+  }
+  for (const [ key, entry ] of Object.entries(value)) {
+    // Metadata can contain arbitrary (possibly cyclic) values that are not part of the query itself.
+    if (key !== 'metadata') {
+      collectVariables(entry, variables);
+    }
+  }
 }

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -5,7 +5,8 @@ import type { BindingsFactory } from '@comunica/utils-bindings-factory';
 import type * as RDF from '@rdfjs/types';
 import type { Variable } from 'rdf-data-factory';
 import { termToString } from 'rdf-string';
-import { mapTermsNested, someTermsNested, uniqTerms } from 'rdf-terms';
+import { mapTermsNested, someTermsNested } from 'rdf-terms';
+import { getExpressionVariables } from './Expressions';
 
 /**
  * Materialize a term with the given binding.
@@ -167,17 +168,17 @@ export function materializeOperation(
           return filterOp;
         }
 
-        // Make a values clause for the variables from originalBindings that occur inside this filter operation.
-        // Bound variables that don't occur here don't have to be re-injected,
+        // Make a values clause for the variables from originalBindings that are used by this filter operation:
+        // the variables in scope of its input, and the variables its expression refers to.
+        // Bound variables that are not used here don't have to be re-injected,
         // since they are joined in at the operations that do refer to them,
         // and at the projection of the query.
         // Injecting them everywhere is semantically harmless,
         // but can significantly degrade the plans of (remote) query engines.
-        const values: Algebra.Operation[] = createValuesFromBindings(
-          algebraFactory,
-          originalBindings,
-          getOperationVariables(filterOp),
-        );
+        const values: Algebra.Operation[] = createValuesFromBindings(algebraFactory, originalBindings, [
+          ...algebraUtils.inScopeVariables(filterOp.input),
+          ...getExpressionVariables(filterOp.expression),
+        ]);
 
         // Recursively materialize the filter expression
         const recursionResultExpression: Algebra.Expression = <Algebra.Expression> materializeOperation(
@@ -341,22 +342,4 @@ function createValuesFromBindings(
   }
 
   return values;
-}
-
-/**
- * Get all variables that occur inside the given operation.
- * Contrary to {@link algebraUtils.inScopeVariables}, this also considers variables that are not in scope,
- * such as variables inside expressions and sub-queries.
- * @param operation An algebra operation.
- * @returns The variables occurring inside the given operation.
- */
-function getOperationVariables(operation: Algebra.Operation): RDF.Variable[] {
-  const variables: RDF.Variable[] = [];
-  // The operation visitors skip the terms inside operations, so we visit all objects instead.
-  algebraUtils.transformer.visitObject(operation, (value) => {
-    if ((<RDF.Term> value).termType === 'Variable') {
-      variables.push(<RDF.Variable> value);
-    }
-  });
-  return uniqTerms(variables);
 }

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -5,7 +5,7 @@ import type { BindingsFactory } from '@comunica/utils-bindings-factory';
 import type * as RDF from '@rdfjs/types';
 import type { Variable } from 'rdf-data-factory';
 import { termToString } from 'rdf-string';
-import { getTermsNested, mapTermsNested, someTermsNested, uniqTerms } from 'rdf-terms';
+import { mapTermsNested, someTermsNested, uniqTerms } from 'rdf-terms';
 
 /**
  * Materialize a term with the given binding.
@@ -352,42 +352,11 @@ function createValuesFromBindings(
  */
 function getOperationVariables(operation: Algebra.Operation): RDF.Variable[] {
   const variables: RDF.Variable[] = [];
-  collectVariables(operation, variables);
+  // The operation visitors skip the terms inside operations, so we visit all objects instead.
+  algebraUtils.transformer.visitObject(operation, (value) => {
+    if ((<RDF.Term> value).termType === 'Variable') {
+      variables.push(<RDF.Variable> value);
+    }
+  });
   return uniqTerms(variables);
-}
-
-/**
- * Recursively collect all variables inside the given algebra value into the given array.
- * @param value Part of an algebra operation, which can be an operation, an RDF term, an array, or any other value.
- * @param variables The array to append the discovered variables to.
- */
-function collectVariables(value: unknown, variables: RDF.Variable[]): void {
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      collectVariables(entry, variables);
-    }
-    return;
-  }
-  if (typeof value !== 'object' || value === null) {
-    return;
-  }
-  if ('termType' in value) {
-    const term = <RDF.Term> value;
-    if (term.termType === 'Variable') {
-      variables.push(term);
-    } else if (term.termType === 'Quad') {
-      for (const subTerm of getTermsNested(term)) {
-        if (subTerm.termType === 'Variable') {
-          variables.push(subTerm);
-        }
-      }
-    }
-    return;
-  }
-  for (const [ key, entry ] of Object.entries(value)) {
-    // Metadata can contain arbitrary (possibly cyclic) values that are not part of the query itself.
-    if (key !== 'metadata') {
-      collectVariables(entry, variables);
-    }
-  }
 }

--- a/packages/utils-query-operation/lib/MaterializeBindings.ts
+++ b/packages/utils-query-operation/lib/MaterializeBindings.ts
@@ -170,11 +170,7 @@ export function materializeOperation(
 
         // Make a values clause for the variables from originalBindings that are used by this filter operation:
         // the variables in scope of its input, and the variables its expression refers to.
-        // Bound variables that are not used here don't have to be re-injected,
-        // since they are joined in at the operations that do refer to them,
-        // and at the projection of the query.
-        // Injecting them everywhere is semantically harmless,
-        // but can significantly degrade the plans of (remote) query engines.
+        // Bound variables that are not used here don't have to be re-injected.
         const values: Algebra.Operation[] = createValuesFromBindings(algebraFactory, originalBindings, [
           ...algebraUtils.inScopeVariables(filterOp.input),
           ...getExpressionVariables(filterOp.expression),

--- a/packages/utils-query-operation/test/MaterializeBindings-test.ts
+++ b/packages/utils-query-operation/test/MaterializeBindings-test.ts
@@ -884,34 +884,132 @@ describe('materializeOperation', () => {
   });
 
   it('should not modify a filter expression without matching variables', () => {
+    const filterOp = AF.createFilter(
+      AF.createBgp([
+        AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+        AF.createPattern(termNamedNode, termVariableB, termVariableC, termNamedNode),
+      ]),
+      AF.createOperatorExpression('contains', [
+        AF.createTermExpression(termVariableB),
+        AF.createTermExpression(termVariableB),
+      ]),
+    );
+    expect(materializeOperation(
+      filterOp,
+      bindingsA,
+      AF,
+      BF,
+    ))
+      .toEqual(filterOp);
+  });
+
+  it('should only add a values clause for bound variables occurring in the filter expression', () => {
     expect(materializeOperation(
       AF.createFilter(
         AF.createBgp([
-          AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
-          AF.createPattern(termNamedNode, termVariableB, termVariableC, termNamedNode),
+          AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
         ]),
         AF.createOperatorExpression('contains', [
           AF.createTermExpression(termVariableB),
-          AF.createTermExpression(termVariableB),
+          AF.createTermExpression(termVariableD),
         ]),
       ),
-      bindingsA,
+      bindingsAB,
       AF,
       BF,
     ))
       .toEqual(AF.createFilter(
         AF.createJoin([
-          AF.createValues([ termVariableA ], [ valuesBindingsA ]),
+          AF.createValues([ termVariableB ], [ valuesBindingsB ]),
           AF.createBgp([
-            AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
-            AF.createPattern(termNamedNode, termVariableB, termVariableC, termNamedNode),
+            AF.createPattern(termVariableD, termNamedNode, termVariableC, termNamedNode),
           ]),
         ]),
         AF.createOperatorExpression('contains', [
-          AF.createTermExpression(termVariableB),
-          AF.createTermExpression(termVariableB),
+          AF.createTermExpression(valueB),
+          AF.createTermExpression(termVariableD),
         ]),
       ));
+  });
+
+  it('should only add a values clause for bound variables occurring in the filter input', () => {
+    expect(materializeOperation(
+      AF.createFilter(
+        AF.createBgp([
+          AF.createPattern(termVariableB, termNamedNode, termVariableD, termNamedNode),
+        ]),
+        AF.createOperatorExpression('contains', [
+          AF.createTermExpression(termVariableD),
+          AF.createTermExpression(termVariableD),
+        ]),
+      ),
+      bindingsAB,
+      AF,
+      BF,
+    ))
+      .toEqual(AF.createFilter(
+        AF.createJoin([
+          AF.createValues([ termVariableB ], [ valuesBindingsB ]),
+          AF.createBgp([
+            AF.createPattern(valueB, termNamedNode, termVariableD, termNamedNode),
+          ]),
+        ]),
+        AF.createOperatorExpression('contains', [
+          AF.createTermExpression(termVariableD),
+          AF.createTermExpression(termVariableD),
+        ]),
+      ));
+  });
+
+  it('should not add values clauses in union branches that do not use the bound variables', () => {
+    expect(materializeOperation(
+      AF.createUnion([
+        AF.createFilter(
+          AF.createBgp([
+            AF.createPattern(termVariableA, termNamedNode, termVariableD, termNamedNode),
+          ]),
+          AF.createOperatorExpression('contains', [
+            AF.createTermExpression(termVariableD),
+            AF.createTermExpression(termVariableD),
+          ]),
+        ),
+        AF.createFilter(
+          AF.createBgp([
+            AF.createPattern(termVariableB, termNamedNode, termVariableD, termNamedNode),
+          ]),
+          AF.createOperatorExpression('contains', [
+            AF.createTermExpression(termVariableD),
+            AF.createTermExpression(termVariableD),
+          ]),
+        ),
+      ]),
+      bindingsA,
+      AF,
+      BF,
+    ))
+      .toEqual(AF.createUnion([
+        AF.createFilter(
+          AF.createJoin([
+            AF.createValues([ termVariableA ], [ valuesBindingsA ]),
+            AF.createBgp([
+              AF.createPattern(valueA, termNamedNode, termVariableD, termNamedNode),
+            ]),
+          ]),
+          AF.createOperatorExpression('contains', [
+            AF.createTermExpression(termVariableD),
+            AF.createTermExpression(termVariableD),
+          ]),
+        ),
+        AF.createFilter(
+          AF.createBgp([
+            AF.createPattern(termVariableB, termNamedNode, termVariableD, termNamedNode),
+          ]),
+          AF.createOperatorExpression('contains', [
+            AF.createTermExpression(termVariableD),
+            AF.createTermExpression(termVariableD),
+          ]),
+        ),
+      ]));
   });
 
   it('should modify a filter expression with matching variables', () => {
@@ -1090,16 +1188,16 @@ describe('materializeOperation', () => {
       AF.createFilter(
         AF.createFilter(
           AF.createBgp([
-            AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+            AF.createPattern(termVariableA, termNamedNode, termVariableC, termNamedNode),
             AF.createPattern(termNamedNode, termVariableB, termVariableC, termNamedNode),
           ]),
           AF.createOperatorExpression('contains', [
-            AF.createTermExpression(termVariableB),
+            AF.createTermExpression(termVariableA),
             AF.createTermExpression(termVariableB),
           ]),
         ),
         AF.createOperatorExpression('contains', [
-          AF.createTermExpression(termVariableB),
+          AF.createTermExpression(termVariableA),
           AF.createTermExpression(termVariableB),
         ]),
       ),
@@ -1114,18 +1212,18 @@ describe('materializeOperation', () => {
             AF.createJoin([
               AF.createValues([ termVariableA ], [ valuesBindingsA ]),
               AF.createBgp([
-                AF.createPattern(termVariableB, termNamedNode, termVariableC, termNamedNode),
+                AF.createPattern(valueA, termNamedNode, termVariableC, termNamedNode),
                 AF.createPattern(termNamedNode, termVariableB, termVariableC, termNamedNode),
               ]),
             ]),
             AF.createOperatorExpression('contains', [
-              AF.createTermExpression(termVariableB),
+              AF.createTermExpression(valueA),
               AF.createTermExpression(termVariableB),
             ]),
           ),
         ]),
         AF.createOperatorExpression('contains', [
-          AF.createTermExpression(termVariableB),
+          AF.createTermExpression(valueA),
           AF.createTermExpression(termVariableB),
         ]),
       ));


### PR DESCRIPTION
Fixes #1759.

## Problem

`materializeOperation` joined a `VALUES` clause for **every** bound variable into **every** `FILTER` operation, including sub-operations that never refer to those variables. For a query run with two `initialBindings` against a SPARQL endpoint, this results in several copies of each clause spread over the query, e.g. inside a UNION branch that mentions neither variable:

```sparql
OPTIONAL {
  ?uri ?parents ?broader .
  VALUES ?parents { gn:parentADM1 gn:parentADM2 }
  { VALUES ?query { "depot" } VALUES ?datasetUri { <ex:d> }   # <-- added, but unused here
    ?broader gn:officialName ?label . FILTER(LANG(?label) IN ("nl", "en")) }
  UNION
  { ?broader gn:name ?label }
  FILTER(?uri != ?broader)
}
```

This is semantically harmless, but it is expensive on the endpoint: as reported in the issue, Apache Jena stops pushing `?broader` into the UNION branch once that branch contains a `VALUES` join, turning a 0.21s query into a timeout.

Since `ActorRdfJoinMultiBind` re-materializes its sub-operations for every binding of the left-hand stream, the same clauses also end up in bind-join sub-queries, not only in queries using `initialBindings`.

## Change

The `VALUES` clauses in a filter are now only created for the bound variables that the filter actually uses: the variables in scope of its input, plus the variables its expression refers to.

```ts
const values: Algebra.Operation[] = createValuesFromBindings(algebraFactory, originalBindings, [
  ...algebraUtils.inScopeVariables(filterOp.input),
  ...getExpressionVariables(filterOp.expression),
]);
```

Bound variables that are not used there don't have to be re-injected, since they are joined in at the operations that do refer to them, and at the projection of the query. When none of them is used, no join is added at all (restoring the `values.length > 0` guard from a531e81, which became unreachable and was dropped in fb27fc7).

The expression variables are needed next to the in-scope ones because in-scope variables deliberately exclude the variables that expressions *refer to* (`inScopeVariables` only reports aggregate and extend *targets*). Those are the ones that still matter with `bindFilter: false`, where the expression keeps referring to the variable instead of being materialized.

Both are pre-existing utils, so this adds no traversal code, and it is cheaper than injecting everywhere: the in-scope visitor prunes inside terms and stops at projections.

Verified on the query from the issue: the two injected clauses inside the UNION branch are gone, and the rest of the query is unchanged.

## SHACL pre-binding compatibility

`initialBindings` is what [shacl-engine](https://github.com/rdf-ext/shacl-engine) uses for SHACL pre-binding (`lib/sparql.js` calls `queryBindings(query, { sources, initialBindings })`), and the cases it depends on are captured in [bergos/comunica-tests](https://github.com/bergos/comunica-tests). All six were run against this branch and against the base commit: identical results, and each matches what the corresponding SHACL test expects.

| comunica-tests case | expected | before | after |
| --- | --- | --- | --- |
| pre-binding-002 (union of filter-only branches) | `$this` bound | ✅ | ✅ |
| pre-binding-004 (`BIND ($this AS ?that)`) | `$this` bound | ✅ | ✅ |
| pre-binding-005 (`bound($this)`) | `$this` bound | ✅ | ✅ |
| pre-binding-006 (sub-select, both projections) | `$this` bound | ✅ | ✅ |
| property-sparql-001 (`$PATH` not projected) | empty | ✅ | ✅ |
| unsupported-sparql-005 (`BIND (true AS $this)`) | error | ✅ | ✅ |

Each existing test now names the case it mirrors, and the one case that had no test — pre-binding-002, a union whose branches only contain a filter, so the pre-bound variable is never matched against a triple — has been added.

## Tests

* `MaterializeBindings-test.ts`:
  * `should not modify a filter expression without matching variables` now asserts that the operation is left untouched (matching what its name always claimed).
  * New: only a values clause for bound variables occurring in the filter expression.
  * New: only a values clause for bound variables occurring in the filter input.
  * New (regression for this issue): no values clauses in union branches that do not use the bound variables.
  * `should use the original InitialBindings in recursive calls with nested filter expressions` now uses filters that refer to the bound variable, so it still covers the propagation of the original bindings into recursive calls.
* `QuerySparql-test.ts`: new end-to-end `initialBindings` test with a filter inside a UNION branch that does not use the bound variable, asserting the results are unaffected, plus the pre-binding-002 test and the case references described above.

Full unit test suite (6726 tests) and the complete spec suite of `@comunica/query-sparql` (SPARQL 1.0/1.1/1.2 query, update, CSV/TSV, JSON, xsd datetime duration) pass.
