### PR TITLE
Fix the SPARQL endpoint hanging on updates with a WHERE clause

### DIFF
--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -491,7 +491,7 @@ export class HttpServiceSparqlEndpoint {
     stdout.write(`      Received ${queryBody.type} query: ${queryBody.value}\n`);
 
     // Send message to master process to indicate the start of an execution
-    process.send!({ type: 'start', queryId });
+    process.send?.({ type: 'start', queryId });
 
     // Determine context
     let context = {
@@ -506,9 +506,12 @@ export class HttpServiceSparqlEndpoint {
     try {
       result = await engine.query(queryBody.value, context);
 
-      // For update queries, also await the result
+      // For update queries, also await the result, so that failures are reported as a bad request.
+      // The execution is memoized, as updates may not be executed again while serializing the result.
       if (result.resultType === 'void') {
-        await result.execute();
+        const executed = result.execute();
+        await executed;
+        result = { ...result, execute: () => executed };
       }
     } catch (error: unknown) {
       stdout.write('[400] Bad request\n');
@@ -578,7 +581,7 @@ export class HttpServiceSparqlEndpoint {
 
     // Send message to master process to indicate the end of an execution
     response.on('close', () => {
-      process.send!({ type: 'end', queryId });
+      process.send?.({ type: 'end', queryId });
     });
 
     this.stopResponse(response, queryId, process.stderr, eventEmitter);

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -2000,6 +2000,57 @@ INSERT DATA {
         expect(process.send).toHaveBeenCalledWith({ type: 'end', queryId: 0 });
       });
 
+      it('should not emit process events when the service does not run as a worker', async() => {
+        const send = process.send;
+        delete (<any> process).send;
+        try {
+          const engine = await new QueryEngineFactoryBase().create();
+          engine.query = () => ({ resultType: 'bindings' });
+
+          await expect(instance.writeQueryResult(
+            engine,
+            new PassThrough(),
+            new PassThrough(),
+            request,
+            response,
+            query,
+            '',
+            false,
+            true,
+            0,
+          )).resolves.toBeUndefined();
+
+          response.emit('close');
+        } finally {
+          (<any> process).send = send;
+        }
+      });
+
+      it('should only execute an update once', async() => {
+        const engine = await new QueryEngineFactoryBase().create();
+        const execute = jest.fn(() => Promise.resolve());
+        engine.query = () => ({ resultType: 'void', execute });
+        jest.spyOn(engine, 'resultToString');
+
+        await instance.writeQueryResult(
+          engine,
+          new PassThrough(),
+          new PassThrough(),
+          request,
+          response,
+          query,
+          '',
+          false,
+          true,
+          0,
+        );
+
+        await expect(endCalledPromise).resolves.toBeFalsy();
+        // Serializing the result may not execute the update a second time
+        await (<any> engine.resultToString).mock.calls[0][0].execute();
+        expect(execute).toHaveBeenCalledTimes(1);
+      });
+
       it('should fallback to simple for updates if media type is falsy', async() => {
         const engine = await new QueryEngineFactoryBase().create();
         engine.query = () => ({ resultType: 'void', execute: () => Promise.resolve() });

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -2026,11 +2026,28 @@ INSERT DATA {
         }
       });
 
-      it('should only execute an update once', async() => {
+      it('should not execute an update again while serializing the result', async() => {
         const engine = await new QueryEngineFactoryBase().create();
-        const execute = jest.fn(() => Promise.resolve());
+        // The update quads mediator consumes the quad streams of the update,
+        // so its execution only ever settles the first time it is invoked.
+        let started = false;
+        const execute = jest.fn(() => {
+          if (started) {
+            return new Promise<void>(() => {
+              // Never settles, as the quad streams have already been consumed
+            });
+          }
+          started = true;
+          return Promise.resolve();
+        });
         engine.query = () => ({ resultType: 'void', execute });
-        jest.spyOn(engine, 'resultToString');
+        // Like the simple serializer, which awaits the update before writing its response
+        engine.resultToString = (result: any) => ({
+          data: Readable.from((async function* () {
+            await result.execute();
+            yield 'ok';
+          })()),
+        });
 
         await instance.writeQueryResult(
           engine,
@@ -2045,9 +2062,8 @@ INSERT DATA {
           0,
         );
 
+        // Without memoizing the execution, the response would never be ended
         await expect(endCalledPromise).resolves.toBeFalsy();
-        // Serializing the result may not execute the update a second time
-        await (<any> engine.resultToString).mock.calls[0][0].execute();
         expect(execute).toHaveBeenCalledTimes(1);
       });
 


### PR DESCRIPTION
An update with a WHERE clause sent to the endpoint never receives a response. The status line and headers are written, but the body never ends, so the client waits until it gives up.

```js
const http = require('node:http');
const { RdfStore } = require('rdf-stores');
const { QueryEngine } = require('@comunica/query-sparql');
const { HttpServiceSparqlEndpoint } = require('@comunica/actor-init-query');

(async() => {
  const store = RdfStore.createDefault(true);
  const engine = new QueryEngine();
  const variants = Object.entries(await engine.getResultMediaTypes())
    .map(([ type, quality ]) => ({ type, quality }));

  const server = http.createServer();
  await new Promise(resolve => server.listen(3000, '127.0.0.1', resolve));
  const service = new HttpServiceSparqlEndpoint({
    engine,
    port: 3000,
    context: { sources: [{ type: 'rdfjs', value: store }], destination: store },
  });
  server.on('request', service.handleRequest.bind(service, engine, variants, process.stdout, process.stderr));

  const res = await fetch('http://127.0.0.1:3000/sparql', {
    method: 'POST',
    headers: { 'content-type': 'application/sparql-update' },
    body: 'INSERT { GRAPH <http://example.org/g> { ?s a <http://example.org/T> } } WHERE { ?s ?p ?o }',
  });
  console.log(res.status, await res.text());
})();
```

The execution is now memoized, so awaiting it and serializing it share a single run.

The two `process.send!` calls in the same method are also guarded. Outside a cluster worker `process.send` is `undefined`, so the snippet above throws `TypeError: process.send is not a function` before it reaches the engine, which makes the endpoint class unusable when it is embedded rather than started through `comunica-sparql-http`.