### PR TITLE
Stop advertising hypermedia as a source type that can be enforced

### DIFF
--- a/engines/query-sparql/README.md
+++ b/engines/query-sparql/README.md
@@ -189,7 +189,7 @@ const bindingsStream = await myEngine.queryBindings(`...`, {
   sources: [
     'http://fragments.dbpedia.org/2015/en',
     {
-      type: 'hypermedia',
+      type: 'qpf',
       value: 'http://fragments.dbpedia.org/2016/en'
     },
     {

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerBase.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerBase.ts
@@ -43,7 +43,7 @@ export class CliArgsHandlerBase implements ICliArgsHandler {
   }
 
   /**
-   * Converts an URL like 'hypermedia@http://user:passwd@example.com to an IDataSource
+   * Converts an URL like 'sparql@http://user:passwd@example.com to an IDataSource
    * @param {string} sourceString An url with possibly a type and authorization.
    * @return {[id: string]: any} An IDataSource which represents the sourceString.
    */

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerHttp.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerHttp.ts
@@ -11,7 +11,7 @@ export class CliArgsHandlerHttp implements ICliArgsHandler {
       .example([
         [ `$0 https://fragments.dbpedia.org/2016-04/en`, '' ],
         [ `$0 https://fragments.dbpedia.org/2016-04/en https://query.wikidata.org/sparql`, '' ],
-        [ `$0 hypermedia@https://fragments.dbpedia.org/2016-04/en sparql@https://query.wikidata.org/sparql`, '' ],
+        [ `$0 qpf@https://fragments.dbpedia.org/2016-04/en sparql@https://query.wikidata.org/sparql`, '' ],
       ])
       .options({
         port: {

--- a/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
+++ b/packages/actor-init-query/lib/cli/CliArgsHandlerQuery.ts
@@ -36,7 +36,7 @@ export class CliArgsHandlerQuery implements ICliArgsHandler {
         [ `$0 https://fragments.dbpedia.org/2016-04/en -q 'SELECT * { ?s ?p ?o }'`, '' ],
         [ `$0 https://fragments.dbpedia.org/2016-04/en -f query.sparql`, '' ],
         [ `$0 https://fragments.dbpedia.org/2016-04/en https://query.wikidata.org/sparql ...`, '' ],
-        [ `$0 hypermedia@https://fragments.dbpedia.org/2016-04/en sparql@https://query.wikidata.org/sparql ...`, '' ],
+        [ `$0 qpf@https://fragments.dbpedia.org/2016-04/en sparql@https://query.wikidata.org/sparql ...`, '' ],
       ])
       .options({
         query: {

--- a/packages/actor-init-query/test/cli/CliArgsHandlerBase-test.ts
+++ b/packages/actor-init-query/test/cli/CliArgsHandlerBase-test.ts
@@ -18,9 +18,9 @@ describe('CliArgsHandlerBase', () => {
     });
 
     it('should work with type annotation', () => {
-      const hypermedia = 'hypermedia@http://example.org/';
+      const hypermedia = 'qpf@http://example.org/';
       expect(CliArgsHandlerBase.getSourceObjectFromString(hypermedia))
-        .toEqual({ value: 'http://example.org/', type: 'hypermedia' });
+        .toEqual({ value: 'http://example.org/', type: 'qpf' });
     });
 
     it('should work with authorization in url', () => {
@@ -33,9 +33,9 @@ describe('CliArgsHandlerBase', () => {
     });
 
     it('should work with type annotation and authorization in url', () => {
-      const hypermedia = 'hypermedia@http://username:passwd@example.org/';
+      const hypermedia = 'qpf@http://username:passwd@example.org/';
       expect(CliArgsHandlerBase.getSourceObjectFromString(hypermedia))
-        .toEqual({ value: 'http://example.org/', type: 'hypermedia', context: new ActionContext({ [KeysHttp.auth.name]: 'username:passwd' }) });
+        .toEqual({ value: 'http://example.org/', type: 'qpf', context: new ActionContext({ [KeysHttp.auth.name]: 'username:passwd' }) });
     });
 
     it('should work with empty username in authorization in url', () => {


### PR DESCRIPTION
Hypermedia-based detection is what happens when *no* source type is set, so `hypermedia` is not a type that can be enforced. The CLI help ends with an example that is guaranteed to fail:

```
$ comunica-sparql --help
...
Examples:
  comunica-sparql hypermedia@https://fragments.dbpedia.org/2016-04/en sparql@https://query.wikidata.org/sparql ...

$ comunica-sparql hypermedia@https://fragments.dbpedia.org/2016-04/en \
    -q 'SELECT ?o WHERE { <http://dbpedia.org/resource/Brad_Pitt> <http://www.w3.org/2000/01/rdf-schema#label> ?o } LIMIT 1'
Query source hypermedia identification failed: none of the configured actors were able to identify https://fragments.dbpedia.org/2016-04/en
    Actor urn:comunica:default:query-source-identify-hypermedia/actors#qpf is not able to handle source type hypermedia.
    ...
```

`ActorQuerySourceIdentifyHypermedia#test` fails whenever `forceSourceType` differs from the actor's own `sourceType`, and the actors on that bus declare `file`, `qpf` (which also accepts `brtpf`) and `sparql` — nothing declares `hypermedia`. Against the same interface, `qpf@`, `brtpf@`, `file@` and no prefix at all all return `"Brad Pitt"@en`.

The examples now use `qpf@`, which is what they were demonstrating, and the fixed example verifiably works:

```
$ comunica-sparql qpf@https://fragments.dbpedia.org/2016-04/en sparql@https://query.wikidata.org/sparql \
    -q 'SELECT ?o WHERE { <http://dbpedia.org/resource/Brad_Pitt> <http://www.w3.org/2000/01/rdf-schema#label> ?o } LIMIT 1'
[
{"o":"\"Brad Pitt\"@en"}
]
```

Changed:

- `CliArgsHandlerQuery` and `CliArgsHandlerHttp` help examples.
- The `getSourceObjectFromString` doc comment, which used `hypermedia@` as its example URL.
- The `type: 'hypermedia'` entry in the `engines/query-sparql` README source list.
- The two `CliArgsHandlerBase` tests that used `hypermedia@` as their example annotation, so the test suite no longer models a type that cannot be used.

No behaviour changes — the parser has always passed the annotation through verbatim, and this only corrects what we tell people to pass.

The matching documentation on comunica.dev is fixed in comunica/website#79, which also drops `hypermedia` from the supported source types table (and the claim that the default is a settable type named `auto`, which fails the same way).

Found while building the Comunica MCP servers: the tool description handed this guidance to LLM agents, which then used a prefix that always fails.

## Testing

`yarn lint`, `yarn build` and the full `yarn test` pass (480 suites, 6770 tests) via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsJEtfJvQuwEneuWAKb5RH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsJEtfJvQuwEneuWAKb5RH)_