### PR TITLE
Sort ORDER BY results in O(n log n) instead of O(n^2)

### DIFF
--- a/packages/actor-query-operation-orderby/lib/SortIterator.ts
+++ b/packages/actor-query-operation-orderby/lib/SortIterator.ts
@@ -20,6 +20,19 @@ export class SortIterator<T> extends TransformIterator<T, T> {
   // Reads the smallest item in the current sorting window
   public override _read(count: number, done: () => void): void {
     let item;
+
+    // Without a window, all items must be buffered before anything can be emitted anyway.
+    // Buffer them unsorted here and sort once in _flush, which is O(n log n).
+    // Maintaining the sorted array incrementally (below) would cost an O(n) splice per item.
+    if (this.windowLength === Number.POSITIVE_INFINITY) {
+      item = this.source!.read();
+      while (item !== null) {
+        this.sorted.push(item);
+        item = this.source!.read();
+      }
+      return done();
+    }
+
     let { length } = this.sorted;
     // Try to read items until we reach the desired window length
     while (length !== this.windowLength) {
@@ -56,6 +69,13 @@ export class SortIterator<T> extends TransformIterator<T, T> {
 
   // Flushes remaining data after the source has ended
   public override _flush(done: () => void): void {
+    if (this.windowLength === Number.POSITIVE_INFINITY) {
+      // Array.prototype.sort is stable, so sorting ascending and reversing keeps equal items
+      // in their original order once they are popped off the end below.
+      // Stability matters because ORDER BY with multiple expressions chains these iterators.
+      this.sorted.sort((left, right) => this.sort(left, right));
+      this.sorted.reverse();
+    }
     let { length } = this.sorted;
     while (length--) {
       this._push(this.sorted.pop()!);

--- a/packages/actor-query-operation-orderby/test/SortIterator-test.ts
+++ b/packages/actor-query-operation-orderby/test/SortIterator-test.ts
@@ -1,0 +1,86 @@
+import arrayifyStream from 'arrayify-stream';
+import { ArrayIterator } from 'asynciterator';
+import { SortIterator } from '../lib/SortIterator';
+
+const ascending = (left: number, right: number): number => left - right;
+
+describe('SortIterator', () => {
+  describe('without a window', () => {
+    it('should sort an unsorted stream', async() => {
+      const iterator = new SortIterator(
+        new ArrayIterator([ 3, 1, 2 ], { autoStart: false }),
+        ascending,
+      );
+      await expect(arrayifyStream(iterator)).resolves.toEqual([ 1, 2, 3 ]);
+    });
+
+    it('should handle an empty stream', async() => {
+      const iterator = new SortIterator(
+        new ArrayIterator<number>([], { autoStart: false }),
+        ascending,
+      );
+      await expect(arrayifyStream(iterator)).resolves.toEqual([]);
+    });
+
+    it('should keep equal items in their original order', async() => {
+      // ORDER BY with multiple expressions chains these iterators,
+      // so the order of equal items must carry over from the previous pass.
+      const items = [
+        { key: 2, id: 'a' },
+        { key: 1, id: 'b' },
+        { key: 2, id: 'c' },
+        { key: 1, id: 'd' },
+        { key: 2, id: 'e' },
+      ];
+      const iterator = new SortIterator(
+        new ArrayIterator(items, { autoStart: false }),
+        (left, right) => left.key - right.key,
+      );
+      await expect(arrayifyStream(iterator).then(results => results.map(item => item.id))).resolves
+        .toEqual([ 'b', 'd', 'a', 'c', 'e' ]);
+    });
+
+    it('should sort a large stream', async() => {
+      const items: number[] = [];
+      for (let i = 0; i < 10_000; i++) {
+        items.push((i * 7919) % 10_000);
+      }
+      const iterator = new SortIterator(
+        new ArrayIterator(items, { autoStart: false }),
+        ascending,
+      );
+      const results = await arrayifyStream<number>(iterator);
+      expect(results).toHaveLength(10_000);
+      expect(results).toEqual([ ...items ].sort(ascending));
+    });
+  });
+
+  describe('with a window', () => {
+    it('should sort within the window', async() => {
+      const iterator = new SortIterator(
+        new ArrayIterator([ 3, 1, 2 ], { autoStart: false }),
+        ascending,
+        { window: 2 },
+      );
+      await expect(arrayifyStream(iterator)).resolves.toEqual([ 1, 2, 3 ]);
+    });
+
+    it('should sort within a window wider than the out-of-order run', async() => {
+      const iterator = new SortIterator(
+        new ArrayIterator([ 1, 3, 2, 2 ], { autoStart: false }),
+        ascending,
+        { window: 3 },
+      );
+      await expect(arrayifyStream(iterator)).resolves.toEqual([ 1, 2, 2, 3 ]);
+    });
+
+    it('should not sort beyond the window', async() => {
+      const iterator = new SortIterator(
+        new ArrayIterator([ 2, 3, 1 ], { autoStart: false }),
+        ascending,
+        { window: 1 },
+      );
+      await expect(arrayifyStream(iterator)).resolves.toEqual([ 2, 3, 1 ]);
+    });
+  });
+});

--- a/performance/benchmark-web/combinations/combination_0/input/queries/dbpedia/people-cambridge-pairs-orderby.sparql
+++ b/performance/benchmark-web/combinations/combination_0/input/queries/dbpedia/people-cambridge-pairs-orderby.sparql
@@ -1,0 +1,10 @@
+# The first pairs of distinct people born in Cambridge, by URI order
+# ORDER BY has no top-k, so this sorts all ~86k solutions in the engine
+# Datasource: https://fragments.dbpedia.org/2016-04/en
+SELECT ?person1 ?person2 WHERE {
+  ?person1 dbpedia-owl:birthPlace dbpedia:Cambridge.
+  ?person2 dbpedia-owl:birthPlace dbpedia:Cambridge.
+  FILTER(?person1 != ?person2)
+}
+ORDER BY ?person1 ?person2
+LIMIT 10

--- a/performance/benchmark-web/combinations/combination_1/input/queries/dbpedia/people-cambridge-pairs-orderby.sparql
+++ b/performance/benchmark-web/combinations/combination_1/input/queries/dbpedia/people-cambridge-pairs-orderby.sparql
@@ -1,0 +1,10 @@
+# The first pairs of distinct people born in Cambridge, by URI order
+# ORDER BY has no top-k, so this sorts all ~86k solutions in the engine
+# Datasource: https://fragments.dbpedia.org/2016-04/en
+SELECT ?person1 ?person2 WHERE {
+  ?person1 dbpedia-owl:birthPlace dbpedia:Cambridge.
+  ?person2 dbpedia-owl:birthPlace dbpedia:Cambridge.
+  FILTER(?person1 != ?person2)
+}
+ORDER BY ?person1 ?person2
+LIMIT 10

--- a/performance/benchmark-web/input/queries/dbpedia/people-cambridge-pairs-orderby.sparql
+++ b/performance/benchmark-web/input/queries/dbpedia/people-cambridge-pairs-orderby.sparql
@@ -1,0 +1,10 @@
+# The first pairs of distinct people born in Cambridge, by URI order
+# ORDER BY has no top-k, so this sorts all ~86k solutions in the engine
+# Datasource: https://fragments.dbpedia.org/2016-04/en
+SELECT ?person1 ?person2 WHERE {
+  ?person1 dbpedia-owl:birthPlace dbpedia:Cambridge.
+  ?person2 dbpedia-owl:birthPlace dbpedia:Cambridge.
+  FILTER(?person1 != ?person2)
+}
+ORDER BY ?person1 ?person2
+LIMIT 10


### PR DESCRIPTION
## Problem

`SortIterator` inserts every item into a sorted array with a binary search followed by an `Array.prototype.splice`. The search is O(log n), but the splice moves O(n) elements, so sorting n results costs O(n²) element moves.

With a sliding `window` this is bounded by the window size. But the window defaults to unbounded, and that is what every ORDER BY uses in practice.

Measured with a primitive comparator:

| n | current | `Array.prototype.sort` | ratio |
|---|---|---|---|
| 10 000 | 17 ms | 4 ms | 4.3× |
| 50 000 | 119 ms | 32 ms | 3.7× |
| 100 000 | 423 ms | 50 ms | 8.5× |
| 200 000 | 1 859 ms | 104 ms | 17.9× |
| 400 000 | 10 438 ms | 289 ms | 36.1× |

Doubling n multiplies the time by 4.4× then 5.6×, so the ratio keeps widening. It is invisible below ~50k results, which is why `benchmark-watdiv-file` (scale 10) and `benchmark-bsbm-file` (1 000 products) never show it.

## Change

When the window is unbounded, nothing can be emitted before the source ends anyway, so there is no reason to maintain the array in sorted order while reading. Buffer the items unsorted in `_read` and sort once in `_flush`.

The windowed path is untouched.

### Stability

`Array.prototype.sort` is stable, so the new path sorts ascending and then reverses, which keeps equal items in their original order once they are popped off the end — matching what the drain loop in `_flush` already expects.

This matters because `ActorQueryOperationOrderBy` chains one `SortIterator` per ORDER BY expression, so each pass has to preserve the order established by the previous one. The existing multiple-comparator tests catch it if this is wrong; `test/SortIterator-test.ts` also asserts it directly.

## Results

| Workload | Before | After |
|---|---|---|
| 400k rows, primitive comparator | 10 438 ms | 390 ms |
| 200k rows, real term comparator | 32 483 ms | 8 520 ms |
| 10M-triple in-memory store, `ORDER BY ?l` over 152k rows | 32 226 ms | 10 258 ms |
| 10M-triple in-memory store, `ORDER BY ?l LIMIT 10` | 25 635 ms | 9 278 ms |

## Benchmark coverage

Every query in `benchmark-web` sorts at most a few hundred solutions, so nothing in the performance suite would have caught this — at those sizes the insertion sort is as fast as anything else.

`performance/benchmark-web/input/queries/dbpedia/people-cambridge-pairs-orderby.sparql` self-joins the people born in Cambridge into ~86k pairs and orders them. The `LIMIT 10` keeps the endpoint response and the recorded `query-times.csv` small (1 KB rather than 5 MB) without making the sort any cheaper, since ORDER BY has no top-k and materialises the whole result set either way.

Measured with `jbr run -c 0 -f cambridge`, mean of 3 replications after 1 warmup:

| | mean | runs |
|---|---|---|
| insertion sort | **11 861 ms** | 11 969 / 12 266 / 11 347 |
| this branch | **4 913 ms** | 4 847 / 5 022 / 4 871 |

2.4× faster, −6.9 s. It costs 4 HTTP requests (294 triples over TPF), so ~19 s of the `benchmark-web` job across the warmup and 3 replications. That makes it the heaviest query in that suite — the rest are 22 ms to 1 s — which is the price of having one query in the suite whose cost is dominated by sorting rather than by fetching. Happy to size it down (York instead of Cambridge gives ~5 s → ~2 s on the same shape) if that is too much.

## Tests

Adds `test/SortIterator-test.ts` covering ordering, stability of equal items, an empty stream, a large stream, and the windowed paths. `SortIterator.ts` stays at 100% statement/branch/function/line coverage, and the full suite passes.

## Follow-ups (not in this PR)

Two related issues showed up while measuring, both worth their own change:

- **The LIMIT is not pushed into the sort.** `explain physical` for `SELECT ?l WHERE { ?s rdfs:label ?l } ORDER BY ?l LIMIT 10` is `slice → project → orderby → pattern`, so the full result set is materialised and sorted to return 10 rows. `SortIterator` already supports a bounded `window`, so an optimize-query-operation actor that rewrites `slice(orderby(x))` into an order-by carrying `window = offset + limit` would turn this into top-k. That is why the `LIMIT 10` row above is still 9.3 s. (It is also what the new benchmark query relies on, so that query would need revisiting when top-k lands — it would record the improvement rather than guard the sort.)
- **The comparator dominates once the quadratic behaviour is gone.** After this change, a 200k-row sort spends ~2 280 ns per comparison in the term comparator against ~45 ns for a primitive compare. `ActorQueryOperationOrderBy` already visits every binding once to evaluate the sort expression; deriving a comparable primitive key there would make each comparison primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fVTUvQ2uCR1p4KQxAYrgs