### PR TITLE
Resolve relative IRIs in endpoint requests against the endpoint

### DIFF
--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -7,6 +7,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import * as path from 'node:path';
 import * as querystring from 'node:querystring';
 import type { Writable } from 'node:stream';
+import type { TLSSocket } from 'node:tls';
 import * as url from 'node:url';
 import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import { ActionContext } from '@comunica/core';
@@ -474,7 +475,8 @@ export class HttpServiceSparqlEndpoint {
    * @return {string} The base IRI.
    */
   public static getBaseIRI(request: http.IncomingMessage, port: number): string {
-    return `http://${request.headers.host ?? `localhost:${port}`}/sparql`;
+    const protocol = (<TLSSocket> request.socket).encrypted ? 'https' : 'http';
+    return `${protocol}://${request.headers.host ?? `localhost:${port}`}/sparql`;
   }
 
   /**

--- a/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
+++ b/packages/actor-init-query/lib/HttpServiceSparqlEndpoint.ts
@@ -468,6 +468,16 @@ export class HttpServiceSparqlEndpoint {
   }
 
   /**
+   * Determine the base IRI that relative IRIs in a request are resolved against.
+   * @param {module:http.IncomingMessage} request Request object.
+   * @param {number} port The port this service is running on.
+   * @return {string} The base IRI.
+   */
+  public static getBaseIRI(request: http.IncomingMessage, port: number): string {
+    return `http://${request.headers.host ?? `localhost:${port}`}/sparql`;
+  }
+
+  /**
    * Writes the result of the given SPARQL query.
    * @param {QueryEngineBase} engine A SPARQL engine.
    * @param {module:stream.internal.Writable} stdout Output stream.
@@ -511,6 +521,7 @@ export class HttpServiceSparqlEndpoint {
 
     // Determine context
     let context = {
+      [KeysInitQuery.baseIRI.name]: HttpServiceSparqlEndpoint.getBaseIRI(request, this.port),
       ...this.context,
       ...this.contextOverride ? queryBody.context : undefined,
     };

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -1373,6 +1373,7 @@ describe('HttpServiceSparqlEndpoint', () => {
         request = Readable.from([ 'default_request_content' ]);
         request.url = '/sparql';
         request.headers = { host: 'localhost:3000' };
+        request.socket = {};
         query = {
           type: 'query',
           value: 'default_test_query',
@@ -2230,15 +2231,55 @@ INSERT DATA {
       });
     });
 
+    describe('a configured base IRI', () => {
+      it('should take precedence over the base IRI of the endpoint', async() => {
+        const engine = await new QueryEngineFactoryBase().create();
+        jest.spyOn(engine, 'query').mockImplementation(() => ({ resultType: 'bindings' }));
+        const response: any = new ServerResponseMock();
+        const request: any = Readable.from([ 'default_request_content' ]);
+        request.url = '/sparql';
+        request.headers = { host: 'localhost:3000' };
+        request.socket = {};
+        instance = new HttpServiceSparqlEndpoint({
+          ...argsDefault,
+          context: { '@comunica/actor-init-query:baseIRI': 'https://example.org/sparql' },
+        });
+
+        await instance.writeQueryResult(
+          engine,
+          new PassThrough(),
+          new PassThrough(),
+          request,
+          response,
+          { type: 'query', value: 'default_test_query', context: undefined },
+          '',
+          false,
+          false,
+          0,
+        );
+
+        expect(engine.query).toHaveBeenCalledWith('default_test_query', {
+          '@comunica/actor-init-query:baseIRI': 'https://example.org/sparql',
+        });
+      });
+    });
+
     describe('getBaseIRI', () => {
       it('should use the host and the path of the request', () => {
-        expect(HttpServiceSparqlEndpoint.getBaseIRI(<any> { headers: { host: 'example.org' }}, 3_000))
+        expect(HttpServiceSparqlEndpoint
+          .getBaseIRI(<any> { headers: { host: 'example.org' }, socket: {}}, 3_000))
           .toBe('http://example.org/sparql');
       });
 
       it('should fall back to the port of the service when the request has no host', () => {
-        expect(HttpServiceSparqlEndpoint.getBaseIRI(<any> { headers: {}}, 1_234))
+        expect(HttpServiceSparqlEndpoint.getBaseIRI(<any> { headers: {}, socket: {}}, 1_234))
           .toBe('http://localhost:1234/sparql');
+      });
+
+      it('should use https when the request was received over an encrypted socket', () => {
+        expect(HttpServiceSparqlEndpoint
+          .getBaseIRI(<any> { headers: { host: 'example.org' }, socket: { encrypted: true }}, 3_000))
+          .toBe('https://example.org/sparql');
       });
     });
 
@@ -2387,6 +2428,7 @@ INSERT DATA {
         request = Readable.from([ 'default_request_content' ]);
         request.url = '/sparql';
         request.method = 'GET';
+        request.socket = {};
         request.headers = {
           host: 'localhost:3000',
           accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',

--- a/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
+++ b/packages/actor-init-query/test/HttpServiceSparqlEndpoint-test.ts
@@ -2152,7 +2152,10 @@ INSERT DATA {
         );
 
         await expect(endCalledPromise).resolves.toBeFalsy();
-        expect(engine.query).toHaveBeenCalledWith('default_test_query', { [KeysQueryOperation.readOnly.name]: true });
+        expect(engine.query).toHaveBeenCalledWith('default_test_query', {
+          '@comunica/actor-init-query:baseIRI': 'http://localhost:3000/sparql',
+          [KeysQueryOperation.readOnly.name]: true,
+        });
       });
 
       it('should set not readOnly in the context if called with readOnly false', async() => {
@@ -2173,7 +2176,7 @@ INSERT DATA {
         );
 
         await expect(endCalledPromise).resolves.toBeFalsy();
-        expect(engine.query).toHaveBeenCalledWith('default_test_query', {});
+        expect(engine.query).toHaveBeenCalledWith('default_test_query', { '@comunica/actor-init-query:baseIRI': 'http://localhost:3000/sparql' });
       });
 
       it('should not override context entries by default', async() => {
@@ -2196,7 +2199,7 @@ INSERT DATA {
         );
 
         await expect(endCalledPromise).resolves.toBeFalsy();
-        expect(engine.query).toHaveBeenCalledWith('default_test_query', {});
+        expect(engine.query).toHaveBeenCalledWith('default_test_query', { '@comunica/actor-init-query:baseIRI': 'http://localhost:3000/sparql' });
       });
 
       it('should override context entries if contextOverride is enabled', async() => {
@@ -2220,7 +2223,22 @@ INSERT DATA {
         );
 
         await expect(endCalledPromise).resolves.toBeFalsy();
-        expect(engine.query).toHaveBeenCalledWith('default_test_query', { overrideKey: 'overrideValue' });
+        expect(engine.query).toHaveBeenCalledWith('default_test_query', {
+          '@comunica/actor-init-query:baseIRI': 'http://localhost:3000/sparql',
+          overrideKey: 'overrideValue',
+        });
+      });
+    });
+
+    describe('getBaseIRI', () => {
+      it('should use the host and the path of the request', () => {
+        expect(HttpServiceSparqlEndpoint.getBaseIRI(<any> { headers: { host: 'example.org' }}, 3_000))
+          .toBe('http://example.org/sparql');
+      });
+
+      it('should fall back to the port of the service when the request has no host', () => {
+        expect(HttpServiceSparqlEndpoint.getBaseIRI(<any> { headers: {}}, 1_234))
+          .toBe('http://localhost:1234/sparql');
       });
     });
 


### PR DESCRIPTION
Any request to the endpoint that contains a relative IRI is rejected, because the service does not define a base IRI to resolve them against.

```js
const http = require('node:http');
const { RdfStore } = require('rdf-stores');
const { QueryEngine } = require('@comunica/query-sparql');
const { HttpServiceSparqlEndpoint } = require('@comunica/actor-init-query');

(async() => {
  const store = RdfStore.createDefault(true);
  const engine = new QueryEngine();
  const variants = Object.entries(await engine.getResultMediaTypes())
    .map(([ type, quality ]) => ({ type, quality }));

  const server = http.createServer();
  await new Promise(resolve => server.listen(3000, '127.0.0.1', resolve));
  const service = new HttpServiceSparqlEndpoint({
    engine,
    port: 3000,
    context: { sources: [{ type: 'rdfjs', value: store }], destination: store },
  });
  server.on('request', service.handleRequest.bind(service, engine, variants, process.stdout, process.stderr));

  const res = await fetch('http://127.0.0.1:3000/sparql', {
    method: 'POST',
    headers: { 'content-type': 'application/sparql-update' },
    body: 'INSERT DATA { <s> <p> <o> }',
  });
  console.log(res.status, await res.text());
})();
```

Before:

```
400 Cannot resolve relative IRI s because no base IRI was set.
```

After:

```
200 ok
```

with `<s>` stored as `http://127.0.0.1:3000/s`.