### PR TITLE
Cap join cardinality estimates using the entries' shared variables

### DIFF
--- a/packages/actor-rdf-join-inner-hash/test/ActorRdfJoinHash-test.ts
+++ b/packages/actor-rdf-join-inner-hash/test/ActorRdfJoinHash-test.ts
@@ -431,8 +431,10 @@ IActorRdfJoinSelectivityOutput
       await actor.run(action, await getSideData(action)).then(async(result: IQueryOperationResultBindings) => {
         await expect((<any> result).metadata()).resolves.toHaveProperty('cardinality', {
           type: 'estimate',
-          value: (await (<any> action.entries[0].output).metadata()).cardinality.value *
-          (await (<any> action.entries[1].output).metadata()).cardinality.value,
+          value: Math.min(
+            (await (<any> action.entries[0].output).metadata()).cardinality.value,
+            (await (<any> action.entries[1].output).metadata()).cardinality.value,
+          ),
         });
 
         await expect(result.bindingsStream.toArray()).resolves.toEqual([]);
@@ -444,7 +446,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves
           .toEqual({
             state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 20 },
+            cardinality: { type: 'estimate', value: 4 },
 
             variables: [
               { variable: DF.variable('a'), canBeUndef: false },
@@ -485,7 +487,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves
           .toEqual({
             state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 20 },
+            cardinality: { type: 'estimate', value: 4 },
 
             variables: [
               { variable: DF.variable('a'), canBeUndef: false },
@@ -533,7 +535,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -656,7 +658,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -736,7 +738,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves
           .toEqual({
             state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 20 },
+            cardinality: { type: 'estimate', value: 4 },
 
             variables: [
               { variable: DF.variable('a'), canBeUndef: false },
@@ -1222,8 +1224,10 @@ IActorRdfJoinSelectivityOutput
       await actor.run(action, await getSideData(action)).then(async(result: IQueryOperationResultBindings) => {
         await expect((<any> result).metadata()).resolves.toHaveProperty('cardinality', {
           type: 'estimate',
-          value: (await (<any> action.entries[0].output).metadata()).cardinality.value *
+          value: Math.min(
+            (await (<any> action.entries[0].output).metadata()).cardinality.value,
             (await (<any> action.entries[1].output).metadata()).cardinality.value,
+          ),
         });
 
         await expect(result.bindingsStream.toArray()).resolves.toEqual([]);
@@ -1235,7 +1239,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves
           .toEqual({
             state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 20 },
+            cardinality: { type: 'estimate', value: 4 },
             variables: [
               { variable: DF.variable('a'), canBeUndef: false },
               { variable: DF.variable('b'), canBeUndef: false },
@@ -1275,7 +1279,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves
           .toEqual({
             state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 20 },
+            cardinality: { type: 'estimate', value: 4 },
             variables: [
               { variable: DF.variable('a'), canBeUndef: true },
               { variable: DF.variable('b'), canBeUndef: false },
@@ -1321,7 +1325,7 @@ IActorRdfJoinSelectivityOutput
       await actor.run(action, await getSideData(action)).then(async(output: IQueryOperationResultBindings) => {
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: true },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1443,7 +1447,7 @@ IActorRdfJoinSelectivityOutput
         ];
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: true },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1523,7 +1527,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves
           .toEqual({
             state: expect.any(MetadataValidationState),
-            cardinality: { type: 'estimate', value: 20 },
+            cardinality: { type: 'estimate', value: 4 },
 
             variables: [
               { variable: DF.variable('a'), canBeUndef: false },
@@ -1591,7 +1595,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1658,7 +1662,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1707,7 +1711,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1774,7 +1778,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1821,7 +1825,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1877,7 +1881,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -1933,7 +1937,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -2003,7 +2007,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -2075,7 +2079,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -2155,7 +2159,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -2231,7 +2235,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },

--- a/packages/actor-rdf-join-inner-multi-bind-source/test/ActorRdfJoinMultiBindSource-test.ts
+++ b/packages/actor-rdf-join-inner-multi-bind-source/test/ActorRdfJoinMultiBindSource-test.ts
@@ -216,7 +216,7 @@ describe('ActorRdfJoinMultiBindSource', () => {
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 9.600_000_000_000_001 },
+          cardinality: { type: 'estimate', value: 3 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -332,7 +332,7 @@ describe('ActorRdfJoinMultiBindSource', () => {
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 9.600_000_000_000_001 },
+          cardinality: { type: 'estimate', value: 3 },
 
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },

--- a/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
@@ -1166,7 +1166,7 @@ IQueryOperationResultBindings
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 240 },
+          cardinality: { type: 'estimate', value: 1 },
 
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
@@ -1335,7 +1335,7 @@ IQueryOperationResultBindings
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 240 },
+          cardinality: { type: 'estimate', value: 1 },
 
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
@@ -1446,7 +1446,7 @@ IQueryOperationResultBindings
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 240 },
+          cardinality: { type: 'estimate', value: 1 },
 
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
@@ -1542,7 +1542,7 @@ IQueryOperationResultBindings
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 240 },
+          cardinality: { type: 'estimate', value: 1 },
 
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
@@ -1664,7 +1664,7 @@ IQueryOperationResultBindings
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 96000 },
+          cardinality: { type: 'estimate', value: 0.75 },
 
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },

--- a/packages/actor-rdf-join-inner-multi-sequential/test/ActorRdfJoinMultiSequential-test.ts
+++ b/packages/actor-rdf-join-inner-multi-sequential/test/ActorRdfJoinMultiSequential-test.ts
@@ -330,7 +330,7 @@ IActorRdfJoinSelectivityOutput
       expect(output.type).toBe('bindings');
       await expect((<any> output).metadata()).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 40 },
+        cardinality: { type: 'estimate', value: 2 },
 
         variables: [
           { variable: DF.variable('a'), canBeUndef: false },
@@ -362,7 +362,7 @@ IActorRdfJoinSelectivityOutput
       expect(output.type).toBe('bindings');
       await expect((<any> output).metadata()).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 80 },
+        cardinality: { type: 'estimate', value: 2 },
 
         variables: [
           { variable: DF.variable('a'), canBeUndef: false },

--- a/packages/actor-rdf-join-inner-multi-smallest-filter-bindings/test/ActorRdfJoinMultiSmallestFilterBindings-test.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest-filter-bindings/test/ActorRdfJoinMultiSmallestFilterBindings-test.ts
@@ -493,7 +493,7 @@ describe('ActorRdfJoinMultiSmallestFilterBindings', () => {
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 1.6 },
+          cardinality: { type: 'estimate', value: 1 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -583,7 +583,7 @@ describe('ActorRdfJoinMultiSmallestFilterBindings', () => {
         ]);
         await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 1.6 },
+          cardinality: { type: 'estimate', value: 1 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },

--- a/packages/actor-rdf-join-inner-multi-smallest/test/ActorRdfJoinMultiSmallest-test.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest/test/ActorRdfJoinMultiSmallest-test.ts
@@ -519,7 +519,7 @@ IActorRdfJoinSelectivityOutput
       expect(output.type).toBe('bindings');
       await expect((<any> output).metadata()).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 40 },
+        cardinality: { type: 'estimate', value: 2 },
 
         variables: [
           { variable: DF.variable('a'), canBeUndef: false },
@@ -553,7 +553,7 @@ IActorRdfJoinSelectivityOutput
       expect(output.type).toBe('bindings');
       await expect((<any> output).metadata()).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 80 },
+        cardinality: { type: 'estimate', value: 2 },
 
         variables: [
           { variable: DF.variable('a'), canBeUndef: false },

--- a/packages/actor-rdf-join-inner-symmetrichash/test/ActorRdfJoinSymmetricHash-test.ts
+++ b/packages/actor-rdf-join-inner-symmetrichash/test/ActorRdfJoinSymmetricHash-test.ts
@@ -286,8 +286,10 @@ IActorRdfJoinSelectivityOutput
       await actor.run(action, undefined!).then(async(result: IQueryOperationResultBindings) => {
         await expect((<any> result).metadata()).resolves.toHaveProperty('cardinality', {
           type: 'estimate',
-          value: (await (<any> action.entries[0].output).metadata()).cardinality.value *
-          (await (<any> action.entries[1].output).metadata()).cardinality.value,
+          value: Math.min(
+            (await (<any> action.entries[0].output).metadata()).cardinality.value,
+            (await (<any> action.entries[1].output).metadata()).cardinality.value,
+          ),
         });
 
         await expect(result.bindingsStream.toArray()).resolves.toEqual([]);
@@ -299,7 +301,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -339,7 +341,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -386,7 +388,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },
@@ -509,7 +511,7 @@ IActorRdfJoinSelectivityOutput
         await expect(output.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
 
-          cardinality: { type: 'estimate', value: 20 },
+          cardinality: { type: 'estimate', value: 4 },
           variables: [
             { variable: DF.variable('a'), canBeUndef: false },
             { variable: DF.variable('b'), canBeUndef: false },

--- a/packages/bus-rdf-join/lib/ActorRdfJoin.ts
+++ b/packages/bus-rdf-join/lib/ActorRdfJoin.ts
@@ -232,6 +232,42 @@ TS
   }
 
   /**
+   * Estimate the cardinality of an equi-join from the cardinalities of its entries.
+   *
+   * Under the usual uniformity assumption, joining two entries on a shared variable divides their cross product by
+   * the number of distinct values that variable takes. That number is unknown here, so it is approximated by the
+   * cardinality of the largest entry binding the variable, which is its upper bound. For two entries sharing a
+   * variable this yields the cardinality of the smaller entry.
+   *
+   * Only the most selective shared variable is taken into account. Entries sharing several variables are more
+   * selective still, but applying the approximation once per variable compounds its error, which would collapse
+   * the estimate far below the smallest entry.
+   *
+   * @param metadatas Metadata of the join entries.
+   * @return The estimated cardinality, or undefined if the entries share no variables.
+   */
+  public static getSharedVariableJoinCardinality(metadatas: MetadataBindings[]): number | undefined {
+    // Collect, per variable, the cardinalities of the entries binding it
+    const cardinalitiesByVariable: Record<string, number[]> = {};
+    for (const metadata of metadatas) {
+      for (const { variable } of metadata.variables) {
+        (cardinalitiesByVariable[variable.value] ??= []).push(metadata.cardinality.value);
+      }
+    }
+
+    let divisor = 0;
+    for (const cardinalities of Object.values(cardinalitiesByVariable)) {
+      if (cardinalities.length > 1) {
+        divisor = Math.max(divisor, Math.max(...cardinalities) ** (cardinalities.length - 1));
+      }
+    }
+    if (divisor === 0) {
+      return undefined;
+    }
+    return metadatas.reduce((acc, metadata) => acc * metadata.cardinality.value, 1) / divisor;
+  }
+
+  /**
    * Helper function to create a new metadata object for the join result.
    * For required metadata entries that are not provided, sane defaults are calculated.
    * @param entries Join entries.
@@ -266,6 +302,16 @@ TS
       // The cardinality should only be zero if one of the entries has zero cardinality, not due to float overflow
       if (!hasZeroCardinality || optional) {
         cardinalityJoined.value *= (await this.mediatorJoinSelectivity.mediate({ entries, context })).selectivity;
+        if (!optional) {
+          // The selectivity heuristic is purely structural, so it can only scale down the cross product by a
+          // constant factor, no matter how large the entries are. Cap the estimate with one that does look at the
+          // cardinalities, so that joining two large entries on a shared variable is not estimated as their product.
+          const capped = ActorRdfJoin.getSharedVariableJoinCardinality(metadatas);
+          if (capped !== undefined && capped < cardinalityJoined.value) {
+            cardinalityJoined.value = capped;
+            cardinalityJoined.type = 'estimate';
+          }
+        }
         if (cardinalityJoined.value === 0) {
           cardinalityJoined.value = Number.MIN_VALUE;
         }

--- a/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
+++ b/packages/bus-rdf-join/test/ActorRdfJoin-test.ts
@@ -738,6 +738,46 @@ IActorRdfJoinSelectivityOutput
     });
   });
 
+  describe('getSharedVariableJoinCardinality', () => {
+    function meta(value: number, ...names: string[]) {
+      return {
+        state: new MetadataValidationState(),
+        cardinality: { type: <const> 'estimate', value },
+        variables: names.map(name => ({ variable: DF.variable(name), canBeUndef: false })),
+      };
+    }
+
+    it('should be undefined without shared variables', () => {
+      expect(ActorRdfJoin.getSharedVariableJoinCardinality([ meta(10, 'a'), meta(5, 'b') ]))
+        .toBeUndefined();
+    });
+
+    it('should be undefined without variables', () => {
+      expect(ActorRdfJoin.getSharedVariableJoinCardinality([ meta(10), meta(5) ]))
+        .toBeUndefined();
+    });
+
+    it('should be the smallest cardinality for two entries sharing a variable', () => {
+      expect(ActorRdfJoin.getSharedVariableJoinCardinality([ meta(10, 'a'), meta(5, 'a') ]))
+        .toBe(5);
+    });
+
+    it('should divide by the largest cardinality once per additional entry sharing a variable', () => {
+      expect(ActorRdfJoin.getSharedVariableJoinCardinality([ meta(10, 'a'), meta(5, 'a'), meta(4, 'a') ]))
+        .toBe(2);
+    });
+
+    it('should divide by the most selective shared variable only', () => {
+      expect(ActorRdfJoin.getSharedVariableJoinCardinality([ meta(10, 'a', 'b'), meta(5, 'a', 'b') ]))
+        .toBe(5);
+    });
+
+    it('should keep the cross product of entries that share nothing with the others', () => {
+      expect(ActorRdfJoin.getSharedVariableJoinCardinality([ meta(10, 'a'), meta(5, 'a'), meta(3, 'b') ]))
+        .toBe(15);
+    });
+  });
+
   describe('constructResultMetadata', () => {
     let instance: Dummy;
 
@@ -776,7 +816,7 @@ IActorRdfJoinSelectivityOutput
         },
       ], action.context, {})).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 20 * 0.8 },
+        cardinality: { type: 'estimate', value: 2 },
         variables: [{ variable: DF.variable('a'), canBeUndef: true }],
       });
       await expect(instance.constructResultMetadata([], [
@@ -792,7 +832,7 @@ IActorRdfJoinSelectivityOutput
         },
       ], action.context, {})).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 20 * 0.8 },
+        cardinality: { type: 'estimate', value: 2 },
         variables: [{ variable: DF.variable('a'), canBeUndef: true }],
       });
       await expect(instance.constructResultMetadata([], [
@@ -810,7 +850,7 @@ IActorRdfJoinSelectivityOutput
         },
       ], action.context, {})).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'estimate', value: 20 * 0.8 },
+        cardinality: { type: 'estimate', value: 2 },
 
         variables: [{ variable: DF.variable('a'), canBeUndef: false }],
       });
@@ -915,7 +955,7 @@ IActorRdfJoinSelectivityOutput
         },
       ], action.context, {})).resolves.toEqual({
         state: expect.any(MetadataValidationState),
-        cardinality: { type: 'exact', value: 20 * 0.8 },
+        cardinality: { type: 'estimate', value: 2 },
         variables: [
           { variable: DF.variable('a'), canBeUndef: false },
           { variable: DF.variable('b'), canBeUndef: true },
@@ -1141,7 +1181,7 @@ IActorRdfJoinSelectivityOutput
       await instance.run(action, undefined!).then(async(result: any) => {
         return await expect(result.metadata()).resolves.toEqual({
           state: expect.any(MetadataValidationState),
-          cardinality: { type: 'estimate', value: 40 },
+          cardinality: { type: 'estimate', value: 5 },
           variables: [{ variable: DF.variable('a'), canBeUndef: true }],
         });
       });


### PR DESCRIPTION
## Problem

`ActorRdfJoin.constructResultMetadata` estimates a join's cardinality as the cross product of its entries scaled by the join selectivity. The default selectivity actor, `ActorRdfJoinSelectivityVariableCounting`, is purely structural: it looks at which triple pattern positions are variables and which are shared, and never at how large the entries actually are. It therefore returns the same constant factor whether the entries hold ten results or ten million, and the estimate grows quadratically with the data.

Two examples measured on WatDiv scale 100 (10.9M triples) over HDT:

| join | estimate | true cardinality |
|---|---:|---:|
| WatDiv S5 | `807 × 1460 × 0.2785` ≈ 328 000 | 0 |
| WatDiv C2 | `108 × 119 316 × 0.5459` ≈ 7 034 000 | 10 533 |

Those estimates feed `getJoinCoefficients` on every join actor, so the planner picks its plan from numbers that are wrong by two to three orders of magnitude.

## Change

Cap the estimate with a second one derived from the cardinalities themselves.

Under the uniformity assumption, joining on a shared variable divides the cross product by the number of distinct values that variable takes. That count is unknown here, so it is approximated by the cardinality of the largest entry binding the variable, which is its upper bound. For a two-way join this yields the smaller entry's cardinality.

Only the most selective shared variable is used. Entries sharing several variables are more selective still, but applying the approximation once per variable compounds its error and collapses the estimate far below the smallest entry (an early revision of this patch estimated a join of two 10- and 5-result entries sharing two variables at 0.5).

The cap only ever lowers the estimate, so a join is never estimated higher than it is today, and it is skipped for optional joins, whose result cannot be smaller than their left entry.

The selectivity bus is untouched. `ActorRdfJoinEntriesSortSelectivity` uses selectivity as a ranking score, where a cardinality-aware value would invert the ordering, so the correction belongs in the cardinality calculation rather than in a selectivity actor.

## Measurements

Best of two rounds, WatDiv scale 100 (10.9M triples) and BSBM 100K products (35.3M triples), both over an HDT source. Result counts are identical to master for all 31 queries under every variant measured.

| query | master (ms) | patched (ms) | ratio |
|---|---:|---:|---:|
| watdiv-S5 | 2016 | 356 | **0.18** |
| watdiv-S2 | 10877 | 5209 | **0.48** |
| watdiv-C1 | 2207 | 2142 | 0.97 |
| watdiv-C2 | 7069 | 6638 | 0.94 |
| watdiv-C3 | 20068 | 19316 | 0.96 |
| watdiv-F1 | 218 | 216 | 0.99 |
| watdiv-F2 | 41 | 39 | 0.95 |
| watdiv-F3 | 37 | 36 | 0.97 |
| watdiv-F4 | 154 | 151 | 0.98 |
| watdiv-F5 | 77 | 77 | 1.00 |
| watdiv-L1 | 12 | 11 | 0.92 |
| watdiv-L2 | 26 | 22 | 0.85 |
| watdiv-L3 | 3 | 3 | 1.00 |
| watdiv-L4 | 25 | 25 | 1.00 |
| watdiv-L5 | 67 | 67 | 1.00 |
| watdiv-S1 | 46 | 46 | 1.00 |
| watdiv-S3 | 190 | 210 | 1.11 |
| watdiv-S4 | 52 | 54 | 1.04 |
| watdiv-S6 | 16 | 17 | 1.06 |
| watdiv-S7 | 1 | 1 | 1.00 |
| bsbm-Q1 | 667 | 627 | 0.94 |
| bsbm-Q2 | 23 | 25 | 1.09 |
| bsbm-Q3 | 1517 | 1428 | 0.94 |
| bsbm-Q4 | 1243 | 1187 | 0.95 |
| bsbm-Q5 | 4231 | 4093 | 0.97 |
| bsbm-Q7 | 95 | 86 | 0.91 |
| bsbm-Q8 | 67 | 68 | 1.01 |
| bsbm-Q9 | 2 | 2 | 1.00 |
| bsbm-Q10 | 60 | 60 | 1.00 |
| bsbm-Q11 | 2 | 2 | 1.00 |
| bsbm-Q12 | 7 | 7 | 1.00 |

The two large wins are exactly the queries whose plans the bad estimates were misdirecting. Every remaining entry above 1.00 is a query running in tens of milliseconds, where the difference is a few milliseconds of run-to-run variance rather than a plan change.

## Caveats

- The cap can produce a cardinality below 1 for a multi-way join containing a very small entry. The existing calculation already produces fractional cardinalities, so this is not new, but it remains meaningless as a count.
- Using an entry's cardinality as a proxy for its distinct-value count is an upper bound, which makes the cap conservative rather than accurate. Real distinct counts from the source would be a strictly better input, and this change is compatible with supplying them later.

## Tests

The full test suite passes (6817 tests) with coverage thresholds intact. 41 tests across seven join actors asserted the old cross-product cardinalities and were updated to the new expectations; `getSharedVariableJoinCardinality` has its own unit tests covering the no-shared-variable, two-entry, multi-entry and multi-variable cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fVTUvQ2uCR1p4KQxAYrgs


---
_Generated by [Claude Code](https://claude.ai/code/session_019fVTUvQ2uCR1p4KQxAYrgs)_