### PR TITLE
Respond with 400 to invalid SPARQL endpoint requests

### DIFF
--- a/packages/actor-init-query/__mocks__/url.js
+++ b/packages/actor-init-query/__mocks__/url.js
@@ -11,6 +11,18 @@ function parse(url, _parseQueryString) {
       query: {},
     };
   }
+  if (url === 'url_sparql_update_param') {
+    return {
+      pathname: '/sparql',
+      query: { update: 'CLEAR ALL' },
+    };
+  }
+  if (url === 'url_sparql_multiple_queries') {
+    return {
+      pathname: '/sparql',
+      query: { query: [ 'test_query', 'other_test_query' ]},
+    };
+  }
   return {
     pathname: 'not_sparql_path',
     query: { query: 'test_query' },

--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -379,22 +379,13 @@ export class HttpServiceSparqlEndpoint {
     let queryBody: IQueryBody | undefined;
     switch (request.method) {
       case 'POST':
-        queryBody = await this.parseBody(request);
-        await this.writeQueryResult(
-          engine,
-          stdout,
-          stderr,
-          request,
-          response,
-          queryBody,
-          mediaType,
-          false,
-          false,
-          this.lastQueryId++,
-        );
-        break;
       case 'QUERY':
-        queryBody = await this.parseBody(request);
+        try {
+          queryBody = await this.parseBody(request);
+        } catch (error: unknown) {
+          this.writeBadRequest(stdout, response, (<Error> error).message);
+          return;
+        }
         await this.writeQueryResult(
           engine,
           stdout,
@@ -404,14 +395,24 @@ export class HttpServiceSparqlEndpoint {
           queryBody,
           mediaType,
           false,
-          true,
+          // QUERY is a safe method, so it may only read data
+          request.method === 'QUERY',
           this.lastQueryId++,
         );
         break;
       case 'HEAD':
       case 'GET':
+        // Updates may only be invoked through POST
+        if (requestUrl.query.update) {
+          this.writeBadRequest(stdout, response, 'SPARQL updates can only be invoked with a POST request');
+          return;
+        }
         // eslint-disable-next-line no-case-declarations
-        const queryValue = <string> requestUrl.query.query;
+        const queryValue = requestUrl.query.query;
+        if (Array.isArray(queryValue)) {
+          this.writeBadRequest(stdout, response, 'A request can only contain a single query parameter');
+          return;
+        }
         queryBody = queryValue ? { type: 'query', value: queryValue, context: undefined } : undefined;
         // eslint-disable-next-line no-case-declarations
         const headOnly = request.method === 'HEAD';
@@ -449,6 +450,21 @@ export class HttpServiceSparqlEndpoint {
         );
         response.end(JSON.stringify({ message: 'Incorrect HTTP method' }));
     }
+  }
+
+  /**
+   * Writes a 400 response with the given message.
+   * @param {module:stream.internal.Writable} stdout Output stream.
+   * @param {module:http.ServerResponse} response Response object.
+   * @param {string} message The reason why the request was rejected.
+   */
+  public writeBadRequest(stdout: Writable, response: http.ServerResponse, message: string): void {
+    stdout.write(`[400] Bad request: ${message}\n`);
+    response.writeHead(
+      400,
+      { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
+    );
+    response.end(message);
   }
 
   /**
@@ -796,11 +812,15 @@ export class HttpServiceSparqlEndpoint {
                 reject(new Error(`Invalid POST body with context received ('${(<any> bodyStructure).context}'): ${(<Error> error).message}`));
               }
             }
+            // A request may only contain a single query or update
+            if (Array.isArray(bodyStructure.query) || Array.isArray(bodyStructure.update)) {
+              return reject(new Error(`Invalid request body received, it can only contain a single query or update parameter`));
+            }
             if (bodyStructure.query) {
-              return resolve({ type: 'query', value: <string> bodyStructure.query, context });
+              return resolve({ type: 'query', value: bodyStructure.query, context });
             }
             if (bodyStructure.update) {
-              return resolve({ type: 'void', value: <string> bodyStructure.update, context });
+              return resolve({ type: 'void', value: bodyStructure.update, context });
             }
           }
         }

--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -464,7 +464,7 @@ export class HttpServiceSparqlEndpoint {
       400,
       { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
     );
-    response.end(message);
+    response.end(`${message}\n`);
   }
 
   /**

--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -527,12 +527,7 @@ export class HttpServiceSparqlEndpoint {
         await result.execute();
       }
     } catch (error: unknown) {
-      stdout.write('[400] Bad request\n');
-      response.writeHead(
-        400,
-        { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
-      );
-      response.end((<Error> error).message);
+      this.writeBadRequest(stdout, response, (<Error> error).message);
       return;
     }
 
@@ -584,12 +579,11 @@ export class HttpServiceSparqlEndpoint {
       data.pipe(response);
       eventEmitter = data;
     } catch {
-      stdout.write('[400] Bad request, invalid media type\n');
-      response.writeHead(
-        400,
-        { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
+      this.writeBadRequest(
+        stdout,
+        response,
+        'The response for the given query could not be serialized for the requested media type',
       );
-      response.end('The response for the given query could not be serialized for the requested media type\n');
     }
 
     // Send message to master process to indicate the end of an execution
@@ -679,12 +673,11 @@ export class HttpServiceSparqlEndpoint {
       data.pipe(response);
       eventEmitter = data;
     } catch {
-      stdout.write('[400] Bad request, invalid media type\n');
-      response.writeHead(
-        400,
-        { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
+      this.writeBadRequest(
+        stdout,
+        response,
+        'The response for the given query could not be serialized for the requested media type',
       );
-      response.end('The response for the given query could not be serialized for the requested media type\n');
       return;
     }
     this.stopResponse(response, 0, process.stderr, eventEmitter);

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -1437,7 +1437,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         );
 
         await expect(endCalledPromise).resolves.toBe(
-          'The response for the given query could not be serialized for the requested media type\n',
+          'The response for the given query could not be serialized for the requested media type',
         );
         expect(response.writeHead).toHaveBeenLastCalledWith(
           400,
@@ -1723,7 +1723,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         expect(spyWriteServiceDescription).toHaveBeenCalledTimes(1);
 
         await expect(endCalledPromise).resolves.toBe(
-          'The response for the given query could not be serialized for the requested media type\n',
+          'The response for the given query could not be serialized for the requested media type',
         );
         expect(response.writeHead)
           .toHaveBeenLastCalledWith(400, { 'content-type': 'text/plain', 'Access-Control-Allow-Origin': '*' });

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -1119,7 +1119,7 @@ describe('HttpServiceSparqlEndpoint', () => {
           400,
           { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
         );
-        expect(response.end).toHaveBeenCalledWith('Invalid request body');
+        expect(response.end).toHaveBeenCalledWith('Invalid request body\n');
       });
 
       it('should respond with 400 when an update is invoked with GET', async() => {
@@ -1132,7 +1132,7 @@ describe('HttpServiceSparqlEndpoint', () => {
           400,
           { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
         );
-        expect(response.end).toHaveBeenCalledWith('SPARQL updates can only be invoked with a POST request');
+        expect(response.end).toHaveBeenCalledWith('SPARQL updates can only be invoked with a POST request\n');
       });
 
       it('should respond with 400 when more than one query parameter is passed', async() => {
@@ -1145,7 +1145,7 @@ describe('HttpServiceSparqlEndpoint', () => {
           400,
           { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
         );
-        expect(response.end).toHaveBeenCalledWith('A request can only contain a single query parameter');
+        expect(response.end).toHaveBeenCalledWith('A request can only contain a single query parameter\n');
       });
 
       it('should choose a mediaType if accept header is set', async() => {
@@ -1414,7 +1414,7 @@ describe('HttpServiceSparqlEndpoint', () => {
           0,
         );
 
-        await expect(endCalledPromise).resolves.toBe('Rejected query');
+        await expect(endCalledPromise).resolves.toBe('Rejected query\n');
         expect(response.writeHead).toHaveBeenLastCalledWith(
           400,
           { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
@@ -1437,7 +1437,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         );
 
         await expect(endCalledPromise).resolves.toBe(
-          'The response for the given query could not be serialized for the requested media type',
+          'The response for the given query could not be serialized for the requested media type\n',
         );
         expect(response.writeHead).toHaveBeenLastCalledWith(
           400,
@@ -1723,7 +1723,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         expect(spyWriteServiceDescription).toHaveBeenCalledTimes(1);
 
         await expect(endCalledPromise).resolves.toBe(
-          'The response for the given query could not be serialized for the requested media type',
+          'The response for the given query could not be serialized for the requested media type\n',
         );
         expect(response.writeHead)
           .toHaveBeenLastCalledWith(400, { 'content-type': 'text/plain', 'Access-Control-Allow-Origin': '*' });

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -1109,6 +1109,45 @@ describe('HttpServiceSparqlEndpoint', () => {
         );
       });
 
+      it.each([ 'POST', 'QUERY' ])('should respond with 400 when the %s body can not be parsed', async(method) => {
+        (<any> instance).parseBody = jest.fn(() => Promise.reject(new Error('Invalid request body')));
+        request.method = method;
+        await instance.handleRequest(engine, variants, stdout, stderr, request, response);
+
+        expect(instance.writeQueryResult).not.toHaveBeenCalled();
+        expect(response.writeHead).toHaveBeenCalledWith(
+          400,
+          { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
+        );
+        expect(response.end).toHaveBeenCalledWith('Invalid request body');
+      });
+
+      it('should respond with 400 when an update is invoked with GET', async() => {
+        request.method = 'GET';
+        request.url = 'url_sparql_update_param';
+        await instance.handleRequest(engine, variants, stdout, stderr, request, response);
+
+        expect(instance.writeQueryResult).not.toHaveBeenCalled();
+        expect(response.writeHead).toHaveBeenCalledWith(
+          400,
+          { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
+        );
+        expect(response.end).toHaveBeenCalledWith('SPARQL updates can only be invoked with a POST request');
+      });
+
+      it('should respond with 400 when more than one query parameter is passed', async() => {
+        request.method = 'GET';
+        request.url = 'url_sparql_multiple_queries';
+        await instance.handleRequest(engine, variants, stdout, stderr, request, response);
+
+        expect(instance.writeQueryResult).not.toHaveBeenCalled();
+        expect(response.writeHead).toHaveBeenCalledWith(
+          400,
+          { 'content-type': HttpServiceSparqlEndpoint.MIME_PLAIN, 'Access-Control-Allow-Origin': '*' },
+        );
+        expect(response.end).toHaveBeenCalledWith('A request can only contain a single query parameter');
+      });
+
       it('should choose a mediaType if accept header is set', async() => {
         const chosen = 'test_chosen_mediatype';
         variants = [{ type: chosen, quality: 1 }];
@@ -2431,6 +2470,20 @@ INSERT DATA {
           type: 'void',
           value: testRequestBody,
         });
+      });
+
+      it('should reject more than one query parameter', async() => {
+        httpRequestMock = Readable.from([ 'query=ASK%20%7B%7D&query=SELECT%20%2A%20%7B%7D' ]);
+        httpRequestMock.headers = { 'content-type': 'application/x-www-form-urlencoded' };
+        await expect(instance.parseBody(httpRequestMock)).rejects
+          .toThrow(`Invalid request body received, it can only contain a single query or update parameter`);
+      });
+
+      it('should reject more than one update parameter', async() => {
+        httpRequestMock = Readable.from([ 'update=CLEAR%20NAMED&update=CLEAR%20DEFAULT' ]);
+        httpRequestMock.headers = { 'content-type': 'application/x-www-form-urlencoded' };
+        await expect(instance.parseBody(httpRequestMock)).rejects
+          .toThrow(`Invalid request body received, it can only contain a single query or update parameter`);
       });
     });
   });


### PR DESCRIPTION
Follow-up to https://github.com/comunica/comunica/pull/1778.

A POST or QUERY request whose body the endpoint cannot interpret, such as one sent without a content type, makes parseBody reject. Nothing handles that rejection, so the client never receives a response at all, and the unhandled rejection terminates the process.

```js
const http = require('node:http');
const { QueryEngine } = require('@comunica/query-sparql');
const { HttpServiceSparqlEndpoint } = require('@comunica/actor-init-query');

(async() => {
  const engine = new QueryEngine();
  const variants = Object.entries(await engine.getResultMediaTypes())
    .map(([ type, quality ]) => ({ type, quality }));

  const server = http.createServer();
  await new Promise(resolve => server.listen(3000, '127.0.0.1', resolve));
  const service = new HttpServiceSparqlEndpoint({ engine, port: 3000 });
  server.on('request', service.handleRequest.bind(service, engine, variants, process.stdout, process.stderr));

  const res = await fetch('http://127.0.0.1:3000/sparql', {
    method: 'POST',
    headers: { 'content-type': 'text/plain' },
    body: 'ASK {}',
  });
  console.log(res.status, await res.text());
})();
```

Before, no status is ever printed, because the process is gone:

```
Error: Invalid request body received, query type could not be determined
```

After:

```
400 Invalid request body received, query type could not be determined
```