### PR TITLE
Fix invalid ??o variable in link emptiness checks

### DIFF
--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
@@ -60,7 +60,7 @@ export class ActorOptimizeQueryOperationPruneEmptySourceOperations extends Actor
     const emptyOperations: Set<Algebra.Operation> = new Set();
     await Promise.all(collectedOperations.map(async(collectedOperation) => {
       const checkOperation = collectedOperation.type === Algebra.Types.LINK ?
-        algebraFactory.createPattern(dataFactory.variable('s'), collectedOperation.iri, dataFactory.variable('?o')) :
+        algebraFactory.createPattern(dataFactory.variable('s'), collectedOperation.iri, dataFactory.variable('o')) :
         collectedOperation;
       if (!await this.hasSourceResults(
         algebraFactory,

--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
@@ -329,6 +329,23 @@ describe('ActorOptimizeQueryOperationPruneEmptySourceOperations', () => {
           ]));
         });
 
+        it('should check links via patterns with valid variables', async() => {
+          const opIn = AF.createAlt([
+            assignOperationSource(AF.createLink(DF.namedNode('p1')), source1),
+            assignOperationSource(AF.createLink(DF.namedNode('empty')), source1),
+          ]);
+          await actor.run({ operation: opIn, context: ctx });
+          expect(source1.source.queryBindings).toHaveBeenCalledTimes(2);
+          expect(source1.source.queryBindings).toHaveBeenCalledWith(
+            AF.createPattern(DF.variable('s'), DF.namedNode('p1'), DF.variable('o')),
+            ctx,
+          );
+          expect(source1.source.queryBindings).toHaveBeenCalledWith(
+            AF.createPattern(DF.variable('s'), DF.namedNode('empty'), DF.variable('o')),
+            ctx,
+          );
+        });
+
         it('should not prune for no empty children', async() => {
           const opIn = AF.createAlt([
             assignOperationSource(AF.createLink(DF.namedNode('p1')), source1),


### PR DESCRIPTION
Fixes https://github.com/comunica/comunica/issues/1764

### Problem

When `ActorOptimizeQueryOperationPruneEmptySourceOperations` checks whether a link (a property path predicate assigned to a specific source) yields any results, it converts the link into a triple pattern. That pattern was built with `dataFactory.variable('?o')`.

RDF/JS variable names must not include the leading `?` — the term value is the bare name. As a result the variable serialized as `??o`, producing invalid requests against sources that materialize the check operation (e.g. QPF interfaces), which is what the reporter observed for a federated property path query.

### Fix

Use `dataFactory.variable('o')`, matching the already-correct subject variable `s` and the equivalent link-to-pattern conversion in `utils-query-operation`'s `CardinalityEstimators`.

### Similar occurrences

I checked the whole monorepo for term constructions that wrongly embed a syntactic prefix in the term value (`variable('?…')`, `blankNode('_:…')`, `namedNode('<…')`, quoted literals). This was the only occurrence.

### Test

Added a regression test in the `with alts` suite asserting that the operations sent to the source for links are patterns over the variables `s` and `o`. It fails on `master` (`??o` instead of `?o`) and passes with the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_018NT3TGNdsJtW4hNCyFpFDc)_