### PR TITLE
Support SERVICE SILENT and nested SERVICE clauses

### DIFF
--- a/engines/query-sparql/package.json
+++ b/engines/query-sparql/package.json
@@ -66,7 +66,7 @@
     "spec:update-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-update/",
     "spec:csv-tsv-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-results-csv-tsv/",
     "spec:json-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-results-json/",
-    "spec:fed-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-federated-query/ --skip \"service/manifest#service(3|5|6|7)\"",
+    "spec:fed-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-federated-query/ --skip \"service/manifest#service5\"",
     "spec:sd-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-service-description/",
     "spec:prot-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-protocol/ --skip \"protocol/manifest#bad_update_dataset_conflict\"",
     "spec:graphstore-1-1": "yarn run --silent spec:base-1-1 -s http://www.w3.org/TR/sparql11-http-rdf-update/",

--- a/packages/actor-init-query/spec/sparql-engine-base.js
+++ b/packages/actor-init-query/spec/sparql-engine-base.js
@@ -113,7 +113,8 @@ function createServiceFetch(engine, serviceData) {
       return new Response(null, { status: 404 });
     }
 
-    const result = await engine.query(query, { sources: [ store ]});
+    // Pass the same fetch function, so that this endpoint can resolve nested SERVICE clauses.
+    const result = await engine.query(query, { sources: [ store ], fetch: serviceFetch });
     const mediaType = 'application/sparql-results+json';
     const body = await stringifyStream((await engine.resultToString(result, mediaType)).data);
     return new Response(body, { status: 200, headers: { 'content-type': mediaType }});

--- a/packages/actor-optimize-query-operation-assign-sources-exhaustive/lib/ActorOptimizeQueryOperationAssignSourcesExhaustive.ts
+++ b/packages/actor-optimize-query-operation-assign-sources-exhaustive/lib/ActorOptimizeQueryOperationAssignSourcesExhaustive.ts
@@ -58,12 +58,14 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
    * @param operation The input operation.
    * @param sources The sources to assign.
    * @param serviceSources Mapping of SERVICE names to sources.
+   * @param withinService If we are assigning sources within the body of a SERVICE clause.
    */
   public assignExhaustive(
     factory: AlgebraFactory,
     operation: Algebra.Operation,
     sources: IQuerySourceWrapper[],
     serviceSources: Record<string, IQuerySourceWrapper>,
+    withinService = false,
   ): Algebra.Operation {
     return algebraUtils.mapOperation(operation, {
       [Algebra.Types.PATTERN]: {
@@ -85,17 +87,28 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
               if (serviceOp.silent) {
                 source = {
                   ...source,
-                  context: (source.context ?? new ActionContext()).set(KeysInitQuery.lenient, true),
+                  context: (source.context ?? new ActionContext())
+                    // Suppresses hard errors while dereferencing a SERVICE target that is a plain document.
+                    .set(KeysInitQuery.lenient, true)
+                    // Replaces errors from the source by a single empty solution.
+                    .set(KeysQueryOperation.silent, true),
                 };
               }
-              return this.assignExhaustive(
+              const input = this.assignExhaustive(
                 factory,
                 serviceOp.input,
                 [ source ],
-                // Pass empty serviceSources to ensure nested SERVICE clauses are not transformed.
+                // Pass empty serviceSources, so that nested SERVICE clauses are delegated to this source.
                 {},
+                true,
               );
+              return input;
             }
+          }
+          // Nested SERVICE clauses are delegated as-is to the source of the enclosing SERVICE clause,
+          // which is responsible for resolving them.
+          if (withinService && sources.length === 1) {
+            return assignOperationSource(serviceOp, sources[0]);
           }
           return serviceOp;
         },

--- a/packages/actor-optimize-query-operation-assign-sources-exhaustive/test/ActorOptimizeQueryOperationAssignSourcesExhaustive-test.ts
+++ b/packages/actor-optimize-query-operation-assign-sources-exhaustive/test/ActorOptimizeQueryOperationAssignSourcesExhaustive-test.ts
@@ -266,9 +266,13 @@ describe('ActorOptimizeQueryOperationAssignSourcesExhaustive', () => {
         const operationOut = actor.assignExhaustive(AF, operationIn, [ source1 ], { source1 });
         expect(operationOut.type).toEqual(Algebra.Types.PATTERN);
         expect(getOperationSource(operationOut)).not.toBe(source1);
+        // Silent SERVICE clauses mark their target, so that its errors can be swallowed at execution time.
         expect(getOperationSource(operationOut)).toEqual({
           source: source1.source,
-          context: new ActionContext({ [KeysInitQuery.lenient.name]: true }),
+          context: new ActionContext({
+            [KeysInitQuery.lenient.name]: true,
+            [KeysQueryOperation.silent.name]: true,
+          }),
         });
       });
 
@@ -284,11 +288,15 @@ describe('ActorOptimizeQueryOperationAssignSourcesExhaustive', () => {
         expect(getOperationSource(operationOut)).not.toBe(source1);
         expect(getOperationSource(operationOut)).toEqual({
           source: source1.source,
-          context: new ActionContext({ [KeysInitQuery.lenient.name]: true, a: 'b' }),
+          context: new ActionContext({
+            [KeysInitQuery.lenient.name]: true,
+            [KeysQueryOperation.silent.name]: true,
+            a: 'b',
+          }),
         });
       });
 
-      it('for service with a known source should assign, but not nested service', async() => {
+      it('for service with a known source should assign, and delegate nested service to it', async() => {
         const operationIn = AF.createService(
           AF.createJoin([
             AF.createPattern(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
@@ -302,7 +310,9 @@ describe('ActorOptimizeQueryOperationAssignSourcesExhaustive', () => {
         const operationOut = actor.assignExhaustive(AF, operationIn, [ source1 ], { source1 });
         expect(operationOut.type).toEqual(Algebra.Types.JOIN);
         expect(getOperationSource((<any> operationOut).input[0])).toBe(source1);
+        // Nested SERVICE clauses are passed on as-is to the source of the enclosing SERVICE clause.
         expect((<any> operationOut).input[1].type).toEqual(Algebra.Types.SERVICE);
+        expect(getOperationSource((<any> operationOut).input[1])).toBe(source1);
       });
 
       it('for service with variable should not assign', async() => {

--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/lib/ActorOptimizeQueryOperationPruneEmptySourceOperations.ts
@@ -4,7 +4,7 @@ import type {
   IActorOptimizeQueryOperationArgs,
 } from '@comunica/bus-optimize-query-operation';
 import { ActorOptimizeQueryOperation } from '@comunica/bus-optimize-query-operation';
-import { KeysInitQuery, KeysQuerySourceIdentify } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation, KeysQuerySourceIdentify } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { failTest, passTestVoid } from '@comunica/core';
 import type {
@@ -201,6 +201,12 @@ export class ActorOptimizeQueryOperationPruneEmptySourceOperations extends Actor
 
     // Traversal contexts should never be considered empty at optimization time.
     if (mergedContext.get(KeysQuerySourceIdentify.traverse)) {
+      return true;
+    }
+
+    // The target of a SERVICE SILENT clause must never be pruned:
+    // if it fails, it must produce a single empty solution rather than no results at all.
+    if (mergedContext.get(KeysQueryOperation.silent)) {
       return true;
     }
 

--- a/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
+++ b/packages/actor-optimize-query-operation-prune-empty-source-operations/test/ActorOptimizeQueryOperationPruneEmptySourceOperations-test.ts
@@ -1,4 +1,4 @@
-import { KeysInitQuery, KeysQuerySourceIdentify } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation, KeysQuerySourceIdentify } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IQuerySourceWrapper } from '@comunica/types';
 import { Algebra, AlgebraFactory } from '@comunica/utils-algebra';
@@ -935,6 +935,16 @@ describe('ActorOptimizeQueryOperationPruneEmptySourceOperations', () => {
 
         it('should be true for 0 cardinality on source with traversal enabled', async() => {
           source1.context = new ActionContext().set(KeysQuerySourceIdentify.traverse, true);
+          source1.source.queryBindings = () => {
+            const bindingsStream = new ArrayIterator<RDF.Bindings>([], { autoStart: false });
+            bindingsStream.setProperty('metadata', { cardinality: { type: 'exact', value: 0 }});
+            return bindingsStream;
+          };
+          await expect(actor.hasSourceResults(AF, source1, AF.createNop(), ctx)).resolves.toBeTruthy();
+        });
+
+        it('should be true for 0 cardinality on the target of a SERVICE SILENT clause', async() => {
+          source1.context = new ActionContext().set(KeysQueryOperation.silent, true);
           source1.source.queryBindings = () => {
             const bindingsStream = new ArrayIterator<RDF.Bindings>([], { autoStart: false });
             bindingsStream.setProperty('metadata', { cardinality: { type: 'exact', value: 0 }});

--- a/packages/actor-optimize-query-operation-query-source-identify/lib/ActorOptimizeQueryOperationQuerySourceIdentify.ts
+++ b/packages/actor-optimize-query-operation-query-source-identify/lib/ActorOptimizeQueryOperationQuerySourceIdentify.ts
@@ -102,6 +102,7 @@ export class ActorOptimizeQueryOperationQuerySourceIdentify extends ActorOptimiz
       const services: Set<string> = new Set();
       algebraUtils.visitOperation(action.operation, {
         [Algebra.Types.SERVICE]: {
+          // Nested SERVICE clauses are delegated to their parent SERVICE target, so they need no source here.
           preVisitor: () => ({ continue: false }),
           visitor: (serviceOperation) => {
             if (serviceOperation.name.termType === 'NamedNode') {

--- a/packages/actor-query-operation-source/lib/ActorQueryOperationSource.ts
+++ b/packages/actor-query-operation-source/lib/ActorQueryOperationSource.ts
@@ -1,16 +1,21 @@
 import type { IActionQueryOperation, IActorQueryOperationArgs } from '@comunica/bus-query-operation';
 import { ActorQueryOperation } from '@comunica/bus-query-operation';
-import { KeysInitQuery } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { failTest, passTest } from '@comunica/core';
 import type {
+  ComunicaDataFactory,
+  IActionContext,
   IPhysicalQueryPlanLogger,
   IQueryOperationResult,
   IQuerySourceWrapper,
 } from '@comunica/types';
 import { Algebra, algebraUtils } from '@comunica/utils-algebra';
+import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { getMetadataBindings, getMetadataQuads } from '@comunica/utils-metadata';
 import { doesShapeAcceptOperation, getOperationSource } from '@comunica/utils-query-operation';
+import type * as RDF from '@rdfjs/types';
+import { SilencedBindingsIterator } from './SilencedBindingsIterator';
 
 /**
  * A comunica Source Query Operation Actor.
@@ -95,12 +100,27 @@ export class ActorQueryOperationSource extends ActorQueryOperation {
         };
     }
 
-    const bindingsStream = sourceWrapper.source.queryBindings(action.operation, mergedContext);
+    let bindingsStream = sourceWrapper.source.queryBindings(action.operation, mergedContext);
+    // Targets of a SERVICE SILENT clause must swallow their errors, and produce a single empty solution instead.
+    if (mergedContext.get(KeysQueryOperation.silent)) {
+      bindingsStream = new SilencedBindingsIterator(
+        bindingsStream,
+        this.createEmptyBindings(action.context),
+        error => this.logWarn(action.context, `An error occurred in a SERVICE SILENT clause: ${error.message}`),
+      );
+    }
     const metadata = getMetadataBindings(bindingsStream);
     return {
       type: 'bindings',
       bindingsStream,
       metadata,
     };
+  }
+
+  protected createEmptyBindings(context: IActionContext): RDF.Bindings {
+    const dataFactory: ComunicaDataFactory = context.getSafe(KeysInitQuery.dataFactory);
+    // The empty solution carries no values, so it needs no context merge handlers.
+    // TODO: add mediatorMergeBindingsContext in next major
+    return new BindingsFactory(dataFactory).bindings();
   }
 }

--- a/packages/actor-query-operation-source/lib/SilencedBindingsIterator.ts
+++ b/packages/actor-query-operation-source/lib/SilencedBindingsIterator.ts
@@ -1,0 +1,68 @@
+import type { BindingsStream, MetadataBindings } from '@comunica/types';
+import { MetadataValidationState } from '@comunica/utils-metadata';
+import type * as RDF from '@rdfjs/types';
+import { BufferedIterator } from 'asynciterator';
+
+/**
+ * Wraps a bindings stream so that its errors are swallowed.
+ * If the wrapped stream errors before emitting anything,
+ * a single empty solution is emitted instead, as mandated by SPARQL 1.1 Federated Query for `SERVICE SILENT`.
+ * If it errors after emitting results, those results are kept and the stream simply ends,
+ * since the empty solution can no longer be substituted for them.
+ */
+export class SilencedBindingsIterator extends BufferedIterator<RDF.Bindings> {
+  private readonly innerSource: BindingsStream;
+  private readonly emptyBindings: RDF.Bindings;
+  private readonly onError: (error: Error) => void;
+  private innerError: Error | undefined;
+  private emittedAny = false;
+
+  public constructor(source: BindingsStream, emptyBindings: RDF.Bindings, onError: (error: Error) => void) {
+    super({ autoStart: false });
+    this.innerSource = source;
+    this.emptyBindings = emptyBindings;
+    this.onError = onError;
+    // Metadata is exposed as an iterator property, so it must be forwarded explicitly.
+    source.getProperty('metadata', (metadata: MetadataBindings) => this.setProperty('metadata', metadata));
+    source.on('error', (error: Error) => {
+      this.innerError = error;
+      if (!this.getProperty('metadata')) {
+        this.setProperty('metadata', {
+          state: new MetadataValidationState(),
+          cardinality: { type: 'exact', value: 1 },
+          variables: [],
+        });
+      }
+      this.readable = true;
+    });
+    source.on('readable', () => {
+      this.readable = true;
+    });
+    source.on('end', () => {
+      this.readable = true;
+    });
+  }
+
+  protected override _read(count: number, done: () => void): void {
+    if (this.innerError) {
+      this.onError(this.innerError);
+      if (!this.emittedAny) {
+        this._push(this.emptyBindings);
+      }
+      this.close();
+      return done();
+    }
+    while (count-- > 0) {
+      const item = this.innerSource.read();
+      if (item === null) {
+        break;
+      }
+      this.emittedAny = true;
+      this._push(item);
+    }
+    if (this.innerSource.done) {
+      this.close();
+    }
+    done();
+  }
+}

--- a/packages/actor-query-operation-source/package.json
+++ b/packages/actor-query-operation-source/package.json
@@ -46,7 +46,10 @@
     "@comunica/core": "^5.3.0",
     "@comunica/types": "^5.3.0",
     "@comunica/utils-algebra": "^5.3.0",
+    "@comunica/utils-bindings-factory": "^5.3.0",
     "@comunica/utils-metadata": "^5.3.0",
-    "@comunica/utils-query-operation": "^5.3.0"
+    "@comunica/utils-query-operation": "^5.3.0",
+    "@rdfjs/types": "*",
+    "asynciterator": "^3.10.0"
   }
 }

--- a/packages/actor-query-operation-source/test/ActorQueryOperationSource-test.ts
+++ b/packages/actor-query-operation-source/test/ActorQueryOperationSource-test.ts
@@ -1,4 +1,4 @@
-import { KeysInitQuery } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import type {
   IActionContext,
@@ -10,8 +10,9 @@ import type {
   IPhysicalQueryPlanLogger,
 } from '@comunica/types';
 import { AlgebraFactory } from '@comunica/utils-algebra';
+import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { assignOperationSource } from '@comunica/utils-query-operation';
-import { ArrayIterator } from 'asynciterator';
+import { ArrayIterator, TransformIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import { ActorQueryOperationSource } from '../lib/ActorQueryOperationSource';
 import 'jest-rdf';
@@ -19,6 +20,7 @@ import '@comunica/utils-jest';
 
 const AF = new AlgebraFactory();
 const DF = new DataFactory();
+const BF = new BindingsFactory(DF);
 
 describe('ActorQueryOperationSource', () => {
   let bus: any;
@@ -101,6 +103,97 @@ describe('ActorQueryOperationSource', () => {
       it('should not handle operations without top-level source', async() => {
         await expect(actor.test({ context: new ActionContext(), operation: AF.createNop() }))
           .resolves.toFailTest(`Actor actor requires an operation with source annotation.`);
+      });
+    });
+
+    describe('run over a silent source', () => {
+      const DFF = DF;
+
+      function silentSource(makeStream: () => any): IQuerySourceWrapper {
+        return <any> {
+          source: { referenceValue: 'silent', queryBindings: jest.fn(makeStream) },
+          context: new ActionContext({ [KeysQueryOperation.silent.name]: true }),
+        };
+      }
+
+      function silentContext(): IActionContext {
+        return new ActionContext({ [KeysInitQuery.dataFactory.name]: DFF });
+      }
+
+      it('should pass results through when the source succeeds', async() => {
+        const wrapper = silentSource(() => {
+          const stream = new ArrayIterator(
+            [ BF.bindings([[ DFF.variable('x'), DFF.literal('1') ]]) ],
+            { autoStart: false },
+          );
+          stream.setProperty('metadata', { cardinality: { type: 'exact', value: 1 }, variables: []});
+          return stream;
+        });
+        const output = <IQueryOperationResultBindings> await actor.run({
+          context: silentContext(),
+          operation: assignOperationSource(AF.createNop(), <any> wrapper),
+        });
+        await expect(output.metadata()).resolves.toEqual({
+          cardinality: { type: 'exact', value: 1 },
+          variables: [],
+        });
+        await expect(output.bindingsStream).toEqualBindingsStream([
+          BF.bindings([[ DFF.variable('x'), DFF.literal('1') ]]),
+        ]);
+      });
+
+      it('should pass results through when the source produces them asynchronously', async() => {
+        const wrapper = silentSource(() => {
+          const stream = new TransformIterator<any>(
+            () => new Promise(resolve => setImmediate(() => resolve(
+              new ArrayIterator([ BF.bindings([[ DFF.variable('x'), DFF.literal('1') ]]) ], { autoStart: false }),
+            ))),
+            { autoStart: false },
+          );
+          stream.setProperty('metadata', { cardinality: { type: 'exact', value: 1 }, variables: []});
+          return stream;
+        });
+        const output = <IQueryOperationResultBindings> await actor.run({
+          context: silentContext(),
+          operation: assignOperationSource(AF.createNop(), <any> wrapper),
+        });
+        await expect(output.bindingsStream).toEqualBindingsStream([
+          BF.bindings([[ DFF.variable('x'), DFF.literal('1') ]]),
+        ]);
+      });
+
+      it('should emit a single empty solution when the source errors', async() => {
+        const wrapper = silentSource(() =>
+          new TransformIterator(() => Promise.reject(new Error('Source down')), { autoStart: false }));
+        const output = <IQueryOperationResultBindings> await actor.run({
+          context: silentContext(),
+          operation: assignOperationSource(AF.createNop(), <any> wrapper),
+        });
+        await expect(output.bindingsStream).toEqualBindingsStream([ BF.bindings() ]);
+        await expect(output.metadata()).resolves.toEqual({
+          state: expect.anything(),
+          cardinality: { type: 'exact', value: 1 },
+          variables: [],
+        });
+      });
+
+      it('should keep results emitted before the source errors', async() => {
+        const wrapper = silentSource(() => {
+          const stream = new ArrayIterator(
+            [ BF.bindings([[ DFF.variable('x'), DFF.literal('1') ]]) ],
+            { autoStart: false },
+          );
+          stream.setProperty('metadata', { cardinality: { type: 'exact', value: 1 }, variables: []});
+          stream.on('end', () => stream.emit('error', new Error('Source down')));
+          return stream;
+        });
+        const output = <IQueryOperationResultBindings> await actor.run({
+          context: silentContext(),
+          operation: assignOperationSource(AF.createNop(), <any> wrapper),
+        });
+        await expect(output.bindingsStream).toEqualBindingsStream([
+          BF.bindings([[ DFF.variable('x'), DFF.literal('1') ]]),
+        ]);
       });
     });
 

--- a/packages/actor-rdf-join-inner-multi-bind-source/lib/ActorRdfJoinMultiBindSource.ts
+++ b/packages/actor-rdf-join-inner-multi-bind-source/lib/ActorRdfJoinMultiBindSource.ts
@@ -37,6 +37,7 @@ export class ActorRdfJoinMultiBindSource extends ActorRdfJoin<IActorRdfJoinMulti
     super(args, {
       logicalType: 'inner',
       physicalName: 'bind-source',
+      pushesBindingsToSource: true,
       canHandleUndefs: true,
     });
     this.selectivityModifier = args.selectivityModifier;

--- a/packages/actor-rdf-join-inner-multi-smallest-filter-bindings/lib/ActorRdfJoinMultiSmallestFilterBindings.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest-filter-bindings/lib/ActorRdfJoinMultiSmallestFilterBindings.ts
@@ -40,6 +40,7 @@ export class ActorRdfJoinMultiSmallestFilterBindings extends ActorRdfJoin {
     super(args, {
       logicalType: 'inner',
       physicalName: 'multi-smallest-filter-bindings',
+      pushesBindingsToSource: true,
       limitEntries: 2,
       limitEntriesMin: true,
       isLeaf: false,

--- a/packages/bus-rdf-join/lib/ActorRdfJoin.ts
+++ b/packages/bus-rdf-join/lib/ActorRdfJoin.ts
@@ -2,7 +2,7 @@ import type { MediatorRdfJoinEntriesSort } from '@comunica/bus-rdf-join-entries-
 import type {
   MediatorRdfJoinSelectivity,
 } from '@comunica/bus-rdf-join-selectivity';
-import { KeysInitQuery } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import type { IAction, IActorArgs, Mediate, TestResult } from '@comunica/core';
 import { passTest, failTest, Actor } from '@comunica/core';
 import type { IMediatorTypeJoinCoefficients } from '@comunica/mediatortype-join-coefficients';
@@ -20,6 +20,7 @@ import type {
 } from '@comunica/types';
 import { instrumentIterator } from '@comunica/utils-iterator';
 import { cachifyMetadata, MetadataValidationState } from '@comunica/utils-metadata';
+import { getOperationSource } from '@comunica/utils-query-operation';
 import type * as RDF from '@rdfjs/types';
 
 /**
@@ -76,6 +77,10 @@ TS
    * This will typically only be true for bind-join-like operators.
    */
   protected readonly canHandleOperationRequired?: boolean;
+  /**
+   * If this actor pushes bindings of one entry into the source of another entry.
+   */
+  protected readonly pushesBindingsToSource?: boolean;
 
   /* eslint-disable max-len */
   /**
@@ -96,6 +101,7 @@ TS
     this.isLeaf = options.isLeaf ?? true;
     this.requiresVariableOverlap = options.requiresVariableOverlap ?? false;
     this.canHandleOperationRequired = options.canHandleOperationRequired ?? false;
+    this.pushesBindingsToSource = options.pushesBindingsToSource ?? false;
   }
 
   /**
@@ -399,12 +405,6 @@ TS
       return failTest(`${this.name} requires at least two join entries.`);
     }
 
-    // Check if operationRequired is supported.
-    const someOperationRequired = action.entries.some(entry => entry.operationRequired);
-    if (!this.canHandleOperationRequired && someOperationRequired) {
-      return failTest(`${this.name} does not work with operationRequired.`);
-    }
-
     // Check if this actor can handle the given number of streams
     if (this.limitEntriesMin ? action.entries.length < this.limitEntries : action.entries.length > this.limitEntries) {
       return failTest(`${this.name} requires ${this.limitEntries
@@ -418,6 +418,20 @@ TS
         // eslint-disable-next-line ts/restrict-template-expressions
         return failTest(`Invalid type of a join entry: Expected 'bindings' but got '${entry.output.type}'`);
       }
+    }
+
+    // Check if operationRequired is supported.
+    const someOperationRequired = action.entries.some(entry => entry.operationRequired);
+    if (!this.canHandleOperationRequired && someOperationRequired) {
+      return failTest(`${this.name} does not work with operationRequired.`);
+    }
+
+    // Pushing bindings into a source happens in chunks, with one source invocation per chunk.
+    // The target of a SERVICE SILENT clause must produce exactly one empty solution when it fails,
+    // which it could not do if it were invoked once per chunk.
+    if (this.pushesBindingsToSource && action.entries
+      .some(entry => getOperationSource(entry.operation)?.context?.get(KeysQueryOperation.silent))) {
+      return failTest(`${this.name} can not push bindings into the target of a SERVICE SILENT clause.`);
     }
 
     const metadatas = await ActorRdfJoin.getMetadatas(action.entries);
@@ -594,6 +608,12 @@ export interface IActorRdfJoinInternalOptions {
    * This will typically only be true for bind-join-like operators.
    */
   canHandleOperationRequired?: boolean;
+  /**
+   * If this actor pushes bindings of one entry into the source of another entry,
+   * which it does in chunks, resulting in one source invocation per chunk.
+   * Defaults to false.
+   */
+  pushesBindingsToSource?: boolean;
 }
 
 export interface IActionRdfJoin extends IAction {

--- a/packages/bus-rdf-join/package.json
+++ b/packages/bus-rdf-join/package.json
@@ -48,6 +48,7 @@
     "@comunica/types": "^5.3.0",
     "@comunica/utils-iterator": "^5.0.0",
     "@comunica/utils-metadata": "^5.3.0",
+    "@comunica/utils-query-operation": "^5.3.0",
     "@rdfjs/types": "*"
   }
 }

--- a/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
+++ b/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
@@ -1,11 +1,13 @@
 import type { IActionRdfJoinSelectivity, IActorRdfJoinSelectivityOutput } from '@comunica/bus-rdf-join-selectivity';
-import { KeysInitQuery } from '@comunica/context-entries';
+import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import type { Actor, IActorTest, Mediator, TestResult } from '@comunica/core';
 import { passTestWithSideData, ActionContext, Bus } from '@comunica/core';
 import type { IMediatorTypeJoinCoefficients } from '@comunica/mediatortype-join-coefficients';
 import type { IPhysicalQueryPlanLogger, IPlanNode, MetadataVariable } from '@comunica/types';
+import { AlgebraFactory } from '@comunica/utils-algebra';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
 import { MetadataValidationState } from '@comunica/utils-metadata';
+import { assignOperationSource } from '@comunica/utils-query-operation';
 import { BufferedIterator, MultiTransformIterator, SingletonIterator } from 'asynciterator';
 import { DataFactory } from 'rdf-data-factory';
 import type { IActionRdfJoin, IActorRdfJoinTestSideData } from '../lib/ActorRdfJoin';
@@ -13,6 +15,7 @@ import '@comunica/utils-jest';
 import { ActorRdfJoin } from '../lib/ActorRdfJoin';
 
 const DF = new DataFactory();
+const AF = new AlgebraFactory(DF);
 const BF = new BindingsFactory(DF);
 
 // Dummy class to test instance of abstract class
@@ -28,6 +31,7 @@ IActorRdfJoinSelectivityOutput
     limitEntries?: number,
     limitEntriesMin?: boolean,
     canHandleUndefs?: boolean,
+    pushesBindingsToSource?: boolean,
   ) {
     super(
       { name: 'name', bus: new Bus({ name: 'bus' }), mediatorJoinSelectivity },
@@ -37,6 +41,7 @@ IActorRdfJoinSelectivityOutput
         limitEntries,
         limitEntriesMin,
         canHandleUndefs,
+        pushesBindingsToSource,
       },
     );
   }
@@ -1036,6 +1041,25 @@ IActorRdfJoinSelectivityOutput
       action.entries[1].operationRequired = true;
       instance = new Dummy(mediatorJoinSelectivity, 99);
       await expect(instance.test(action)).resolves.toFailTest(`name does not work with operationRequired.`);
+    });
+
+    it('should throw an error if bindings are pushed into the target of a SERVICE SILENT clause', async() => {
+      action.entries[1].operation = assignOperationSource(AF.createNop(), <any> {
+        source: {},
+        context: new ActionContext({ [KeysQueryOperation.silent.name]: true }),
+      });
+      instance = new Dummy(mediatorJoinSelectivity, 99, false, false, true);
+      await expect(instance.test(action)).resolves
+        .toFailTest(`name can not push bindings into the target of a SERVICE SILENT clause.`);
+    });
+
+    it('should not throw an error if bindings are not pushed into a source', async() => {
+      action.entries[1].operation = assignOperationSource(AF.createNop(), <any> {
+        source: {},
+        context: new ActionContext({ [KeysQueryOperation.silent.name]: true }),
+      });
+      instance = new Dummy(mediatorJoinSelectivity, 99);
+      await expect(instance.test(action)).resolves.toPassTest(expect.anything());
     });
 
     it('should return a value if both metadata objects are present', async() => {

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -331,6 +331,12 @@ export const KeysQueryOperation = {
    */
   readOnly: new ActionContextKey<boolean>('@comunica/bus-query-operation:readOnly'),
   /**
+   * Flag on a query source context indicating that this source is the target of a `SERVICE SILENT` clause.
+   * Errors from such a source must be swallowed, and replaced by a single empty solution,
+   * as mandated by SPARQL 1.1 Federated Query.
+   */
+  silent: new ActionContextKey<boolean>('@comunica/bus-query-operation:silent'),
+  /**
    * An internal context entry to mark that a property path with arbitrary length and a distinct key is being processed.
    */
   isPathArbitraryLengthDistinctKey: new ActionContextKey<boolean>(


### PR DESCRIPTION
Enables three of the four SPARQL 1.1 Federated Query spec tests that were skipped in https://github.com/comunica/comunica/pull/1772: `service3`, `service6` and `service7`. Contributes to https://github.com/comunica/comunica/issues/721.

`service5` uses a variable as SERVICE target and stays skipped here; it is handled separately in https://github.com/comunica/comunica/pull/1810.

## Background

Since [`04b51f8`](https://github.com/comunica/comunica/commit/04b51f8b45a4ef0cbc870fe132b102c237d58e17) ("Rewrite SERVICE clauses as query operation with annotated source"), SERVICE is handled at optimize time by `assign-sources-exhaustive` instead of by a runtime actor. That rewrite only covers `SERVICE <iri>` at the top level of the operation tree; anything it does not rewrite leaves a bare `service` node that nothing on the query operation bus can execute:

```
none of the configured actors were able to handle the operation type service
```

Two cases fell into that gap, and `SERVICE SILENT` regressed at the same time.

## Changes

**Nested SERVICE clauses (`service3`)** — these were deliberately left untransformed, but were then unexecutable. They are now annotated with the source of the *enclosing* SERVICE clause and passed along verbatim, so the parent target is responsible for resolving them, as the spec intends. `assignExhaustive` gained a `withinService` flag for this; `query-source-identify` still does not descend into SERVICE bodies.

**`SERVICE SILENT` (`service6`, `service7`)** — this only set `KeysInitQuery.lenient` on the target source, which is read solely by `ActorDereferenceBase`; errors raised by the source itself still propagated, so `SERVICE SILENT` behaved identically to non-silent. Silent targets now additionally carry a new `KeysQueryOperation.silent` flag on their source context, which `ActorQueryOperationSource` acts on by swallowing errors and producing a single empty solution, as required by [§3.2](https://www.w3.org/TR/sparql11-federated-query/#serviceFailure).

Actors that push bindings of one entry into the source of another declare this through the new `pushesBindingsToSource` option, and `ActorRdfJoin` rejects them for a silent target. They invoke the source once per chunk of bindings, bypassing `ActorQueryOperationSource` entirely, so such a clause would otherwise throw rather than produce its empty solution — and since an empty solution joins with everything, silencing per chunk would multiply the other side by the number of chunks. Emptiness probes in `prune-empty-source-operations` skip silent targets for the same reason: a failing target must produce an empty solution rather than be pruned away.

The spec test harness now passes its service fetch function into the nested `engine.query` call, so a mocked endpoint can resolve nested SERVICE clauses in turn.

## Testing

Spec suites, compared against a baseline run on `b5afaa3`:

| Suite | Before | After |
|---|---|---|
| SPARQL 1.1 federated query | 5 / 9 | **9 / 9** (`service5` skipped) |
| SPARQL 1.0 | 467 / 476 | 467 / 476 |
| SPARQL 1.1 query | 326 / 328 | 326 / 328 |
| SPARQL 1.1 update | 157 / 157 | 157 / 157 |
| SPARQL 1.1 csv/tsv, json, service description | all pass | all pass |
| SPARQL 1.2 | 263 / 263 | 263 / 263 |

The pre-existing SPARQL 1.0 and 1.1 failures are the ones the `spec:*` scripts `--skip`; they are unchanged by this PR.

Unit tests pass across the touched packages, with full coverage of the silencing iterator and every changed branch. Beyond the spec tests, a `SERVICE SILENT` against a broken endpoint joined with 40 local bindings returns exactly 40 rows, where the same query throws without the pushdown check.

## Notes for review

- **A behaviour difference worth a decision.** The `serviceAllowFileTargets` test added in https://github.com/comunica/comunica/pull/1808 asserts that a silent SERVICE against a blocked local file yields *no* results, and it still passes: `lenient` turns the dereference failure into an empty document before any error reaches the bindings stream, so the new silencing never sees it. A failing *endpoint* now yields the spec's single empty solution instead. Both are "the service failed", so the two paths disagree. Unifying them means not setting `lenient` for silent targets and letting the error reach `SilencedBindingsIterator`, which would change that test from 0 rows to 1. I left the merged behaviour alone — happy to unify if you prefer.
- Delegating nested SERVICE clauses assumes the parent endpoint supports nested SERVICE. That matches the spec and the manifest's own comment on `service3` ("This query depends in the capabilities of the example1.org endpoint"), but it does mean such queries fail against endpoints that do not support it.
- The delegated query serializes with a redundant `SELECT … WHERE { SELECT … WHERE { … } }` nesting. Harmless, but worth a follow-up.
- Refusing binding pushdown into silent sources costs that optimisation for `SERVICE SILENT` clauses; `multi-bind` takes over and silences per binding, which is correct.
- The empty solution is built with `new BindingsFactory(dataFactory)` rather than through `mediatorMergeBindingsContext`, to avoid adding a mediator parameter to `ActorQueryOperationSource`. It carries no values, so it needs no context merge handlers; a `TODO` marks this for the next major.
- `SilencedBindingsIterator` ends the stream quietly if a silent source errors after results were already emitted, since the empty solution can no longer be substituted. The spec only defines the all-or-nothing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4QghLG8yMWpYmoYHdckv9