### PR TITLE
Fixed three `FROM NAMED`-related bugs

### DIFF
--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -60,7 +60,7 @@
     "spec:base-1-0": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-tests/sparql/sparql10/manifest.ttl -c ../../.rdf-test-suite-cache/",
     "spec:base-1-1": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl -c ../../.rdf-test-suite-cache/",
     "spec:base-1-2": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-tests/sparql/sparql12/manifest.ttl -c ../../.rdf-test-suite-cache/",
-    "spec:query-1-0": "yarn run --silent spec:base-1-0 --skip \"(date-1|date-2|open-eq-08|open-eq-10|open-eq-11|open-eq-12|#graph-|dataset-)\"",
+    "spec:query-1-0": "yarn run --silent spec:base-1-0 --skip \"(date-1|date-2|open-eq-08|open-eq-10|open-eq-11|open-eq-12|#graph-)\"",
     "spec:query-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-query/ --skip \"(agg-empty-group-count-graph|bindings/manifest#graph)\"",
     "spec:query-1-2": "yarn run --silent spec:base-1-2",
     "spec:update-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-update/",

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -128,9 +128,12 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
       if (patternGraph.termType === 'DefaultGraph') {
         // SPARQL spec (8.2) describes that when FROM NAMED's are used without a FROM, the default graph must be empty.
         // The FROMs are transformed before this step to a named node, so this will not apply to this case anymore.
-        return algebraFactory.createBgp([]);
+        return algebraFactory.createValues([], []);
       }
       if (patternGraph.termType === 'Variable') {
+        if (namedGraphs.length === 0) {
+          return algebraFactory.createValues([], []);
+        }
         if (namedGraphs.length === 1) {
           const graph: RDF.NamedNode = namedGraphs[0];
           // If the pattern graph is a variable, replace the graph and bind the variable using VALUES
@@ -173,7 +176,7 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
         return operation;
       }
       // No-op if the pattern's graph was not selected in a FROM NAMED.
-      return algebraFactory.createBgp([]);
+      return algebraFactory.createValues([], []);
     }
 
     return ActorQueryOperationFromQuad.copyOperation(

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -131,9 +131,6 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
         return algebraFactory.createValues([], []);
       }
       if (patternGraph.termType === 'Variable') {
-        if (namedGraphs.length === 0) {
-          return algebraFactory.createValues([], []);
-        }
         if (namedGraphs.length === 1) {
           const graph: RDF.NamedNode = namedGraphs[0];
           // If the pattern graph is a variable, replace the graph and bind the variable using VALUES

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -132,7 +132,6 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
       }
       if (patternGraph.termType === 'Variable') {
         if (namedGraphs.length === 0) {
-          // No named graphs available to bind to the variable -> zero solutions
           return algebraFactory.createValues([], []);
         }
         if (namedGraphs.length === 1) {

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -131,6 +131,10 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
         return algebraFactory.createValues([], []);
       }
       if (patternGraph.termType === 'Variable') {
+        if (namedGraphs.length === 0) {
+          // No named graphs available to bind to the variable -> zero solutions
+          return algebraFactory.createValues([], []);
+        }
         if (namedGraphs.length === 1) {
           const graph: RDF.NamedNode = namedGraphs[0];
           // If the pattern graph is a variable, replace the graph and bind the variable using VALUES

--- a/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
+++ b/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
@@ -394,6 +394,17 @@ describe('ActorQueryOperationFromQuad', () => {
       expect(quad('s', 'p', 'o', 'g').equals(result.input[1])).toBeTruthy();
     });
 
+    it('should transform a Path with a variable graph pattern without any named graphs to a no-op', () => {
+      const result = <Algebra.Join> ActorQueryOperationFromQuad
+        .applyOperationNamedGraph(
+          AF,
+          Object.assign(quad('s', 'p', 'o', '?g'), { type: 'path' }),
+          [],
+          [ DF.namedNode('g') ],
+        );
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
+    });
+
     it('should transform a Path with a non-available non-default graph pattern to a no-op', () => {
       const result = ActorQueryOperationFromQuad
         .applyOperationNamedGraph(

--- a/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
+++ b/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
@@ -242,7 +242,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a pattern with a variable graph pattern', () => {
@@ -270,7 +270,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should not transform a pattern with a non-available non-default graph pattern but available as default', () => {
@@ -305,7 +305,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a pattern with variable graph patterns', () => {
@@ -350,7 +350,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a pattern with available non-default graph patterns', () => {
@@ -373,7 +373,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Path with a variable graph pattern', () => {
@@ -402,7 +402,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Path with an available non-default graph pattern', () => {
@@ -425,7 +425,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Path with variable graph patterns', () => {
@@ -481,7 +481,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with a default graph pattern to a no-op', () => {
@@ -492,7 +492,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with a variable graph pattern', () => {
@@ -522,7 +522,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with an available non-default graph pattern', () => {
@@ -545,7 +545,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with variable graph patterns', () => {
@@ -601,7 +601,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform other types of operations', () => {
@@ -773,9 +773,10 @@ describe('ActorQueryOperationFromQuad', () => {
         named: [],
         type: 'from',
       };
-      const result = <Algebra.Bgp> ActorQueryOperationFromQuad.createOperation(AF, pattern);
-      expect(result.type).toBe('bgp');
-      expect(result.patterns).toEqual([]);
+      const result = <Algebra.Values> ActorQueryOperationFromQuad.createOperation(AF, pattern);
+      expect(result.type).toBe('values');
+      expect(result.variables).toEqual([]);
+      expect(result.bindings).toEqual([]);
     });
 
     it('should transform without default graphs and with one variable named graph', () => {
@@ -816,9 +817,10 @@ describe('ActorQueryOperationFromQuad', () => {
         named: [ DF.namedNode('g2') ],
         type: 'from',
       };
-      const result = <Algebra.Bgp> ActorQueryOperationFromQuad.createOperation(AF, pattern);
-      expect(result.type).toBe('bgp');
-      expect(result.patterns).toEqual([]);
+      const result = <Algebra.Values> ActorQueryOperationFromQuad.createOperation(AF, pattern);
+      expect(result.type).toBe('values');
+      expect(result.variables).toEqual([]);
+      expect(result.bindings).toEqual([]);
     });
 
     it('should transform without default graphs and with two variable named graphs', () => {
@@ -874,10 +876,11 @@ describe('ActorQueryOperationFromQuad', () => {
         named: [ DF.namedNode('g2'), DF.namedNode('g3') ],
         type: 'from',
       };
-      const result = <Algebra.Bgp> ActorQueryOperationFromQuad.createOperation(AF, pattern);
+      const result = <Algebra.Values> ActorQueryOperationFromQuad.createOperation(AF, pattern);
 
-      expect(result.type).toBe('bgp');
-      expect(result.patterns).toEqual([]);
+      expect(result.type).toBe('values');
+      expect(result.variables).toEqual([]);
+      expect(result.bindings).toEqual([]);
     });
 
     it('should transform with one default graph and with one variable named graph', () => {
@@ -984,9 +987,10 @@ describe('ActorQueryOperationFromQuad', () => {
       const result = <Algebra.Join> ActorQueryOperationFromQuad.createOperation(AF, pattern);
       expect(result.type).toBe('join');
 
-      const res0 = <Algebra.Bgp> result.input[0];
-      expect(res0.type).toBe('bgp');
-      expect(res0.patterns).toEqual([]);
+      const res0 = <Algebra.Values> result.input[0];
+      expect(res0.type).toBe('values');
+      expect(res0.variables).toEqual([]);
+      expect(res0.bindings).toEqual([]);
 
       const res1 = <Algebra.Bgp> result.input[1];
       expect(res1.type).toBe('bgp');


### PR DESCRIPTION
Part of #1736.

## bug 1

dataset-02 returned `bindings: [{}]`, while it expected `bindings: []`

## bug 2

When using `FROM` and `GRAPH` in the same query, it results in an error:

```
Error: A union can only be applied on at least one operation
....
```

## bug 3

When using `FROM NAMED` and `GRAPH` in the same query, it results in an error:

```
Error: Query operation processing failed: none of the configured actors were able to handle the operation type pattern
    Error messages of failing actors:
        Actor urn:comunica:default:query-operation/actors#source requires an operation with source annotation.
        ....
```
