### PR TITLE
Improve accuracy of costs in multi-bind actor

### DIFF
--- a/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
@@ -377,7 +377,7 @@ export interface IActorRdfJoinMultiBindArgs extends IActorRdfJoinArgs<IActorRdfJ
   // TODO: in next major, make mandatory.
   /**
    * The cost of planning and evaluating one bound operation, expressed in produced rows.
-   * Not applied to sources that are read page by page.
+   * Not applied to remote sources.
    * @range {double}
    * @default {100}
    */

--- a/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
@@ -32,6 +32,7 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
   public readonly bindOrder: BindOrder;
   public readonly selectivityModifier: number;
   public readonly minMaxCardinalityRatio: number;
+  public readonly subQueryCost: number;
   public readonly mediatorJoinEntriesSort: MediatorRdfJoinEntriesSort;
   public readonly mediatorQueryOperation: MediatorQueryOperation;
   public readonly mediatorMergeBindingsContext: MediatorMergeBindingsContext;
@@ -46,6 +47,7 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
     this.bindOrder = args.bindOrder;
     this.selectivityModifier = args.selectivityModifier;
     this.minMaxCardinalityRatio = args.minMaxCardinalityRatio;
+    this.subQueryCost = args.subQueryCost;
     this.mediatorJoinEntriesSort = args.mediatorJoinEntriesSort;
     this.mediatorQueryOperation = args.mediatorQueryOperation;
     this.mediatorMergeBindingsContext = args.mediatorMergeBindingsContext;
@@ -315,21 +317,45 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
         context: action.context,
       })).selectivity * this.selectivityModifier));
 
-    // Determine coefficients for remaining entries
+    // Determine how many rows the remaining entries produce for a single binding of the first entry.
+    // Joining two entries over a shared variable yields at most as many rows as the smaller of the two,
+    // so spread over the bindings of the first entry that is roughly one row per entry.
+    // This puts the count on the same scale as the row counts the other join actors report, unlike scaling
+    // the structural selectivity by a constant. Entries sharing no variable still fall back to that.
+    const cardinalityFirst = metadatas[0].cardinality.value;
+    let entriesWithoutSharedVariable = 0;
     const cardinalityRemaining = remainingEntries
-      .map((entry, i) => entry.metadata.cardinality.value * selectivities[i])
+      .map((entry, i) => {
+        const joined = ActorRdfJoin.getSharedVariableJoinCardinality([ metadatas[0], entry.metadata ]);
+        if (joined === undefined) {
+          entriesWithoutSharedVariable++;
+          return entry.metadata.cardinality.value * selectivities[i];
+        }
+        return joined / cardinalityFirst;
+      })
       .reduce((sum, element) => sum + element, 0);
     const receiveInitialCostRemaining = remainingRequestInitialTimes
       .reduce((sum, element) => sum + element, 0);
     const receiveItemCostRemaining = remainingRequestItemTimes
       .reduce((sum, element) => sum + element, 0);
 
+    // Every binding of the first entry makes all remaining operations be planned and executed again from
+    // scratch, which costs much more than producing a row, so charge it once per binding per operation.
+    // An operation that shares no variable with the first entry is not a lookup for such a binding: it still
+    // has to be joined with all the others, so it costs about as much again as the whole sub-plan.
+    // Sources that answer page by page are excluded. There, the alternative to binding is paging through a
+    // whole pattern, and the request time that costs is summed here as if the pages were fetched at once,
+    // so charging anything extra for binding pushes the plan the wrong way.
+    const subPlanCost = isRemoteAccess ?
+      0 :
+      this.subQueryCost * remainingEntries.length * (1 + entriesWithoutSharedVariable);
+
     return passTestWithSideData({
-      iterations: metadatas[0].cardinality.value * cardinalityRemaining,
+      iterations: cardinalityFirst * (cardinalityRemaining + subPlanCost),
       persistedItems: 0,
       blockingItems: 0,
       requestTime: requestInitialTimes[0] +
-        metadatas[0].cardinality.value * (
+        cardinalityFirst * (
           requestItemTimes[0] +
           receiveInitialCostRemaining +
           cardinalityRemaining * receiveItemCostRemaining
@@ -356,6 +382,13 @@ export interface IActorRdfJoinMultiBindArgs extends IActorRdfJoinArgs<IActorRdfJ
    * @default {60}
    */
   minMaxCardinalityRatio: number;
+  /**
+   * The cost of planning and evaluating one bound operation, expressed in produced rows.
+   * Not applied to sources that are read page by page.
+   * @range {double}
+   * @default {100}
+   */
+  subQueryCost: number;
   /**
    * The join entries sort mediator
    */

--- a/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
@@ -47,7 +47,7 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
     this.bindOrder = args.bindOrder;
     this.selectivityModifier = args.selectivityModifier;
     this.minMaxCardinalityRatio = args.minMaxCardinalityRatio;
-    this.subQueryCost = args.subQueryCost;
+    this.subQueryCost = args.subQueryCost ?? 100;
     this.mediatorJoinEntriesSort = args.mediatorJoinEntriesSort;
     this.mediatorQueryOperation = args.mediatorQueryOperation;
     this.mediatorMergeBindingsContext = args.mediatorMergeBindingsContext;
@@ -317,11 +317,8 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
         context: action.context,
       })).selectivity * this.selectivityModifier));
 
-    // Determine how many rows the remaining entries produce for a single binding of the first entry.
-    // Joining two entries over a shared variable yields at most as many rows as the smaller of the two,
-    // so spread over the bindings of the first entry that is roughly one row per entry.
-    // This puts the count on the same scale as the row counts the other join actors report, unlike scaling
-    // the structural selectivity by a constant. Entries sharing no variable still fall back to that.
+    // Rows each remaining entry adds per binding: a join over a shared variable yields at most the smaller
+    // cardinality, so about one row each. Entries sharing no variable fall back to the selectivity.
     const cardinalityFirst = metadatas[0].cardinality.value;
     let entriesWithoutSharedVariable = 0;
     const cardinalityRemaining = remainingEntries
@@ -339,13 +336,9 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
     const receiveItemCostRemaining = remainingRequestItemTimes
       .reduce((sum, element) => sum + element, 0);
 
-    // Every binding of the first entry makes all remaining operations be planned and executed again from
-    // scratch, which costs much more than producing a row, so charge it once per binding per operation.
-    // An operation that shares no variable with the first entry is not a lookup for such a binding: it still
-    // has to be joined with all the others, so it costs about as much again as the whole sub-plan.
-    // Sources that answer page by page are excluded. There, the alternative to binding is paging through a
-    // whole pattern, and the request time that costs is summed here as if the pages were fetched at once,
-    // so charging anything extra for binding pushes the plan the wrong way.
+    // Each binding re-plans and re-runs every remaining operation, which costs far more than a row.
+    // One sharing no variable is no lookup: it must still be joined, costing about a sub-plan again.
+    // Not charged for paged sources, where the alternative is paging a whole pattern and binding wins anyway.
     const subPlanCost = isRemoteAccess ?
       0 :
       this.subQueryCost * remainingEntries.length * (1 + entriesWithoutSharedVariable);
@@ -382,13 +375,14 @@ export interface IActorRdfJoinMultiBindArgs extends IActorRdfJoinArgs<IActorRdfJ
    * @default {60}
    */
   minMaxCardinalityRatio: number;
+  // TODO: in next major, make mandatory.
   /**
    * The cost of planning and evaluating one bound operation, expressed in produced rows.
    * Not applied to sources that are read page by page.
    * @range {double}
    * @default {100}
    */
-  subQueryCost: number;
+  subQueryCost?: number;
   /**
    * The join entries sort mediator
    */

--- a/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
@@ -317,8 +317,9 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
         context: action.context,
       })).selectivity * this.selectivityModifier));
 
-    // Rows each remaining entry adds per binding: a join over a shared variable yields at most the smaller
-    // cardinality, so about one row each. Entries sharing no variable fall back to the selectivity.
+    // Bindings each remaining entry adds per binding of the first: their pairwise join capped by the
+    // variables they share, spread over the first entry's cardinality, so at most one. Entries sharing no
+    // variable have no such cap and keep using the join selectivity.
     const cardinalityFirst = metadatas[0].cardinality.value;
     let entriesWithoutSharedVariable = 0;
     const cardinalityRemaining = remainingEntries

--- a/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/lib/ActorRdfJoinMultiBind.ts
@@ -336,9 +336,8 @@ export class ActorRdfJoinMultiBind extends ActorRdfJoin<IActorRdfJoinMultiBindTe
     const receiveItemCostRemaining = remainingRequestItemTimes
       .reduce((sum, element) => sum + element, 0);
 
-    // Each binding re-plans and re-runs every remaining operation, which costs far more than a row.
-    // One sharing no variable is no lookup: it must still be joined, costing about a sub-plan again.
-    // Not charged for paged sources, where the alternative is paging a whole pattern and binding wins anyway.
+    // Each binding re-plans and re-runs every remaining operation.
+    // This does not apply to remote sources, where this cost is already incorporated into requestTime.
     const subPlanCost = isRemoteAccess ?
       0 :
       this.subQueryCost * remainingEntries.length * (1 + entriesWithoutSharedVariable);

--- a/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
@@ -92,6 +92,7 @@ IQueryOperationResultBindings
         bus,
         bindOrder: 'depth-first',
         selectivityModifier: 0.1,
+        subQueryCost: 100,
         mediatorQueryOperation,
         mediatorJoinSelectivity,
         mediatorJoinEntriesSort,
@@ -250,10 +251,71 @@ IQueryOperationResultBindings
             ],
           },
         )).resolves.toPassTest({
-          iterations: 80.48000000000002,
+          iterations: 4,
           persistedItems: 0,
           blockingItems: 0,
-          requestTime: 32.592000000000006,
+          requestTime: 2,
+        });
+      });
+      it('should handle three entries where one shares no variable', async() => {
+        await expect(actor.getJoinCoefficients(
+          {
+            type: 'inner',
+            entries: [
+              {
+                output: <any>{},
+                operation: FACTORY.createNop(),
+              },
+              {
+                output: <any>{},
+                operation: FACTORY.createNop(),
+              },
+              {
+                output: <any>{},
+                operation: FACTORY.createNop(),
+              },
+            ],
+            context: new ActionContext(),
+          },
+          {
+            metadatas: [
+              {
+                state: new MetadataValidationState(),
+                cardinality: { type: 'estimate', value: 3 },
+                pageSize: 100,
+                requestTime: 10,
+
+                variables: [
+                  { variable: DF.variable('a'), canBeUndef: false },
+                ],
+              },
+              {
+                state: new MetadataValidationState(),
+                cardinality: { type: 'estimate', value: 2 },
+                pageSize: 100,
+                requestTime: 20,
+
+                variables: [
+                  { variable: DF.variable('a'), canBeUndef: false },
+                ],
+              },
+              {
+                state: new MetadataValidationState(),
+                cardinality: { type: 'estimate', value: 500 },
+                pageSize: 100,
+                requestTime: 30,
+
+                variables: [
+                  { variable: DF.variable('b'), canBeUndef: false },
+                ],
+              },
+            ],
+          },
+        )).resolves.toPassTest({
+          iterations: 82.00000000000001,
+          persistedItems: 0,
+          blockingItems: 0,
+          requestTime: 33.2,
         });
       });
 
@@ -315,10 +377,10 @@ IQueryOperationResultBindings
             ],
           },
         )).resolves.toPassTest({
-          iterations: 80.48000000000002,
+          iterations: 4,
           persistedItems: 0,
           blockingItems: 0,
-          requestTime: 32.592000000000006,
+          requestTime: 2,
         });
       });
 
@@ -503,10 +565,10 @@ IQueryOperationResultBindings
             ],
           },
         )).resolves.toPassTest({
-          iterations: 48.00000000000001,
+          iterations: 2,
           persistedItems: 0,
           blockingItems: 0,
-          requestTime: 5.200000000000001,
+          requestTime: 0.6000000000000001,
         });
       });
 
@@ -723,7 +785,7 @@ IQueryOperationResultBindings
             ],
           },
         )).resolves.toPassTest({
-          iterations: 32.64,
+          iterations: 404,
           persistedItems: 0,
           blockingItems: 0,
           requestTime: 0,
@@ -1353,6 +1415,7 @@ IQueryOperationResultBindings
           bus,
           bindOrder: 'breadth-first',
           selectivityModifier: 0.1,
+          subQueryCost: 100,
           minMaxCardinalityRatio: 100,
           mediatorQueryOperation,
           mediatorJoinSelectivity,

--- a/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
+++ b/packages/actor-rdf-join-inner-multi-bind/test/ActorRdfJoinMultiBind-test.ts
@@ -106,6 +106,22 @@ IQueryOperationResultBindings
       return (await actor.test(action)).getSideData();
     }
 
+    describe('constructor', () => {
+      it('should fall back to a default sub-query cost', () => {
+        expect(new ActorRdfJoinMultiBind({
+          name: 'actor',
+          bus,
+          bindOrder: 'depth-first',
+          selectivityModifier: 0.1,
+          mediatorQueryOperation,
+          mediatorJoinSelectivity,
+          mediatorJoinEntriesSort,
+          mediatorMergeBindingsContext,
+          minMaxCardinalityRatio: 100,
+        }).subQueryCost).toBe(100);
+      });
+    });
+
     describe('static helper methods', () => {
       describe('canBindWithOperation', () => {
         describe('default without boundVariables', () => {


### PR DESCRIPTION
The multi-bind actor reported two things wrong to `mediator-join-coefficients-fixed`, and both made it be chosen where another join actor is much faster.

**The estimated number of rows was not on the same scale as the other actors'.** It was the cardinality of each remaining entry scaled by `selectivityModifier`, a fixed 0.0001, so the number it reported was about four orders of magnitude below what a row count means to any other actor. It is now derived from the variables the entries share: joining two entries over a shared variable yields at most as many rows as the smaller of the two, which spread over the bindings of the first entry is about one row per entry. `selectivityModifier` still applies to entries that share no variable with the first, where there is nothing to derive it from.

**The cost of binding itself was missing.** Every binding of the first entry makes all remaining operations be planned and executed again from scratch, over the query operation bus and back into this one. That is far more work than producing a row, and leaving it out is what let this actor win against joining the entries once. It is now charged once per binding per remaining operation, through a new `subQueryCost` parameter (default 100, in produced rows). An operation that shares no variable with the first entry is not a lookup for such a binding, since it still has to be joined with all the others, so it counts for about the whole sub-plan again: the charge per binding is `subQueryCost * remaining * (1 + remaining without a shared variable)`.

Sources that answer page by page are excluded from that charge. There the alternative to binding is paging through a whole pattern, whose request time this model sums as if the pages were fetched at once, so charging anything extra for binding picks the slower plan. An earlier revision of this PR did charge it there, and made `desserts-plants` of the web benchmark bimodal at ~800 ms or ~16.7 s against the live DBpedia server.

## Measurements

All on one machine, master vs this branch, two independent rounds each so the run-to-run spread is visible; the ratio compares the means of the two rounds. Result counts were identical to master in every run.

The first table is at a larger scale than CI runs, to show what the change is for. The five after it are the datasets and query sets of the CI benchmarks.

### WatDiv scale 100 (10.9M triples) over HDT, ms, best of 2

| Query | master 1 | master 2 | fix 1 | fix 2 | Ratio |
|---|---|---|---|---|---|
| C1 | 2281 | 2476 | 521 | 525 | 0.22 |
| C2 | 7350 | 7485 | 2229 | 2319 | 0.31 |
| C3 | 14268 | 13578 | 13400 | 14245 | 0.99 |
| F1 | 259 | 250 | 99 | 90 | 0.37 |
| F2 | 48 | 46 | 46 | 49 | 1.01 |
| F3 | 42 | 40 | 42 | 43 | 1.04 |
| F4 | 183 | 163 | 41 | 43 | 0.24 |
| F5 | 93 | 89 | 87 | 96 | 1.01 |
| L1 | 13 | 11 | 11 | 12 | 0.96 |
| L2 | 58 | 55 | 66 | 56 | 1.08 |
| L3 | 3 | 3 | 4 | 3 | 1.17 |
| L4 | 24 | 21 | 22 | 22 | 0.98 |
| L5 | 55 | 55 | 57 | 60 | 1.06 |
| S1 | 45 | 48 | 47 | 47 | 1.01 |
| S2 | 549 | 544 | 511 | 581 | 1.00 |
| S3 | 225 | 210 | 55 | 58 | 0.26 |
| S4 | 58 | 67 | 65 | 74 | 1.11 |
| S5 | 58 | 62 | 62 | 66 | 1.07 |
| S6 | 17 | 18 | 18 | 20 | 1.09 |
| S7 | 1 | 1 | 1 | 1 | 1.00 |
| **Total** | **25426** | | **17897** | | **0.70** |

### benchmark-watdiv-file: WatDiv scale 10 over a file, ms, mean of the 5 instances of each template

| Query | master 1 | master 2 | fix 1 | fix 2 | Ratio |
|---|---|---|---|---|---|
| C1 | 264 | 267 | 168 | 150 | 0.60 |
| C2 | 2803 | 2891 | 264 | 251 | 0.09 |
| C3 | 1679 | 1745 | 2154 | 1794 | 1.15 |
| F1 | 14 | 13 | 19 | 15 | 1.26 |
| F2 | 32 | 32 | 22 | 16 | 0.59 |
| F3 | 71 | 67 | 12 | 9 | 0.15 |
| F4 | 32 | 34 | 16 | 14 | 0.45 |
| F5 | 94 | 98 | 93 | 75 | 0.88 |
| L1 | 16 | 17 | 13 | 11 | 0.73 |
| L2 | 5 | 6 | 5 | 4 | 0.82 |
| L3 | 7 | 9 | 7 | 6 | 0.81 |
| L4 | 2 | 2 | 3 | 2 | 1.25 |
| L5 | 5 | 5 | 5 | 4 | 0.90 |
| S1 | 32 | 33 | 32 | 28 | 0.92 |
| S2 | 10 | 11 | 32 | 24 | 2.67 |
| S3 | 26 | 30 | 4 | 3 | 0.12 |
| S4 | 25 | 29 | 35 | 27 | 1.15 |
| S5 | 3 | 3 | 3 | 4 | 1.17 |
| S6 | 3 | 3 | 5 | 4 | 1.50 |
| S7 | 1 | 1 | 1 | 2 | 1.50 |
| **Total** | **5210** | | **2668** | | **0.51** |

### benchmark-watdiv-tpf: WatDiv scale 10 over an LDF server, ms, mean of the 5 instances of each template

| Query | master 1 | master 2 | fix 1 | fix 2 | Ratio |
|---|---|---|---|---|---|
| C1 | 1326 | 1387 | 1363 | 1259 | 0.97 |
| C2 | 3293 | 3330 | 3291 | 3340 | 1.00 |
| C3 | 21928 | 22059 | 23002 | 21660 | 1.02 |
| F1 | 82 | 81 | 93 | 78 | 1.05 |
| F2 | 324 | 343 | 415 | 348 | 1.14 |
| F3 | 229 | 239 | 261 | 248 | 1.09 |
| F4 | 308 | 356 | 374 | 367 | 1.12 |
| F5 | 547 | 564 | 608 | 543 | 1.04 |
| L1 | 97 | 113 | 102 | 89 | 0.91 |
| L2 | 42 | 41 | 42 | 38 | 0.96 |
| L3 | 66 | 74 | 69 | 59 | 0.91 |
| L4 | 21 | 19 | 21 | 17 | 0.95 |
| L5 | 43 | 43 | 45 | 40 | 0.99 |
| S1 | 605 | 545 | 603 | 517 | 0.97 |
| S2 | 115 | 121 | 128 | 120 | 1.05 |
| S3 | 23 | 22 | 24 | 20 | 0.98 |
| S4 | 329 | 331 | 384 | 327 | 1.08 |
| S5 | 20 | 21 | 22 | 22 | 1.07 |
| S6 | 38 | 40 | 47 | 41 | 1.13 |
| S7 | 12 | 12 | 14 | 13 | 1.12 |
| **Total** | **29594** | | **30027** | | **1.01** |

The number of HTTP requests is identical to master for every one of the 20 templates (128843 in total, per round), so the plans over the LDF server are unchanged and the differences above are timing noise.

### benchmark-bsbm-file: BSBM productCount 1000 over a file, ms, mean of 10 runs after 5 warmups

| Query | master 1 | master 2 | fix 1 | fix 2 | Ratio |
|---|---|---|---|---|---|
| Q1 | 12.2 | 12.5 | 13 | 12.1 | 1.02 |
| Q2 | 5.1 | 5 | 4.9 | 4.6 | 0.94 |
| Q3 | 12.4 | 11.4 | 11 | 10.4 | 0.90 |
| Q4 | 14.7 | 15.4 | 11.9 | 11.1 | 0.76 |
| Q5 | 3.5 | 3.9 | 4 | 3.7 | 1.04 |
| Q7 | 6 | 5.5 | 6.1 | 5.7 | 1.03 |
| Q8 | 5.5 | 5 | 5.1 | 4.9 | 0.95 |
| Q9 | 29.5 | 22 | 27.2 | 24.7 | 1.01 |
| Q10 | 3.9 | 3.6 | 3.6 | 3.6 | 0.96 |
| Q11 | 1.1 | 1.4 | 1.2 | 1.3 | 1.00 |
| Q12 | 7.1 | 7.1 | 7.3 | 8.2 | 1.09 |
| **Total** | **97** | | **93** | | **0.96** |

### benchmark-bsbm-tpf: BSBM productCount 1000 over an LDF server, ms, mean of 10 runs after 5 warmups

| Query | master 1 | master 2 | fix 1 | fix 2 | Ratio |
|---|---|---|---|---|---|
| Q1 | 110 | 96.6 | 100.4 | 108.1 | 1.01 |
| Q2 | 26.8 | 24.5 | 24.9 | 28.1 | 1.03 |
| Q3 | 96.1 | 93 | 92.7 | 99 | 1.01 |
| Q4 | 164.1 | 160.4 | 151.3 | 148.6 | 0.92 |
| Q5 | 19.6 | 19.4 | 16.5 | 19.1 | 0.91 |
| Q7 | 29.5 | 33.1 | 25.9 | 27.1 | 0.85 |
| Q8 | 23.9 | 24.1 | 23.5 | 22.9 | 0.97 |
| Q9 | 13 | 13.1 | 12.8 | 13 | 0.99 |
| Q10 | 17.5 | 22 | 17 | 16.8 | 0.86 |
| Q11 | 8.8 | 9.1 | 9.7 | 9 | 1.04 |
| Q12 | 29.2 | 30.6 | 30.9 | 28.6 | 0.99 |
| **Total** | **532** | | **513** | | **0.96** |

### benchmark-web: the queries of `performance/benchmark-web/input/queries`, against their live sources, ms

| Query | master 1 | master 2 | fix 1 | fix 2 | Ratio |
|---|---|---|---|---|---|
| airports-italy | 23 | 24 | 25 | 27 | 1.11 |
| artists-york | 146 | 159 | 151 | 197 | 1.14 |
| artists-york-filter | 244 | 191 | 178 | 240 | 0.96 |
| authors-books | 10 | 19 | 18 | 13 | 1.07 |
| bands-queen | 15 | 13 | 19 | 18 | 1.32 |
| belgian-software | 62 | 72 | 66 | 66 | 0.99 |
| brad-pitt | 133 | 95 | 84 | 132 | 0.95 |
| brad-pitt-inlaws-pp | 6 | 6 | 6 | 6 | 1.00 |
| brad-pitt-pp | 109 | 94 | 76 | 94 | 0.84 |
| brad-pitt-service | 113 | 101 | 93 | 104 | 0.92 |
| bruce-willis-pp | 6 | 6 | 5 | 8 | 1.08 |
| carpenters-crucifixion | 2 | 2 | 2 | 3 | 1.25 |
| common-jesus | 781 | 845 | 741 | 760 | 0.92 |
| desserts-plants | 766 | 774 | 717 | 805 | 0.99 |
| events-trentino | 635 | 648 | 575 | 878 | 1.13 |
| indian-dishes | 97 | 98 | 141 | 97 | 1.22 |
| michael-jackson | timeout | timeout | timeout | timeout | - |
| natalie-portman | 42 | 39 | 43 | 33 | 0.94 |
| os-raspberrypi | 19 | 8 | 8 | 12 | 0.74 |
| people-cambridge-pairs-orderby | 3681 | 3416 | 3984 | 3548 | 1.06 |
| women-mythology | 289 | 279 | 256 | 288 | 0.96 |
| harvard-san-francisco-limit | 311 | 373 | 373 | 374 | 1.09 |
| harvard-san-francisco-limit-filter | 320 | 330 | 324 | 332 | 1.01 |
| harvard-san-francisco-limit-service | timeout | timeout | timeout | timeout | - |
| lindas-rhea-identifiers | fetch failed | fetch failed | fetch failed | fetch failed | - |
| wikidata-dbpedia-cats | timeout | timeout | timeout | timeout | - |
| bruce-willis-pp-cartesian | 19 | 22 | 19 | 22 | 1.00 |
| ruben-knows-zero-or-more | 212 | 268 | 201 | 228 | 0.89 |
| ruben-knows-zero-or-one | 10 | 8 | 6 | 7 | 0.72 |
| ruben-predicates | 3 | 3 | 3 | 3 | 1.00 |
| rubens-articles | 68 | 101 | 55 | 56 | 0.66 |
| **Total** | **8058** | | **8260** | | **1.03** |

These go over the public internet, so the per-query spread is large and the total is not a meaningful score; four queries fail identically on both sides and are excluded from it. The table is here to show that no query changes character, which is what the earlier revision of this PR did to `desserts-plants`.

## Summary

| Benchmark | Ratio |
|---|---|
| WatDiv scale 100 over HDT | 0.70 |
| benchmark-watdiv-file | 0.51 |
| benchmark-watdiv-tpf | 1.01, requests 1.00 |
| benchmark-bsbm-file | 0.96 |
| benchmark-bsbm-tpf | 0.96 |
| benchmark-web | 1.03 |

## Time to the first result

Completion time is not the whole story: a bind join emits its first row as soon as its first sub-query answers, while a hash join has to build its table first. Since this change moves plans on local sources away from binding, it can buy total time and pay for it in latency. Measured from before `engine.query()` to the first binding, two rounds, over the templates that return at least one row:

| Benchmark | Ratio |
|---|---|
| benchmark-watdiv-file | 1.02 |
| benchmark-watdiv-tpf | 1.10, inside the run-to-run spread |
| benchmark-bsbm-file | 0.92 |
| benchmark-bsbm-tpf | 1.00 |

Flat in aggregate over WatDiv, better over BSBM, with large per-query swings on the file source: F3 89 ms to 7 ms, F2 28 to 17, F4 20 to 13, against C3 55 to 141, F5 6.4 to 21.6 and S2 4.8 to 13.2.

## Regressions

Two queries of `benchmark-watdiv-file` are slower in a way that survives both rounds:

- **S2, 10.5 ms to 28 ms**, and its first result 4.8 ms to 13.2 ms. A four-pattern star with two bound patterns, so the model charges 300 rows of work per binding for a sub-plan that is three index lookups, and switches to a hash join. The same query is unaffected over HDT and over TPF.
- **C3, 1712 ms to 1974 ms**, and its first result 55 ms to 141 ms. The completion time alone is at the edge of the spread between the two master rounds, but the first-result time is 2.5x in both rounds, so this is a real change rather than noise.

**F5** trades the other way: its first result goes 6.4 ms to 21.6 ms while it completes in 84 ms instead of 96 ms.

`benchmark-watdiv-file` S4 at 1.15 sits at the edge of the master-to-master spread. The remaining File entries above 1.0 (F1, L4, S5, S6, S7) are all queries of 1 to 17 ms where a round differs by one or two milliseconds.

Over HDT nothing regresses beyond the run-to-run spread; the largest ratio, L3 at 1.17, is 3 ms against 3.5 ms.

## What this does not fix

`subQueryCost` is one constant standing in for the cost of a sub-plan that in reality varies by orders of magnitude, from a single bound index lookup to a recursive cascade of further bind joins. The multiplier here is a coarse approximation of that, and it was chosen by measuring which values flip which queries on these benchmarks, so it may not generalise.

Binding over a paged source is now left entirely uncosted rather than costed badly. Doing better needs the request time of the alternative to account for the fact that paging through a pattern is serial, which this cost model does not express.

The cost model has no notion of latency to the first result, so a plan that streams and a plan that blocks are compared on total work alone. That is what the C3 and F5 rows above are.

`ActorRdfJoinMultiBindSource` still reports a hardcoded `iterations: 1`, so it is not comparable to any other actor either. That is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fVTUvQ2uCR1p4KQxAYrgs