### PR TITLE
Fix DESCRIBE queries with a FROM (NAMED) dataset

### DIFF
--- a/packages/actor-optimize-query-operation-describe-to-constructs-subject/lib/ActorOptimizeQueryOperationDescribeToConstructsSubject.ts
+++ b/packages/actor-optimize-query-operation-describe-to-constructs-subject/lib/ActorOptimizeQueryOperationDescribeToConstructsSubject.ts
@@ -8,7 +8,7 @@ import { KeysInitQuery } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { failTest, passTest } from '@comunica/core';
 import type { ComunicaDataFactory } from '@comunica/types';
-import { Algebra, AlgebraFactory } from '@comunica/utils-algebra';
+import { Algebra, AlgebraFactory, algebraUtils } from '@comunica/utils-algebra';
 import type * as RDF from '@rdfjs/types';
 
 /**
@@ -20,7 +20,14 @@ export class ActorOptimizeQueryOperationDescribeToConstructsSubject extends Acto
   }
 
   public async test(action: IActionOptimizeQueryOperation): Promise<TestResult<IActorTest>> {
-    if (action.operation.type !== Algebra.Types.DESCRIBE) {
+    let found = false;
+    algebraUtils.visitOperation(action.operation, {
+      [Algebra.Types.DESCRIBE]: { preVisitor: () => {
+        found = true;
+        return { continue: false };
+      } },
+    });
+    if (!found) {
       return failTest(`Actor ${this.name} only supports describe operations, but got ${action.operation.type}`);
     }
     return passTest(true);
@@ -30,8 +37,27 @@ export class ActorOptimizeQueryOperationDescribeToConstructsSubject extends Acto
     const dataFactory: ComunicaDataFactory = action.context.getSafe(KeysInitQuery.dataFactory);
     const algebraFactory = new AlgebraFactory(dataFactory);
 
-    const operationOriginal: Algebra.Describe = <Algebra.Describe> action.operation;
+    // Describes can be wrapped in a FROM (NAMED) dataset, so they are not necessarily the outermost operation
+    const operation = algebraUtils.mapOperation(action.operation, {
+      [Algebra.Types.DESCRIBE]: {
+        transform: describe => this.describeToConstructs(describe, dataFactory, algebraFactory),
+      },
+    });
 
+    return { operation, context: action.context };
+  }
+
+  /**
+   * Rewrite a describe operation into a union of construct operations.
+   * @param {Algebra.Describe} operationOriginal The describe operation to rewrite.
+   * @param {ComunicaDataFactory} dataFactory The data factory.
+   * @param {AlgebraFactory} algebraFactory The algebra factory.
+   */
+  protected describeToConstructs(
+    operationOriginal: Algebra.Describe,
+    dataFactory: ComunicaDataFactory,
+    algebraFactory: AlgebraFactory,
+  ): Algebra.Operation {
     // Create separate construct queries for all non-variable terms
     const operations: Algebra.Construct[] = operationOriginal.terms
       .filter(term => term.termType !== 'Variable')
@@ -84,8 +110,6 @@ export class ActorOptimizeQueryOperationDescribeToConstructsSubject extends Acto
     }
 
     // Union the construct operations
-    const operation = algebraFactory.createUnion(operations, false);
-
-    return { operation, context: action.context };
+    return algebraFactory.createUnion(operations, false);
   }
 }

--- a/packages/actor-optimize-query-operation-describe-to-constructs-subject/package.json
+++ b/packages/actor-optimize-query-operation-describe-to-constructs-subject/package.json
@@ -44,6 +44,7 @@
     "@comunica/bus-optimize-query-operation": "^5.3.0",
     "@comunica/context-entries": "^5.3.0",
     "@comunica/core": "^5.3.0",
+    "@comunica/types": "^5.3.0",
     "@comunica/utils-algebra": "^5.3.0"
   }
 }

--- a/packages/actor-optimize-query-operation-describe-to-constructs-subject/test/ActorOptimizeQueryOperationDescribeToConstructsSubject-test.ts
+++ b/packages/actor-optimize-query-operation-describe-to-constructs-subject/test/ActorOptimizeQueryOperationDescribeToConstructsSubject-test.ts
@@ -35,6 +35,33 @@ describe('ActorOptimizeQueryOperationDescribeToConstructsSubject', () => {
         .toFailTest(`Actor actor only supports describe operations, but got some-other-type`);
     });
 
+    it('should test on a describe within a dataset', async() => {
+      const op: any = { operation: AF.createFrom(<any> { type: 'describe' }, [ DF.namedNode('g') ], []) };
+      await expect(actor.test(op)).resolves.toPassTestVoid();
+    });
+
+    it('should run on a describe within a dataset', async() => {
+      const op: any = {
+        context: new ActionContext({ name: 'context', [KeysInitQuery.dataFactory.name]: DF }),
+        operation: AF.createFrom(<any> {
+          type: 'describe',
+          terms: [ DF.namedNode('a') ],
+          input: { type: 'bgp', patterns: []},
+        }, [ DF.namedNode('g') ], []),
+      };
+      const { operation: opOut } = await actor.run(op);
+      expect(opOut).toEqual(AF.createFrom(AF.createUnion([
+        AF.createConstruct(
+          AF.createBgp([
+            AF.createPattern(DF.namedNode('a'), DF.variable('__predicate'), DF.variable('__object')),
+          ]),
+          [
+            AF.createPattern(DF.namedNode('a'), DF.variable('__predicate'), DF.variable('__object')),
+          ],
+        ),
+      ]), [ DF.namedNode('g') ], []));
+    });
+
     it('should run without variable terms', async() => {
       const op: any = {
         context: new ActionContext({ name: 'context', [KeysInitQuery.dataFactory.name]: DF }),


### PR DESCRIPTION
A DESCRIBE query that defines its own dataset fails:

```js
const { QueryEngine } = require('@comunica/query-sparql');

const sources = [{
  type: 'serialized',
  mediaType: 'application/trig',
  baseIRI: 'http://example.org/',
  value: `
    <http://example.org/s> <http://example.org/p> <http://example.org/o> .
    <http://example.org/g> { <http://example.org/s> <http://example.org/p> <http://example.org/o> }
  `,
}];

async function run(query) {
  try {
    const quads = await new QueryEngine().queryQuads(query, { sources });
    console.log(`${query}\n  => ${(await quads.toArray()).length} quads`);
  } catch (error) {
    console.log(`${query}\n  => ${error.message.split('\n')[0]}`);
  }
}

(async() => {
  await run('DESCRIBE <http://example.org/s>');
  await run('CONSTRUCT { ?s ?p ?o } FROM <http://example.org/g> WHERE { ?s ?p ?o }');
  await run('DESCRIBE <http://example.org/s> FROM <http://example.org/g>');
})();
```

```
DESCRIBE <http://example.org/s>
  => 1 quads
CONSTRUCT { ?s ?p ?o } FROM <http://example.org/g> WHERE { ?s ?p ?o }
  => 1 quads
DESCRIBE <http://example.org/s> FROM <http://example.org/g>
  => Query operation processing failed: none of the configured actors were able to handle the operation type describe
```

A describe on its own works, and so does a FROM dataset on a construct, but their combination does not.