### PR TITLE
Keep endpoint logs out of the generated EARL reports

### DIFF
--- a/packages/actor-init-query/spec/sparql-engine-base.js
+++ b/packages/actor-init-query/spec/sparql-engine-base.js
@@ -165,7 +165,8 @@ function createEndpointStarter(engine, createContext = () => ({})) {
     }
 
     const service = new HttpServiceSparqlEndpoint({ engine, port: address.port, context: createContext() });
-    server.on('request', service.handleRequest.bind(service, engine, variants, process.stdout, process.stderr));
+    // The endpoint logs to stderr, so that its output does not end up in the EARL reports on stdout
+    server.on('request', service.handleRequest.bind(service, engine, variants, process.stderr, process.stderr));
 
     endpoint = `http://127.0.0.1:${address.port}/sparql`;
     return { close, endpoint };


### PR DESCRIPTION
`spec-earl:sd-1-1` and `spec-earl:prot-1-1` redirect stdout into the EARL report, but the spec harness binds the SPARQL endpoint's log stream to stdout as well. Every request the endpoint serves is prepended to the report, so the file it
produces is not valid Turtle:

```
earl-sd-1-1.ttl
[200] GET to /sparql
      Requested media type: application/ld+json
      Received query for service description.
```