### PR TITLE
Cost the multi-smallest join by the plan it builds

### DIFF
--- a/packages/actor-rdf-join-inner-multi-smallest/lib/ActorRdfJoinMultiSmallest.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest/lib/ActorRdfJoinMultiSmallest.ts
@@ -125,8 +125,19 @@ export class ActorRdfJoinMultiSmallest extends ActorRdfJoin<IActorRdfJoinMultiSm
     const requestInitialTimes = ActorRdfJoin.getRequestInitialTimes(metadatas);
     const requestItemTimes = ActorRdfJoin.getRequestItemTimes(metadatas);
 
+    // This actor joins the entries one at a time, in the order they were just sorted into: it joins the first two,
+    // then joins that result with the third, and so on. Each of those joins reads both of its inputs, so the work
+    // is the size of the result so far plus the size of the entry being added to it, summed over the steps.
+    // Entries are joined on a variable they share, so a join produces at most as many rows as its smaller input.
+    let rows = metadatas[0].cardinality.value;
+    let iterations = rows;
+    for (const metadata of metadatas.slice(1)) {
+      iterations += rows + metadata.cardinality.value;
+      rows = Math.min(rows, metadata.cardinality.value);
+    }
+
     return passTestWithSideData({
-      iterations: metadatas.reduce((acc, metadata) => acc * metadata.cardinality.value, 1),
+      iterations,
       persistedItems: 0,
       blockingItems: 0,
       requestTime: metadatas.reduce((sum, metadata, i) => sum + requestInitialTimes[i] +

--- a/packages/actor-rdf-join-inner-multi-smallest/test/ActorRdfJoinMultiSmallest-test.ts
+++ b/packages/actor-rdf-join-inner-multi-smallest/test/ActorRdfJoinMultiSmallest-test.ts
@@ -480,7 +480,7 @@ IActorRdfJoinSelectivityOutput
     it('should test on 3 streams', async() => {
       const action = action3();
       await expect(actor.test(action)).resolves.toPassTest({
-        iterations: 40,
+        iterations: 15,
         persistedItems: 0,
         blockingItems: 0,
         requestTime: 2,
@@ -493,7 +493,7 @@ IActorRdfJoinSelectivityOutput
     it('should test on 4 streams', async() => {
       const action = action4();
       await expect(actor.test(action)).resolves.toPassTest({
-        iterations: 80,
+        iterations: 19,
         persistedItems: 0,
         blockingItems: 0,
         requestTime: 2.8,
@@ -506,7 +506,7 @@ IActorRdfJoinSelectivityOutput
     it('should test 4 streams when vars disjoint in 2 smallest', async() => {
       const action = action5();
       await expect(actor.test(action)).resolves.toPassTest({
-        iterations: 840,
+        iterations: 34,
         persistedItems: 0,
         blockingItems: 0,
         requestTime: 6,


### PR DESCRIPTION
`ActorRdfJoinMultiSmallest` joins its entries two at a time over shared variables, mediating each of those joins on the join bus, so every one of them is free to pick a hash join, a bind join, or anything else. It reported the cross product of all its entries as its cost, which is not a plan that any of them would execute.

For an eight-pattern WatDiv query over 10M triples that came to 1.4e34 iterations, against 5.3e5 for the multi-way bind join. The tree of binary joins could not win however much cheaper it actually was.

So the bind join took those queries, and re-planned the same bound sub-pattern once per binding: 2501 times over 7 distinct operation shapes for C1, and 40297 times over a single shape for S2. That planning asks the source for cardinalities far more often than the execution asks it for data. C1 made **25779 `countTriples` calls against 1673 `searchBindings` calls**, and a CPU profile split its time about evenly between reading data (~1119 ms) and bus dispatch plus algebra rebuilding (~1100 ms).

## The change

The cost is now the sum of what the binary joins read, with each step bounded by the variable the two entries share, the same assumption `getSharedVariableJoinCardinality` makes for a pair.

## Measurements

Best-of-3 after a warmup round, on the WatDiv-10 dataset used by the performance benchmarks, scaled to 10M triples for the HDT runs. Result counts are identical to master on every query of every benchmark.

### WatDiv 10M over HDT

| query | master | this PR | ratio |
|-|-|-|-|
| C1 | 2552 ms | 1765 ms | 0.69 |
| C2 | 9065 ms | 6175 ms | 0.68 |
| C3 | 27527 ms | 12536 ms | 0.46 |
| F1 | 353 ms | 231 ms | 0.65 |
| F2 | 85 ms | 55 ms | 0.65 |
| F3 | 69 ms | 52 ms | 0.75 |
| F4 | 237 ms | 156 ms | 0.66 |
| F5 | 147 ms | 111 ms | 0.76 |
| L1 | 29 ms | 23 ms | 0.79 |
| L2 | 96 ms | 60 ms | 0.62 |
| L3 | 8 ms | 5 ms | 0.62 |
| L4 | 41 ms | 31 ms | 0.76 |
| L5 | 89 ms | 56 ms | 0.63 |
| S1 | 79 ms | 59 ms | 0.75 |
| S2 | 648 ms | 371 ms | 0.57 |
| S3 | 314 ms | 183 ms | 0.58 |
| S4 | 111 ms | 82 ms | 0.74 |
| S5 | 88 ms | 36 ms | 0.41 |
| S6 | 38 ms | 24 ms | 0.63 |
| S7 | 5 ms | 2 ms | 0.40 |
| **total** | **41581 ms** | **22013 ms** | **0.53** |

No query is slower.

### WatDiv-File

| query | master | this PR | ratio |
|-|-|-|-|
| C1 | 317 ms | 318 ms | 1.00 |
| C2 | 3064 ms | 3009 ms | 0.98 |
| C3 | 1863 ms | 1804 ms | 0.97 |
| F1 | 17 ms | 18 ms | 1.06 |
| F2 | 36 ms | 36 ms | 1.00 |
| F3 | 84 ms | 74 ms | 0.88 |
| F4 | 37 ms | 40 ms | 1.08 |
| F5 | 113 ms | 110 ms | 0.97 |
| L1 | 21 ms | 19 ms | 0.90 |
| L2 | 5 ms | 6 ms | 1.20 |
| L3 | 13 ms | 8 ms | 0.62 |
| L4 | 4 ms | 4 ms | 1.00 |
| L5 | 7 ms | 7 ms | 1.00 |
| S1 | 38 ms | 38 ms | 1.00 |
| S2 | 14 ms | 13 ms | 0.93 |
| S3 | 33 ms | 33 ms | 1.00 |
| S4 | 34 ms | 31 ms | 0.91 |
| S5 | 5 ms | 5 ms | 1.00 |
| S6 | 4 ms | 5 ms | 1.25 |
| S7 | 4 ms | 3 ms | 0.75 |
| **total** | **5713 ms** | **5581 ms** | **0.98** |

The queries where the ratio looks large are the ones measured in single-digit milliseconds, where a millisecond of scheduling dominates. Nothing here moves outside run-to-run noise.

### WatDiv-TPF

HTTP requests, summed over the five instances of each template. Against a local Linked Data Fragments server over the same dataset.

| query | master | this PR |
|-|-|-|
| C1 | 4700 | 4700 |
| C2 | 10955 | 10955 |
| C3 | 102270 | 102270 |
| F1 | 215 | 215 |
| F2 | 1671 | 1671 |
| F3 | 986 | 986 |
| F4 | 1498 | 1498 |
| F5 | 1859 | 1859 |
| L1 | 184 | 184 |
| L2 | 55 | 55 |
| L3 | 200 | 200 |
| L4 | 25 | 25 |
| L5 | 55 | 55 |
| S1 | 2963 | 2963 |
| S2 | 550 | 550 |
| S3 | 35 | 35 |
| S4 | 369 | 369 |
| S5 | 35 | 35 |
| S6 | 138 | 138 |
| S7 | 26 | 26 |
| **total** | **128789** | **128789** |

Identical on every query: the plans over a paged remote source do not shift.

## What I tried first, and why this is what is left

I first wrote a new join actor that planned a whole basic graph pattern once and executed it as a chain of direct source lookups, in the shape Oxigraph and Jena use. `oxigraph query --explain` over this dataset produces a left-deep chain of `Lateral` nodes for every one of these queries, with no hash join anywhere, planned in 70 to 230 µs.

That reached 0.75 at 10M with L2 at 1.81 and L5 at 2.67, because chaining fixes one strategy for the whole pattern, and some steps are better served by reading both sides once. Reusing the tree this actor already builds is both faster and safer, since each step of the tree picks its own operator. L2 comes out at 0.62 here.

I also tried replacing `ActorRdfJoinMultiBind`'s `selectivityModifier`, a constant 0.0001 that puts its iteration count about four orders of magnitude below the row counts the hash joins report, with the same shared variable estimate. That is more defensible in isolation but measurably worse: the 10M total goes from 22013 ms to 24967 ms, almost entirely C3 going from 12536 ms to 15617 ms, reproduced with and without an accompanying per-binding cost term. The constant appears to be compensating for an error elsewhere, so I have left it alone rather than trade a real 7% for a tidier number.

`ActorRdfJoinMultiBindSource` reports `iterations: 1` regardless of the work it does, which is the same class of problem. It is untouched here.

## Verification

Full Jest suite (6817 tests), `yarn run lint`, `yarn run depcheck`, and `yarn run test:config-compat` all pass. Three expected cost values in the actor's own tests are updated; `ActorRdfJoinMultiSmallest` remains at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fVTUvQ2uCR1p4KQxAYrgs