### PR TITLE
Add regression tests for describes nested under FROM and slices

### DIFF
--- a/engines/query-sparql/test/QuerySparql-test.ts
+++ b/engines/query-sparql/test/QuerySparql-test.ts
@@ -342,6 +342,50 @@ describe('System test: QuerySparql', () => {
         });
       });
 
+      describe('handle DESCRIBE queries that are not the outermost operation', () => {
+        let store: Store;
+        const quadDefault = DF.quad(DF.namedNode('ex:s'), DF.namedNode('ex:p'), DF.namedNode('ex:o'));
+        const quadNamed = DF
+          .quad(DF.namedNode('ex:sg'), DF.namedNode('ex:pg'), DF.namedNode('ex:og'), DF.namedNode('ex:g'));
+
+        async function describeQuads(query: string): Promise<RDF.Quad[]> {
+          return arrayifyStream(await engine.queryQuads(query, <any> { sources: [ store ]}));
+        }
+
+        beforeEach(() => {
+          store = new Store();
+          store.addQuads([ quadDefault, quadNamed ]);
+        });
+
+        it('handles a describe wrapped in a FROM dataset', async() => {
+          await expect(describeQuads('DESCRIBE <ex:sg> FROM <ex:g>')).resolves
+            .toEqualRdfQuadArray([ DF.quad(DF.namedNode('ex:sg'), DF.namedNode('ex:pg'), DF.namedNode('ex:og')) ]);
+        });
+
+        it('handles a describe wrapped in a FROM dataset that excludes the term', async() => {
+          await expect(describeQuads('DESCRIBE <ex:s> FROM <ex:g>')).resolves.toEqualRdfQuadArray([]);
+        });
+
+        it('handles a describe with variable terms wrapped in a FROM dataset', async() => {
+          await expect(describeQuads('DESCRIBE ?s FROM <ex:g> WHERE { ?s ?p ?o }')).resolves
+            .toEqualRdfQuadArray([ DF.quad(DF.namedNode('ex:sg'), DF.namedNode('ex:pg'), DF.namedNode('ex:og')) ]);
+        });
+
+        it('handles a describe wrapped in a FROM NAMED dataset with an empty default graph', async() => {
+          // SPARQL 1.1 spec (13.2): when FROM NAMED is used without a FROM, the default graph must be empty
+          await expect(describeQuads('DESCRIBE <ex:s> FROM NAMED <ex:g>')).resolves.toEqualRdfQuadArray([]);
+        });
+
+        it('handles a describe wrapped in a slice', async() => {
+          await expect(describeQuads('DESCRIBE <ex:s> LIMIT 10')).resolves.toEqualRdfQuadArray([ quadDefault ]);
+        });
+
+        it('handles a describe wrapped in both a FROM dataset and a slice', async() => {
+          await expect(describeQuads('DESCRIBE <ex:sg> FROM <ex:g> LIMIT 10')).resolves
+            .toEqualRdfQuadArray([ DF.quad(DF.namedNode('ex:sg'), DF.namedNode('ex:pg'), DF.namedNode('ex:og')) ]);
+        });
+      });
+
       describe('extension function', () => {
         let funcAllow: string;
         let store: Store;

--- a/packages/actor-optimize-query-operation-describe-to-constructs-subject/lib/ActorOptimizeQueryOperationDescribeToConstructsSubject.ts
+++ b/packages/actor-optimize-query-operation-describe-to-constructs-subject/lib/ActorOptimizeQueryOperationDescribeToConstructsSubject.ts
@@ -20,6 +20,8 @@ export class ActorOptimizeQueryOperationDescribeToConstructsSubject extends Acto
   }
 
   public async test(action: IActionOptimizeQueryOperation): Promise<TestResult<IActorTest>> {
+    // Describes can be wrapped in a FROM (NAMED) dataset or a LIMIT/OFFSET slice,
+    // so they are not necessarily the outermost operation
     let found = false;
     algebraUtils.visitOperation(action.operation, {
       [Algebra.Types.DESCRIBE]: { preVisitor: () => {
@@ -28,7 +30,9 @@ export class ActorOptimizeQueryOperationDescribeToConstructsSubject extends Acto
       } },
     });
     if (!found) {
-      return failTest(`Actor ${this.name} only supports describe operations, but got ${action.operation.type}`);
+      return failTest(
+        `Actor ${this.name} only supports operations containing a describe, but got ${action.operation.type}`,
+      );
     }
     return passTest(true);
   }
@@ -37,9 +41,12 @@ export class ActorOptimizeQueryOperationDescribeToConstructsSubject extends Acto
     const dataFactory: ComunicaDataFactory = action.context.getSafe(KeysInitQuery.dataFactory);
     const algebraFactory = new AlgebraFactory(dataFactory);
 
-    // Describes can be wrapped in a FROM (NAMED) dataset, so they are not necessarily the outermost operation
+    // Describes can be wrapped in a FROM (NAMED) dataset or a LIMIT/OFFSET slice,
+    // so they are not necessarily the outermost operation
     const operation = algebraUtils.mapOperation(action.operation, {
       [Algebra.Types.DESCRIBE]: {
+        // Describes can not be nested, so there is no need to look inside of one
+        preVisitor: () => ({ continue: false }),
         transform: describe => this.describeToConstructs(describe, dataFactory, algebraFactory),
       },
     });

--- a/packages/actor-optimize-query-operation-describe-to-constructs-subject/test/ActorOptimizeQueryOperationDescribeToConstructsSubject-test.ts
+++ b/packages/actor-optimize-query-operation-describe-to-constructs-subject/test/ActorOptimizeQueryOperationDescribeToConstructsSubject-test.ts
@@ -32,7 +32,7 @@ describe('ActorOptimizeQueryOperationDescribeToConstructsSubject', () => {
     it('should not test on non-describe', async() => {
       const op: any = { operation: { type: 'some-other-type' }};
       await expect(actor.test(op)).resolves
-        .toFailTest(`Actor actor only supports describe operations, but got some-other-type`);
+        .toFailTest(`Actor actor only supports operations containing a describe, but got some-other-type`);
     });
 
     it('should test on a describe within a dataset', async() => {
@@ -60,6 +60,61 @@ describe('ActorOptimizeQueryOperationDescribeToConstructsSubject', () => {
           ],
         ),
       ]), [ DF.namedNode('g') ], []));
+    });
+
+    it('should test on a describe within a slice', async() => {
+      const op: any = { operation: AF.createSlice(<any> { type: 'describe' }, 0, 10) };
+      await expect(actor.test(op)).resolves.toPassTestVoid();
+    });
+
+    it('should run on a describe within a slice', async() => {
+      const op: any = {
+        context: new ActionContext({ name: 'context', [KeysInitQuery.dataFactory.name]: DF }),
+        operation: AF.createSlice(<any> {
+          type: 'describe',
+          terms: [ DF.namedNode('a') ],
+          input: { type: 'bgp', patterns: []},
+        }, 0, 10),
+      };
+      const { operation: opOut } = await actor.run(op);
+      expect(opOut).toEqual(AF.createSlice(AF.createUnion([
+        AF.createConstruct(
+          AF.createBgp([
+            AF.createPattern(DF.namedNode('a'), DF.variable('__predicate'), DF.variable('__object')),
+          ]),
+          [
+            AF.createPattern(DF.namedNode('a'), DF.variable('__predicate'), DF.variable('__object')),
+          ],
+        ),
+      ]), 0, 10));
+    });
+
+    it('should run on a describe with variable terms within a dataset', async() => {
+      const input = AF.createBgp([
+        AF.createPattern(DF.variable('a'), DF.namedNode('p'), DF.namedNode('o')),
+      ]);
+      const op: any = {
+        context: new ActionContext({ name: 'context', [KeysInitQuery.dataFactory.name]: DF }),
+        operation: AF.createFrom(<any> {
+          type: 'describe',
+          terms: [ DF.variable('a') ],
+          input,
+        }, [ DF.namedNode('g') ], [ DF.namedNode('gn') ]),
+      };
+      const { operation: opOut } = await actor.run(op);
+      expect(opOut).toEqual(AF.createFrom(AF.createUnion([
+        AF.createConstruct(
+          AF.createJoin([
+            input,
+            AF.createBgp([
+              AF.createPattern(DF.variable('a'), DF.variable('__predicate0'), DF.variable('__object0')),
+            ]),
+          ]),
+          [
+            AF.createPattern(DF.variable('a'), DF.variable('__predicate0'), DF.variable('__object0')),
+          ],
+        ),
+      ]), [ DF.namedNode('g') ], [ DF.namedNode('gn') ]));
     });
 
     it('should run without variable terms', async() => {


### PR DESCRIPTION
Follow-up to #1782.

## Why

While reviewing #1782 I found the bug it fixes is wider than its description says. `toAlgebra` also lifts `LIMIT`/`OFFSET` above the describe, so a `DESCRIBE` with a solution modifier and **no `FROM` at all** was broken on master too:

```
DESCRIBE ?s WHERE { ?s ?p ?o } LIMIT 5   ->  slice(describe(bgp))
DESCRIBE <a> FROM <g>                    ->  from(describe(bgp))
DESCRIBE ?s FROM <g> WHERE {...} LIMIT 5 ->  from(slice(describe(bgp)))
```

`DESCRIBE ?s WHERE { ?s ?p ?o } LIMIT 5` failed with `none of the configured actors were able to handle the operation type describe` before #1782, and works after it. That is a plain, `FROM`-free query, and nothing covered it.

This also means the generic tree walk #1782 introduced is the right call: a shallow "root, or the input of a root `from`" check would have missed the slice case entirely.

The other gap: the tests added in #1782 assert the actor's output shape (`from(union(construct))`), which does not establish that `ActorQueryOperationFromQuad` downstream turns that into the right quads. It does, but nothing locked it in.

## Changes

* **System tests** in `engines/query-sparql` that run describes under a `FROM (NAMED)` dataset and under a slice through a real engine, checking the actual quads. All six fail against the actor as it was before #1782.
* **Actor tests** for a describe under a slice, and for a describe with variable terms under a dataset (the branch that joins the `WHERE` input).
* **Stop descending into describes** while rewriting, matching `ActorOptimizeQueryOperationConstructDistinct`, which uses `preVisitor: () => ({ continue: false })` in the same `mapOperation` pattern. Describes can not be nested, so the transformer was deep-copying the describe's subtree only for `describeToConstructs` to discard the copy. Output is identical with and without it, so this is waste, not correctness.
* **Comments and message.** The comments now mention slices as well as datasets, and the test failure message says "only supports operations containing a describe" rather than "only supports describe operations", which stopped being true when the actor started accepting wrapped describes.

## Not included

Two pre-existing issues I ran into while checking this. Both predate #1782, neither is caused by it, and both look like they want their own fix:

* **Solution modifiers are applied to quads, not solutions.** Because the slice sits outside, `DESCRIBE ?s WHERE { ?s ?p ?o } LIMIT 1` over a subject with 3 triples returns 1 quad. Per spec 10.4/16.4 the modifiers apply to the `WHERE` solution sequence, then the describe builds the graph, so it should describe 1 resource and return all 3 of its triples. `CONSTRUCT { ?s ?p ?o . ?s <x> "y" } WHERE {...} LIMIT 1` has the same shape and returns 1 quad instead of 2. This is why the tests here use a `LIMIT` larger than the result set: they check that these queries run and return the right quads without freezing in the questionable slicing semantics.
* **Describes do not deduplicate.** `DESCRIBE ?s WHERE { ?s ?p ?o }` over 4 triples returns 10 quads, with the same triple repeated three times. A describe result is an RDF graph, so it should be a set.

## Checks

`yarn lint`, `yarn build`, and the full `jest` suite pass (6781 tests). Coverage on the changed actor file stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFgT4nKEC4ZzoKK4hUceGr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFgT4nKEC4ZzoKK4hUceGr)_