### PR TITLE
Do not cache sources that could not be dereferenced

### DIFF
--- a/packages/actor-query-source-identify-hypermedia/lib/QuerySourceHypermedia.ts
+++ b/packages/actor-query-source-identify-hypermedia/lib/QuerySourceHypermedia.ts
@@ -138,7 +138,7 @@ export class QuerySourceHypermedia implements IQuerySource {
     handledDatasets: Record<string, boolean>,
     context: IActionContext,
   ): Promise<ISourceState> {
-    let source = this.sourcesState.get(link.url);
+    const source = this.sourcesState.get(link.url);
     if (source) {
       return (async() => {
         // Check if cache policy is still valid
@@ -155,9 +155,17 @@ export class QuerySourceHypermedia implements IQuerySource {
         return sourceMaterialized;
       })();
     }
-    source = this.getSource(link, handledDatasets, context);
-    this.sourcesState.set(link.url, source);
-    return source;
+    const sourcePromise = this.getSource(link, handledDatasets, context);
+    this.sourcesState.set(link.url, sourcePromise);
+    // Remove failed sources from the cache, so that later calls can retry them.
+    // Without this, a source that (for example) did not exist yet at the time of the first request
+    // would remain unavailable for the lifetime of this query source.
+    sourcePromise.catch(() => {
+      if (this.sourcesState.get(link.url) === sourcePromise) {
+        this.sourcesState.delete(link.url);
+      }
+    });
+    return sourcePromise;
   }
 
   public toString(): string {

--- a/packages/actor-query-source-identify-hypermedia/test/QuerySourceHypermedia-test.ts
+++ b/packages/actor-query-source-identify-hypermedia/test/QuerySourceHypermedia-test.ts
@@ -519,6 +519,42 @@ describe('QuerySourceHypermedia', () => {
         const src2 = source.getSourceCached({ url: 'cachepolicyfalse' }, {}, context);
         await expect(src1).resolves.not.toBe(await src2);
       });
+
+      it('should not cache sources that could not be resolved', async() => {
+        const spy = jest.spyOn(utilMediators.mediatorQuerySourceDereferenceLink, 'mediate');
+        spy.mockClear();
+        spy.mockRejectedValueOnce(new Error('Source does not exist'));
+
+        await expect(source.getSourceCached({ url: 'startUrl' }, {}, context)).rejects
+          .toThrow('Source does not exist');
+        await expect(source.getSourceCached({ url: 'startUrl' }, {}, context)).resolves.toMatchObject({
+          link: { url: 'startUrl' },
+          metadata: { a: 1 },
+        });
+        expect(spy).toHaveBeenCalledTimes(2);
+
+        spy.mockRestore();
+      });
+
+      it('should not remove a newer cache entry when an older source could not be resolved', async() => {
+        const spy = jest.spyOn(utilMediators.mediatorQuerySourceDereferenceLink, 'mediate');
+        spy.mockClear();
+        let rejectFirst: (error: Error) => void;
+        spy.mockReturnValueOnce(<any> new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        }));
+
+        const srcFailing = source.getSourceCached({ url: 'startUrl' }, {}, context);
+        // Replace the cache entry before the first source fails
+        source.sourcesState.delete('startUrl');
+        const srcNew = source.getSourceCached({ url: 'startUrl' }, {}, context);
+        rejectFirst!(new Error('Source does not exist'));
+
+        await expect(srcFailing).rejects.toThrow('Source does not exist');
+        expect(source.sourcesState.get('startUrl')).toBe(srcNew);
+
+        spy.mockRestore();
+      });
     });
   });
 });


### PR DESCRIPTION
`QuerySourceHypermedia` stores the promise of every source it resolves in its `sourcesState` cache, including rejected ones. Only successful entries can be revalidated through their cache policy, so a failed source stays in the cache for the lifetime of the query source.

This becomes a problem when a resource is created during query execution, which is what happens for updates over LDP destinations: the update dereferences the destination while it does not exist yet, and the resulting 404 makes the resource unreadable within the same engine afterwards.

```ts
// Creates the resource with a PUT request
await engine.queryVoid(`INSERT DATA { <ex:s> <ex:p> <ex:o> }`, { sources: [ resource ]});
// Fails with "Could not retrieve <resource> (HTTP status 404)", even though the resource exists
await engine.queryQuads(`CONSTRUCT WHERE { ?s ?p ?o }`, { sources: [ resource ]});
```

Reported in https://github.com/comunica/comunica-feature-solid/issues/43, where the final `CONSTRUCT` of the reported script still returns nothing today. (The original symptom of that issue — the second `INSERT DATA` replacing the resource via `PUT` — no longer occurs; updates on an existing resource correctly use a SPARQL Update `PATCH`.) The current workaround is `await engine.invalidateHttpCache()` after the update, or using a separate engine for reading.

This PR removes rejected sources from the cache again, so that later calls retry them. Successful entries keep their existing caching and revalidation behaviour, and the entry is only removed when it is still the failed promise, so a newer entry for the same URL is never evicted.

Verified against the engine of this repository, with an LDP server that replays the update-related response headers of the Community Solid Server: the read above fails on `master` and succeeds with this change. Unit tests for both new branches are included, and the full test suite passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ga4koWj2GzJyJp8w6ZVPF8)_