### PR TITLE
Fix the FROM (NAMED) dataset spec tests of SPARQL 1.0

### DIFF
--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -60,7 +60,7 @@
     "spec:base-1-0": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-tests/sparql/sparql10/manifest.ttl -c ../../.rdf-test-suite-cache/",
     "spec:base-1-1": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl -c ../../.rdf-test-suite-cache/",
     "spec:base-1-2": "node ../../node_modules/rdf-test-suite/bin/Runner.js spec/sparql-engine.js https://w3c.github.io/rdf-tests/sparql/sparql12/manifest.ttl -c ../../.rdf-test-suite-cache/",
-    "spec:query-1-0": "yarn run --silent spec:base-1-0 --skip \"(date-1|date-2|open-eq-08|open-eq-10|open-eq-11|open-eq-12|#graph-|dataset-)\"",
+    "spec:query-1-0": "yarn run --silent spec:base-1-0 --skip \"(date-1|date-2|open-eq-08|open-eq-10|open-eq-11|open-eq-12|#graph-)\"",
     "spec:query-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-query/ --skip \"(agg-empty-group-count-graph|bindings/manifest#graph)\"",
     "spec:query-1-2": "yarn run --silent spec:base-1-2",
     "spec:update-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-update/",

--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -2323,6 +2323,62 @@ WHERE { }
       });
     });
 
+    describe('RDF dataset construction with FROM and FROM NAMED', () => {
+      // These cases are defined by https://www.w3.org/TR/sparql11-query/#specifyingDataset
+      const G1 = 'http://example.org/g1';
+      const G2 = 'http://example.org/g2';
+      let store: RdfStore;
+
+      beforeEach(() => {
+        store = RdfStore.createDefault();
+        store.addQuad(DF.quad(DF.namedNode('ex:s1'), DF.namedNode('ex:p'), DF.namedNode('ex:o1'), DF.namedNode(G1)));
+        store.addQuad(DF.quad(DF.namedNode('ex:s2'), DF.namedNode('ex:p'), DF.namedNode('ex:o2'), DF.namedNode(G2)));
+      });
+
+      async function queryCount(query: string): Promise<number> {
+        return (await (await engine.queryBindings(query, { sources: [ store ]})).toArray()).length;
+      }
+
+      it('should query the default graph over the graphs in FROM', async() => {
+        await expect(queryCount(`SELECT * FROM <${G1}> { ?s ?p ?o }`)).resolves.toBe(1);
+        await expect(queryCount(`SELECT * FROM <${G1}> FROM <${G2}> { ?s ?p ?o }`)).resolves.toBe(2);
+      });
+
+      it('should have an empty default graph if only FROM NAMED is used', async() => {
+        await expect(queryCount(`SELECT * FROM NAMED <${G1}> { ?s ?p ?o }`)).resolves.toBe(0);
+      });
+
+      it('should query the graphs in FROM NAMED via GRAPH', async() => {
+        await expect(queryCount(`SELECT * FROM NAMED <${G1}> { GRAPH ?g { ?s ?p ?o } }`)).resolves.toBe(1);
+        await expect(queryCount(`SELECT * FROM NAMED <${G1}> FROM NAMED <${G2}> { GRAPH ?g { ?s ?p ?o } }`))
+          .resolves.toBe(2);
+        await expect(queryCount(`SELECT * FROM NAMED <${G1}> { GRAPH <${G1}> { ?s ?p ?o } }`)).resolves.toBe(1);
+      });
+
+      it('should have no named graphs if only FROM is used', async() => {
+        await expect(queryCount(`SELECT * FROM <${G1}> { GRAPH ?g { ?s ?p ?o } }`)).resolves.toBe(0);
+        // Graphs from FROM are merged into the default graph, they are not available as named graph
+        await expect(queryCount(`SELECT * FROM <${G1}> { GRAPH <${G1}> { ?s ?p ?o } }`)).resolves.toBe(0);
+      });
+
+      it('should not make graphs from FROM available as named graphs', async() => {
+        await expect(queryCount(`SELECT * FROM <${G1}> FROM NAMED <${G2}> { GRAPH ?g { ?s ?p ?o } }`)).resolves.toBe(1);
+        await expect(queryCount(`SELECT * FROM <${G1}> FROM NAMED <${G2}> { GRAPH <${G1}> { ?s ?p ?o } }`))
+          .resolves.toBe(0);
+      });
+
+      it('should combine the default graph and named graphs in a union', async() => {
+        await expect(queryCount(`SELECT * FROM <${G1}> FROM NAMED <${G2}> {
+          { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } }
+        }`)).resolves.toBe(2);
+      });
+
+      it('should query the graphs in FROM NAMED via GRAPH with property paths', async() => {
+        await expect(queryCount(`SELECT * FROM NAMED <${G1}> { GRAPH ?g { ?s <ex:p>* ?o } }`)).resolves.toBe(3);
+        await expect(queryCount(`SELECT * FROM <${G1}> { GRAPH ?g { ?s <ex:p>* ?o } }`)).resolves.toBe(0);
+      });
+    });
+
     describe('for a complex query', () => {
       it('with VALUES and OPTIONAL', async() => {
         const context: QueryStringContext = {

--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
@@ -54,6 +54,10 @@ export class ActorOptimizeQueryOperationPruneEmptySourceOperations extends Actor
         return { continue: false };
       } },
       [Algebra.Types.SERVICE]: { preVisitor: () => ({ continue: false }) },
+      // Operations within FROM (NAMED) are evaluated over a different dataset than the source's default dataset.
+      // Their graphs are only rewritten when the FROM operation is executed,
+      // so emptiness checks against the source would be done on the wrong graphs here.
+      [Algebra.Types.FROM]: { preVisitor: () => ({ continue: false }) },
     });
 
     // Determine in an async manner whether or not these sources return non-empty results

--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
@@ -527,6 +527,42 @@ describe('ActorOptimizeQueryOperationPruneEmptySourceOperations', () => {
         });
       });
 
+      describe('with from operations', () => {
+        it('should not modify children', async() => {
+          // The graphs of the patterns within a FROM are only rewritten when that FROM is executed,
+          // so their emptiness may not be determined against the source's dataset here.
+          const opIn = AF.createFrom(
+            AF.createUnion([
+              assignOperationSource(AF
+                .createPattern(DF.namedNode('s'), DF.namedNode('p1'), DF.namedNode('o')), source1),
+              assignOperationSource(AF
+                .createPattern(DF.namedNode('s'), DF.namedNode('empty'), DF.namedNode('o')), source1),
+              AF.createAlt([
+                assignOperationSource(AF.createLink(DF.namedNode('p1')), source1),
+                assignOperationSource(AF.createLink(DF.namedNode('empty')), source1),
+              ]),
+            ]),
+            [ DF.namedNode('g1') ],
+            [ DF.namedNode('g2') ],
+          );
+          const { operation: opOut } = await actor.run({ operation: opIn, context: ctx });
+          expect(opOut).toEqual(AF.createFrom(
+            AF.createUnion([
+              assignOperationSource(AF
+                .createPattern(DF.namedNode('s'), DF.namedNode('p1'), DF.namedNode('o')), source1),
+              assignOperationSource(AF
+                .createPattern(DF.namedNode('s'), DF.namedNode('empty'), DF.namedNode('o')), source1),
+              AF.createAlt([
+                assignOperationSource(AF.createLink(DF.namedNode('p1')), source1),
+                assignOperationSource(AF.createLink(DF.namedNode('empty')), source1),
+              ]),
+            ]),
+            [ DF.namedNode('g1') ],
+            [ DF.namedNode('g2') ],
+          ));
+        });
+      });
+
       describe('with projections', () => {
         it('should prune if the projection now has missing variables in union', async() => {
           const opIn = AF.createProject(

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -47,6 +47,21 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
   }
 
   /**
+   * Copy the metadata of the given original operation onto the given new operation.
+   * This is required because operations are recreated with a different graph in this actor,
+   * and the metadata may contain information that must be retained, such as the source annotation.
+   * @param {Operation} operationNew The new operation to copy the metadata to. This operation is mutated.
+   * @param {Operation} operationOriginal The original operation to copy the metadata from.
+   * @return {Operation} The new operation.
+   */
+  public static copyMetadata<O extends Algebra.Operation>(operationNew: O, operationOriginal: Algebra.Operation): O {
+    if (operationOriginal.metadata) {
+      operationNew.metadata = operationOriginal.metadata;
+    }
+    return operationNew;
+  }
+
+  /**
    * Recursively transform the given operation to use the given graphs as default graph
    * This will (possibly) create a new operation and not modify the given operation.
    * @package
@@ -70,10 +85,10 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
               return algebraFactory.createBgp([ pattern ]);
             }
             const bgps = defaultGraphs.map((graph: RDF.Term) =>
-              algebraFactory.createBgp([ Object.assign(
+              algebraFactory.createBgp([ ActorQueryOperationFromQuad.copyMetadata(
                 algebraFactory
                   .createPattern(pattern.subject, pattern.predicate, pattern.object, graph),
-                { metadata: pattern.metadata },
+                pattern,
               ) ]));
             return ActorQueryOperationFromQuad.unionOperations(algebraFactory, bgps);
           }));
@@ -84,16 +99,20 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
       const paths = defaultGraphs.map(
         (graph: RDF.Term) => {
           if (isKnownOperation(operation, Algebra.Types.PATH)) {
-            return algebraFactory
-              .createPath(operation.subject, operation.predicate, operation.object, graph);
+            return ActorQueryOperationFromQuad.copyMetadata(
+              algebraFactory.createPath(operation.subject, operation.predicate, operation.object, graph),
+              operation,
+            );
           }
-          return Object.assign(algebraFactory
-            .createPattern(
+          return ActorQueryOperationFromQuad.copyMetadata(
+            algebraFactory.createPattern(
               operation.subject,
               operation.predicate,
               operation.object,
               graph,
-            ), { metadata: operation.metadata });
+            ),
+            operation,
+          );
         },
       );
       return ActorQueryOperationFromQuad.unionOperations(algebraFactory, paths);
@@ -111,8 +130,8 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
    * @package
    * @param algebraFactory The algebra factory.
    * @param {Operation} operation An operation.
-   * @param {RDF.Term[]} namedGraphs Graph terms.
-   * @param {RDF.Term[]} defaultGraphs Default graph terms.
+   * @param {RDF.Term[]} namedGraphs Graph terms, as defined by FROM NAMED.
+   * @param {RDF.Term[]} defaultGraphs Default graph terms, as defined by FROM.
    * @return {Operation} A new operation.
    */
   public static applyOperationNamedGraph(
@@ -126,8 +145,13 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
       isKnownOperation(operation, Algebra.Types.PATH) || isKnownOperation(operation, Algebra.Types.PATTERN)) {
       const patternGraph: RDF.Term = operation.type === 'bgp' ? operation.patterns[0].graph : operation.graph;
       if (patternGraph.termType === 'DefaultGraph') {
-        // SPARQL spec (8.2) describes that when FROM NAMED's are used without a FROM, the default graph must be empty.
-        // The FROMs are transformed before this step to a named node, so this will not apply to this case anymore.
+        // Patterns over the default graph are not restricted by FROM NAMED.
+        // They are handled afterwards by the default graph transformation.
+        if (defaultGraphs.length > 0) {
+          return operation;
+        }
+        // SPARQL 1.0 spec (8.2) and SPARQL 1.1 spec (13.2) describe that
+        // when FROM NAMED's are used without a FROM, the default graph must be empty.
         return algebraFactory.createValues([], []);
       }
       if (patternGraph.termType === 'Variable') {
@@ -145,14 +169,20 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
           let pattern: Algebra.Operation;
           if (operation.type === 'bgp') {
             pattern = algebraFactory
-              .createBgp(operation.patterns.map((pat: Algebra.Pattern) => algebraFactory
-                .createPattern(pat.subject, pat.predicate, pat.object, graph)));
+              .createBgp(operation.patterns.map((pat: Algebra.Pattern) => ActorQueryOperationFromQuad.copyMetadata(
+                algebraFactory.createPattern(pat.subject, pat.predicate, pat.object, graph),
+                pat,
+              )));
           } else if (operation.type === 'path') {
-            pattern = algebraFactory
-              .createPath(operation.subject, operation.predicate, operation.object, graph);
+            pattern = ActorQueryOperationFromQuad.copyMetadata(
+              algebraFactory.createPath(operation.subject, operation.predicate, operation.object, graph),
+              operation,
+            );
           } else {
-            pattern = algebraFactory
-              .createPattern(operation.subject, operation.predicate, operation.object, graph);
+            pattern = ActorQueryOperationFromQuad.copyMetadata(
+              algebraFactory.createPattern(operation.subject, operation.predicate, operation.object, graph),
+              operation,
+            );
           }
 
           return algebraFactory.createJoin([ values, pattern ]);
@@ -167,8 +197,10 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
           ),
         ));
       }
-      // The pattern's graph is defined (including the default graphs)
-      const isNamedGraphAvailable: boolean = [ ...namedGraphs, ...defaultGraphs ].some(
+      // The pattern's graph is defined.
+      // SPARQL 1.0 spec (8.2) and SPARQL 1.1 spec (13.2) describe that only the graphs from FROM NAMED
+      // are available as named graphs, so graphs that were only selected in a FROM must not be matched here.
+      const isNamedGraphAvailable: boolean = namedGraphs.some(
         (namedGraph: RDF.Term) => namedGraph.equals(patternGraph),
       );
       if (isNamedGraphAvailable) {
@@ -236,12 +268,15 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
    */
   public static createOperation(algebraFactory: AlgebraFactory, pattern: Algebra.From): Algebra.Operation {
     let operation: Algebra.Operation = pattern.input;
-    if (pattern.default.length > 0) {
-      operation = ActorQueryOperationFromQuad.applyOperationDefaultGraph(algebraFactory, operation, pattern.default);
-    }
+    // The named graph transformation must be applied first,
+    // as it needs to distinguish patterns that apply to the default graph
+    // from patterns that were explicitly scoped to a graph via GRAPH.
     if (pattern.named.length > 0 || pattern.default.length > 0) {
       operation = ActorQueryOperationFromQuad
         .applyOperationNamedGraph(algebraFactory, operation, pattern.named, pattern.default);
+    }
+    if (pattern.default.length > 0) {
+      operation = ActorQueryOperationFromQuad.applyOperationDefaultGraph(algebraFactory, operation, pattern.default);
     }
     return operation;
   }

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -128,9 +128,12 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
       if (patternGraph.termType === 'DefaultGraph') {
         // SPARQL spec (8.2) describes that when FROM NAMED's are used without a FROM, the default graph must be empty.
         // The FROMs are transformed before this step to a named node, so this will not apply to this case anymore.
-        return algebraFactory.createBgp([]);
+        return algebraFactory.createValues([], []);
       }
       if (patternGraph.termType === 'Variable') {
+        if (namedGraphs.length === 0) {
+          return algebraFactory.createValues([], []);
+        }
         if (namedGraphs.length === 1) {
           const graph: RDF.NamedNode = namedGraphs[0];
           // If the pattern graph is a variable, replace the graph and bind the variable using VALUES
@@ -173,7 +176,7 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
         return operation;
       }
       // No-op if the pattern's graph was not selected in a FROM NAMED.
-      return algebraFactory.createBgp([]);
+      return algebraFactory.createValues([], []);
     }
 
     return ActorQueryOperationFromQuad.copyOperation(

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -131,9 +131,6 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
         return algebraFactory.createValues([], []);
       }
       if (patternGraph.termType === 'Variable') {
-        if (namedGraphs.length === 0) {
-          return algebraFactory.createValues([], []);
-        }
         if (namedGraphs.length === 1) {
           const graph: RDF.NamedNode = namedGraphs[0];
           // If the pattern graph is a variable, replace the graph and bind the variable using VALUES

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -132,7 +132,6 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
       }
       if (patternGraph.termType === 'Variable') {
         if (namedGraphs.length === 0) {
-          // No named graphs available to bind to the variable -> zero solutions
           return algebraFactory.createValues([], []);
         }
         if (namedGraphs.length === 1) {

--- a/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
+++ b/packages/actor-query-operation-from-quad/lib/ActorQueryOperationFromQuad.ts
@@ -131,6 +131,10 @@ export class ActorQueryOperationFromQuad extends ActorQueryOperationTypedMediate
         return algebraFactory.createValues([], []);
       }
       if (patternGraph.termType === 'Variable') {
+        if (namedGraphs.length === 0) {
+          // No named graphs available to bind to the variable -> zero solutions
+          return algebraFactory.createValues([], []);
+        }
         if (namedGraphs.length === 1) {
           const graph: RDF.NamedNode = namedGraphs[0];
           // If the pattern graph is a variable, replace the graph and bind the variable using VALUES

--- a/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
+++ b/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
@@ -394,6 +394,17 @@ describe('ActorQueryOperationFromQuad', () => {
       expect(quad('s', 'p', 'o', 'g').equals(result.input[1])).toBeTruthy();
     });
 
+    it('should transform a Path with a variable graph pattern without any named graphs to a no-op', () => {
+      const result = <Algebra.Join> ActorQueryOperationFromQuad
+        .applyOperationNamedGraph(
+          AF,
+          Object.assign(quad('s', 'p', 'o', '?g'), { type: 'path' }),
+          [],
+          [ DF.namedNode('g') ],
+        );
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
+    });
+
     it('should transform a Path with a non-available non-default graph pattern to a no-op', () => {
       const result = ActorQueryOperationFromQuad
         .applyOperationNamedGraph(

--- a/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
+++ b/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
@@ -141,6 +141,19 @@ describe('ActorQueryOperationFromQuad', () => {
       expect(quad('s', 'p', 'o', 'gother').equals(result)).toBeTruthy();
     });
 
+    it('should transform a Path with a default graph pattern and keep metadata', () => {
+      const metadata = { a: 'b' };
+      const result = <Algebra.Path> ActorQueryOperationFromQuad
+        .applyOperationDefaultGraph(
+          AF,
+          Object.assign(quad('s', 'p', 'o'), { type: 'path', metadata }),
+          [ DF.namedNode('g') ],
+        );
+      expect(result.type).toBe('path');
+      expect(quad('s', 'p', 'o', 'g').equals(result)).toBeTruthy();
+      expect(result.metadata).toBe(metadata);
+    });
+
     it('should transform a Path with default graph patterns', () => {
       const result = <Algebra.Union> ActorQueryOperationFromQuad
         .applyOperationDefaultGraph(
@@ -262,6 +275,19 @@ describe('ActorQueryOperationFromQuad', () => {
       expect(quad('s', 'p', 'o', 'g').equals((<Algebra.Bgp>result.input[1]).patterns[0])).toBeTruthy();
     });
 
+    it('should transform a pattern with a variable graph pattern and keep metadata', () => {
+      const metadata = { a: 'b' };
+      const result = <Algebra.Join> ActorQueryOperationFromQuad
+        .applyOperationNamedGraph(
+          AF,
+          AF.createBgp([ Object.assign(quad('s', 'p', 'o', '?g'), { type: 'pattern', metadata }) ]),
+          [ DF.namedNode('g') ],
+          [],
+        );
+      expect(result.type).toBe('join');
+      expect((<Algebra.Bgp> result.input[1]).patterns[0].metadata).toBe(metadata);
+    });
+
     it('should transform a pattern with a non-available non-default graph pattern to a no-op', () => {
       const result = ActorQueryOperationFromQuad
         .applyOperationNamedGraph(
@@ -273,16 +299,28 @@ describe('ActorQueryOperationFromQuad', () => {
       expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
-    it('should not transform a pattern with a non-available non-default graph pattern but available as default', () => {
-      const result = <Algebra.Bgp> ActorQueryOperationFromQuad
+    it('should transform a pattern with a graph pattern that is only available as default graph to a no-op', () => {
+      // Graphs that are only selected in a FROM are not available as named graph
+      const result = ActorQueryOperationFromQuad
         .applyOperationNamedGraph(
           AF,
           AF.createBgp([ Object.assign(quad('s', 'p', 'o', 'gother'), { type: 'pattern' }) ]),
           [ DF.namedNode('g') ],
           [ DF.namedNode('gother') ],
         );
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
+    });
+
+    it('should not transform a default graph pattern if default graphs are available', () => {
+      const result = <Algebra.Bgp> ActorQueryOperationFromQuad
+        .applyOperationNamedGraph(
+          AF,
+          AF.createBgp([ Object.assign(quad('s', 'p', 'o'), { type: 'pattern' }) ]),
+          [ DF.namedNode('g') ],
+          [ DF.namedNode('gother') ],
+        );
       expect(result.type).toBe('bgp');
-      expect(quad('s', 'p', 'o', 'gother').equals(result.patterns[0])).toBeTruthy();
+      expect(quad('s', 'p', 'o').equals(result.patterns[0])).toBeTruthy();
     });
 
     it('should not transform a pattern with an available non-default graph pattern', () => {
@@ -392,6 +430,20 @@ describe('ActorQueryOperationFromQuad', () => {
       expect(values.bindings[0].g).toEqual(DF.namedNode('g'));
       expect(result.input[1].type).toBe('path');
       expect(quad('s', 'p', 'o', 'g').equals(result.input[1])).toBeTruthy();
+    });
+
+    it('should transform a Path with a variable graph pattern and keep metadata', () => {
+      const metadata = { a: 'b' };
+      const result = <Algebra.Join> ActorQueryOperationFromQuad
+        .applyOperationNamedGraph(
+          AF,
+          Object.assign(quad('s', 'p', 'o', '?g'), { type: 'path', metadata }),
+          [ DF.namedNode('g') ],
+          [],
+        );
+      expect(result.type).toBe('join');
+      expect(result.input[1].type).toBe('path');
+      expect(result.input[1].metadata).toBe(metadata);
     });
 
     it('should transform a Path with a variable graph pattern without any named graphs to a no-op', () => {
@@ -523,6 +575,21 @@ describe('ActorQueryOperationFromQuad', () => {
       const pattern = <Algebra.Pattern> result.input[1];
       expect(pattern.type).toBe('pattern');
       expect(quad('s', 'p', 'o', 'g').equals(pattern)).toBeTruthy();
+    });
+
+    it('should transform a Pattern with a variable graph pattern and keep metadata', () => {
+      const metadata = { a: 'b' };
+      const result = <Algebra.Join> ActorQueryOperationFromQuad
+        .applyOperationNamedGraph(
+          AF,
+          Object.assign(quad('s', 'p', 'o', '?g'), { type: 'pattern', metadata }),
+          [ DF.namedNode('g') ],
+          [],
+        );
+      expect(result.type).toBe('join');
+      const pattern = <Algebra.Pattern> result.input[1];
+      expect(pattern.type).toBe('pattern');
+      expect(pattern.metadata).toBe(metadata);
     });
 
     it('should transform a Pattern with a non-available non-default graph pattern to a no-op', () => {

--- a/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
+++ b/packages/actor-query-operation-from-quad/test/ActorQueryOperationFromQuad-test.ts
@@ -242,7 +242,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a pattern with a variable graph pattern', () => {
@@ -270,7 +270,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should not transform a pattern with a non-available non-default graph pattern but available as default', () => {
@@ -305,7 +305,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a pattern with variable graph patterns', () => {
@@ -350,7 +350,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a pattern with available non-default graph patterns', () => {
@@ -373,7 +373,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Path with a variable graph pattern', () => {
@@ -402,7 +402,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Path with an available non-default graph pattern', () => {
@@ -425,7 +425,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Path with variable graph patterns', () => {
@@ -481,7 +481,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with a default graph pattern to a no-op', () => {
@@ -492,7 +492,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with a variable graph pattern', () => {
@@ -522,7 +522,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with an available non-default graph pattern', () => {
@@ -545,7 +545,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform a Pattern with variable graph patterns', () => {
@@ -601,7 +601,7 @@ describe('ActorQueryOperationFromQuad', () => {
           [ DF.namedNode('g'), DF.namedNode('h') ],
           [],
         );
-      expect(result).toEqual({ type: Algebra.Types.BGP, patterns: []});
+      expect(result).toEqual({ type: Algebra.Types.VALUES, bindings: [], variables: []});
     });
 
     it('should transform other types of operations', () => {
@@ -773,9 +773,10 @@ describe('ActorQueryOperationFromQuad', () => {
         named: [],
         type: 'from',
       };
-      const result = <Algebra.Bgp> ActorQueryOperationFromQuad.createOperation(AF, pattern);
-      expect(result.type).toBe('bgp');
-      expect(result.patterns).toEqual([]);
+      const result = <Algebra.Values> ActorQueryOperationFromQuad.createOperation(AF, pattern);
+      expect(result.type).toBe('values');
+      expect(result.variables).toEqual([]);
+      expect(result.bindings).toEqual([]);
     });
 
     it('should transform without default graphs and with one variable named graph', () => {
@@ -816,9 +817,10 @@ describe('ActorQueryOperationFromQuad', () => {
         named: [ DF.namedNode('g2') ],
         type: 'from',
       };
-      const result = <Algebra.Bgp> ActorQueryOperationFromQuad.createOperation(AF, pattern);
-      expect(result.type).toBe('bgp');
-      expect(result.patterns).toEqual([]);
+      const result = <Algebra.Values> ActorQueryOperationFromQuad.createOperation(AF, pattern);
+      expect(result.type).toBe('values');
+      expect(result.variables).toEqual([]);
+      expect(result.bindings).toEqual([]);
     });
 
     it('should transform without default graphs and with two variable named graphs', () => {
@@ -874,10 +876,11 @@ describe('ActorQueryOperationFromQuad', () => {
         named: [ DF.namedNode('g2'), DF.namedNode('g3') ],
         type: 'from',
       };
-      const result = <Algebra.Bgp> ActorQueryOperationFromQuad.createOperation(AF, pattern);
+      const result = <Algebra.Values> ActorQueryOperationFromQuad.createOperation(AF, pattern);
 
-      expect(result.type).toBe('bgp');
-      expect(result.patterns).toEqual([]);
+      expect(result.type).toBe('values');
+      expect(result.variables).toEqual([]);
+      expect(result.bindings).toEqual([]);
     });
 
     it('should transform with one default graph and with one variable named graph', () => {
@@ -984,9 +987,10 @@ describe('ActorQueryOperationFromQuad', () => {
       const result = <Algebra.Join> ActorQueryOperationFromQuad.createOperation(AF, pattern);
       expect(result.type).toBe('join');
 
-      const res0 = <Algebra.Bgp> result.input[0];
-      expect(res0.type).toBe('bgp');
-      expect(res0.patterns).toEqual([]);
+      const res0 = <Algebra.Values> result.input[0];
+      expect(res0.type).toBe('values');
+      expect(res0.variables).toEqual([]);
+      expect(res0.bindings).toEqual([]);
 
       const res1 = <Algebra.Bgp> result.input[1];
       expect(res1.type).toBe('bgp');


### PR DESCRIPTION
Part of #1736, and branched off https://github.com/comunica/comunica/pull/1768 (the first five commits are @noahvsb's, so that PR can be closed in favour of this one, or this one rebased once it lands).

With this, **all `dataset-*` tests of the SPARQL 1.0 suite pass**, and `dataset-` is dropped from the `spec:query-1-0` skip list.

## The remaining bugs on top of #1768

#1768 fixed the empty-solutions bug of `dataset-02` and the crash on `FROM` + `GRAPH` (`dataset-04`). Three more problems remained, all in the construction of the RDF dataset:

### 1. The source annotation was dropped when rewriting graphs

`ActorQueryOperationFromQuad` recreates patterns and paths with another graph, but only `applyOperationDefaultGraph` carried over their `metadata`. That metadata holds the `scopedSource` annotation, so every rewritten `GRAPH` pattern lost its source and failed with:

```
Actor urn:comunica:default:query-operation/actors#source requires an operation with source annotation.
```

This was the unresolved 3rd bug of #1768, and made `dataset-03`, `dataset-06`, `dataset-08`, `dataset-09b` and `dataset-10b` fail.

### 2. Operations within a FROM were pruned before their graphs were rewritten

`ActorOptimizeQueryOperationPruneEmptySourceOperations` asks the source whether a pattern has results, during query optimization. The graphs of patterns within a `FROM` are only rewritten when that `FROM` operation is executed, which happens *after* optimization, so those emptiness checks run against the wrong graphs.

For `dataset-07`, `dataset-11` and `dataset-12b`, this pruned the left-hand side of

```sparql
SELECT * FROM <data-g1.ttl> FROM NAMED <data-g2.ttl>
{ { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }
```

because `?s ?p ?o` was still scoped to the (empty) default graph of the source at that point. The optimizer now no longer descends into `FROM` operations, just like it already did for `SERVICE`.

This is not limited to queries: the `USING` and `USING NAMED` clauses of an update are translated into a `FROM` operation *nested* within the update operation, so the same pruning made

```sparql
DELETE { GRAPH <g1> { ?s ?p ?o } } USING <g1> WHERE { { ?s ?p ?o } UNION { ?s ?p ?o } }
```

silently delete nothing. Both cases are covered by tests.

### 3. Graphs selected by FROM were matched by GRAPH clauses

The named graph transformation considered a pattern graph available when it occurred in `FROM` *or* `FROM NAMED`, because it ran after the default graph transformation had already rewritten default graph patterns to the `FROM` graphs. So `FROM <g1> { GRAPH <g1> { ?s ?p ?o } }` returned results, while SPARQL 1.0 (8.2) and SPARQL 1.1 (13.2) define the named graphs of the dataset as exactly those of `FROM NAMED` (and `FROM <g1> { GRAPH ?g { … } }` already correctly returned nothing, so the engine was also inconsistent with itself here).

The two transformations are swapped, so that the named graph transformation can still tell patterns over the default graph apart from patterns explicitly scoped via `GRAPH`, and only `FROM NAMED` graphs are exposed as named graphs. This matches the reading in https://github.com/comunica/comunica/pull/1757#discussion_r3886066906: `FROM` merges into the default graph, `FROM NAMED` keeps the graph named.

## Testing

- `dataset` manifest of SPARQL 1.0: 12 / 12 (was 4 / 12 on #1768)
- `spec:query-1-0`: 464 / 464
- `spec:query-1-1`: 326 / 326, `spec:update-1-1`: 157 / 157, `spec:csv-tsv-1-1`: 6 / 6, `spec:json-1-1`: 4 / 4, `spec:query-1-2`: 263 / 263
- Full unit test suite passes, both changed files remain at 100% coverage.
- Added unit tests for the metadata retention and the `FROM` skip, and a `RDF dataset construction with FROM and FROM NAMED` block of end-to-end tests in `QuerySparql-test.ts` covering the dataset rules of the spec (including property paths within `GRAPH`, and the `USING` case above).