### PR TITLE
Throw when deleting quads with blank nodes via SPARQL Update patches

### DIFF
--- a/packages/actor-rdf-update-hypermedia-patch-sparql-update/lib/QuadDestinationPatchSparqlUpdate.ts
+++ b/packages/actor-rdf-update-hypermedia-patch-sparql-update/lib/QuadDestinationPatchSparqlUpdate.ts
@@ -30,9 +30,48 @@ export class QuadDestinationPatchSparqlUpdate implements IQuadDestination {
   public async update(
     quadStreams: { insert?: AsyncIterator<RDF.Quad>; delete?: AsyncIterator<RDF.Quad> },
   ): Promise<void> {
+    // The quads to delete are collected before the request is started, so that quads that can not be deleted
+    // are reported as an error, instead of resulting in a partially written request body.
+    const quadsToDelete = quadStreams.delete && await quadStreams.delete.toArray();
+    if (quadsToDelete) {
+      for (const quad of quadsToDelete) {
+        // SPARQL does not allow blank nodes inside DELETE DATA blocks, as a blank node label can not be used
+        // to refer to a blank node in the destination.
+        // Replacing them by variables in a DELETE ... WHERE ... operation is not a valid alternative,
+        // as such a pattern also matches other blank nodes and terms,
+        // by which more would be deleted than was asked for.
+        if (QuadDestinationPatchSparqlUpdate.hasBlankNode(quad)) {
+          throw new Error(`Unable to delete '${QuadDestinationPatchSparqlUpdate.tripleToString(quad)}' via a SPARQL Update patch, as blank nodes can not be referred to by label. Consider replacing the contents of the destination instead.`);
+        }
+      }
+    }
+
     // Create combined query stream with quads to insert and delete
-    const queryStream = this.createCombinedQuadsQuery(quadStreams.insert, quadStreams.delete);
+    const queryStream = this.createCombinedQuadsQuery(
+      quadStreams.insert,
+      quadsToDelete && new ArrayIterator<RDF.Quad>(quadsToDelete, { autoStart: false }),
+    );
     await this.wrapSparqlUpdateRequest(queryStream);
+  }
+
+  /**
+   * Check if the given term is a blank node, or contains one inside a quoted triple.
+   */
+  private static hasBlankNode(term: RDF.Term): boolean {
+    if (term.termType === 'BlankNode') {
+      return true;
+    }
+    if (term.termType === 'Quad') {
+      return QuadDestinationPatchSparqlUpdate.hasBlankNode(term.subject) ||
+        QuadDestinationPatchSparqlUpdate.hasBlankNode(term.predicate) ||
+        QuadDestinationPatchSparqlUpdate.hasBlankNode(term.object) ||
+        QuadDestinationPatchSparqlUpdate.hasBlankNode(term.graph);
+    }
+    return false;
+  }
+
+  private static tripleToString(quad: RDF.Quad): string {
+    return `${termToString(quad.subject)} ${termToString(quad.predicate)} ${termToString(quad.object)} .`;
   }
 
   private createCombinedQuadsQuery(
@@ -52,7 +91,7 @@ export class QuadDestinationPatchSparqlUpdate implements IQuadDestination {
     // Wrap triples in DATA block
     return quads
       .map((quad: RDF.Quad) => {
-        let stringQuad = `${termToString(quad.subject)} ${termToString(quad.predicate)} ${termToString(quad.object)} .`;
+        let stringQuad = QuadDestinationPatchSparqlUpdate.tripleToString(quad);
         if (quad.graph.termType === 'DefaultGraph') {
           stringQuad = `  ${stringQuad}\n`;
         } else {

--- a/packages/actor-rdf-update-hypermedia-patch-sparql-update/test/QuadDestinationPatchSparqlUpdate-test.ts
+++ b/packages/actor-rdf-update-hypermedia-patch-sparql-update/test/QuadDestinationPatchSparqlUpdate-test.ts
@@ -104,6 +104,19 @@ describe('QuadDestinationPatchSparqlUpdate', () => {
 }`);
     });
 
+    it('should keep blank nodes in an insert', async() => {
+      await destination.update({
+        insert: fromArray([
+          DF.quad(DF.blankNode('b1'), DF.namedNode('ex:p1'), DF.namedNode('ex:o1')),
+        ]),
+      });
+
+      await expect(stringifyStream(ActorHttp.toNodeReadable(mediatorHttp.mediate.mock.calls[0][0].init.body))).resolves
+        .toBe(`INSERT DATA {
+  _:b1 <ex:p1> <ex:o1> .
+}`);
+    });
+
     it('should throw on a server error', async() => {
       mediatorHttp.mediate = () => ({ status: 400 });
       await expect(destination.update({ insert: fromArray<RDF.Quad>([]) })).rejects
@@ -143,6 +156,59 @@ describe('QuadDestinationPatchSparqlUpdate', () => {
         .toBe(`DELETE DATA {
   <ex:s1> <ex:p1> <ex:o1> .
   GRAPH <ex:g2> { <ex:s2> <ex:p2> <ex:o2> . }
+}`);
+    });
+
+    it('should throw on a blank node subject', async() => {
+      await expect(destination.update({
+        delete: fromArray<RDF.Quad>([
+          DF.quad(DF.blankNode('b1'), DF.namedNode('ex:p1'), DF.namedNode('ex:o1')),
+        ]),
+      })).rejects.toThrow(`Unable to delete '_:b1 <ex:p1> <ex:o1> .' via a SPARQL Update patch, as blank nodes can not be referred to by label. Consider replacing the contents of the destination instead.`);
+    });
+
+    it('should throw on a blank node object', async() => {
+      await expect(destination.update({
+        delete: fromArray<RDF.Quad>([
+          DF.quad(DF.namedNode('ex:s1'), DF.namedNode('ex:p1'), DF.blankNode('b1')),
+        ]),
+      })).rejects.toThrow(`Unable to delete '<ex:s1> <ex:p1> _:b1 .' via a SPARQL Update patch`);
+    });
+
+    it('should throw on a blank node graph', async() => {
+      await expect(destination.update({
+        delete: fromArray<RDF.Quad>([
+          DF.quad(DF.namedNode('ex:s1'), DF.namedNode('ex:p1'), DF.namedNode('ex:o1'), DF.blankNode('b1')),
+        ]),
+      })).rejects.toThrow(`Unable to delete '<ex:s1> <ex:p1> <ex:o1> .' via a SPARQL Update patch`);
+    });
+
+    it('should throw on a blank node inside a quoted triple', async() => {
+      await expect(destination.update({
+        delete: fromArray<RDF.Quad>([
+          DF.quad(
+            DF.namedNode('ex:s1'),
+            DF.namedNode('ex:p1'),
+            DF.quad(DF.blankNode('b1'), DF.namedNode('ex:p2'), DF.namedNode('ex:o2')),
+          ),
+        ]),
+      })).rejects.toThrow(`via a SPARQL Update patch, as blank nodes can not be referred to by label`);
+    });
+
+    it('should not throw on a quoted triple without blank nodes', async() => {
+      await destination.update({
+        delete: fromArray<RDF.Quad>([
+          DF.quad(
+            DF.namedNode('ex:s1'),
+            DF.namedNode('ex:p1'),
+            DF.quad(DF.namedNode('ex:s2'), DF.namedNode('ex:p2'), DF.namedNode('ex:o2')),
+          ),
+        ]),
+      });
+
+      await expect(stringifyStream(ActorHttp.toNodeReadable(mediatorHttp.mediate.mock.calls[0][0].init.body))).resolves
+        .toBe(`DELETE DATA {
+  <ex:s1> <ex:p1> <<<ex:s2> <ex:p2> <ex:o2>>> .
 }`);
     });
   });


### PR DESCRIPTION
Refs comunica/comunica-feature-solid#68.

> **Note**
> An earlier revision of this PR rewrote these quads into a `DELETE ... WHERE ...` operation. That turned out to be unsound and has been replaced — see [Why not rewrite to `DELETE ... WHERE ...`](#why-not-rewrite-to-delete--where-) below.

## Problem

`QuadDestinationPatchSparqlUpdate` serializes every quad to delete into a `DELETE DATA` block. SPARQL does not allow blank nodes there, since a blank node label cannot be used to refer to a blank node in the destination. Any update deleting a quad that contains a blank node therefore produced an invalid patch, which a Solid server rejects with a message that gives the user nothing to act on. From comunica/comunica-feature-solid#68, against Community Solid Server 7.2.0:

```
$ comunica-sparql-solid http://localhost:3000/bike.ttl \
    "INSERT DATA { <ex:s> <ex:p> [ <ex:q> <ex:o> ] }"      # ok, 2 triples stored

$ comunica-sparql-solid http://localhost:3000/bike.ttl "DELETE WHERE { ?s ?p ?o . }"
Could not update http://localhost:3000/bike.ttl (HTTP status 400):
{"name":"BadRequestHttpError","message":"Detected illegal blank node in BGP", ...}
```

The reporter's reaction — *"What does this error mean? Blank node was created by comunica!"* — is the actual problem: the blank node came from `[ ... ]` in their own earlier insert, and nothing points at the cause.

## Change

Quads containing blank nodes are now detected and reported with an error that says why they cannot be deleted:

```
Unable to delete '_:b0_g_000 <ex:q> <ex:o> .' via a SPARQL Update patch, as blank nodes
can not be referred to by label. Consider replacing the contents of the destination instead.
```

The quads to delete are collected before the request is started. That is needed for correctness, not just tidiness: an error raised while the body is being streamed does **not** reject `update()` — the returned promise resolves and a truncated body goes out. Validating up front keeps the destination untouched, which I verified against a live server (resource identical before and after a rejected mixed insert/delete update, up to blank node relabelling).

Blank nodes remain untouched in `INSERT DATA`, where SPARQL does allow them.

## Why not rewrite to `DELETE ... WHERE ...`?

Replacing each blank node with a variable produces a patch servers accept, and it does clear the resource in the issue's scenario. But it silently deletes more than was asked for, in two independent ways. Both reproduce against CSS 7.2.0:

**1. Constraints that live only in the query's `WHERE` clause are lost.**

```
_:b1 <ex:q> <ex:o> . _:b1 <ex:tag> "A" .
_:b2 <ex:q> <ex:o> . _:b2 <ex:tag> "B" .

DELETE { ?b <ex:q> <ex:o> } WHERE { ?b <ex:tag> "A" . ?b <ex:q> <ex:o> }
```

The delete set is only `_:b1 <ex:q> <ex:o>`, but the emitted patch is `DELETE { ?b0 <ex:q> <ex:o> } WHERE { ?b0 <ex:q> <ex:o> }` — `<ex:tag> "A"` never reaches the patch, because it was in the query's `WHERE`, not in the delete template. `_:b2`'s triple is destroyed too: 4 triples → 2, where 3 is correct.

**2. The substituted variable also matches named nodes.**

```
_:b1 <ex:q> <ex:o> . _:b1 <ex:tag> "A" .
<ex:iri> <ex:q> <ex:o> .
```

The same update also deletes `<ex:iri> <ex:q> <ex:o>`, a triple containing no blank node at all: 3 triples → 1, where 2 is correct.

Constraining the variables with `FILTER(isBlank(?b0))` would fix (2) but not (1), and is not available anyway: CSS accepts only a plain BGP as a patch's `WHERE` clause and answers anything else with `501 Non-BGP WHERE statements are not supported`. Keeping all blank-node quads in a single operation preserves the joins between them, which helps in some shapes, but does not address either case above.

So the rewrite would trade a loud failure for silent data loss. Erroring costs nothing in functionality — these updates already fail today — and makes the failure diagnosable.

## Actually supporting these deletes

Out of scope here, but for the record: since the destination is a document whose full contents are already read, the exact delete could be performed by rewriting the document with PUT. That needs the source's parsed content plumbed through to the destination actor, because blank node labels are reassigned on each read (visible above: the same resource serializes as `_:b126_g_000` and then `_:b130_g_000`), plus `If-Match` to avoid clobbering concurrent writes. It also gives up patch atomicity.

## Testing

- 6 new unit tests covering blank nodes in the subject, object, graph and inside quoted triples, that a quoted triple without blank nodes is unaffected, and that `INSERT DATA` still keeps blank nodes. `QuadDestinationPatchSparqlUpdate.ts` stays at 100% statement/branch/function/line coverage.
- Verified against a live Community Solid Server 7.2.0 with the local build: both variants reported in the issue now fail with the explanatory error instead of `Detected illegal blank node in BGP`, deletes without blank nodes are unaffected, and a rejected update leaves the resource unchanged.
- Both over-deletion cases above were run against the previous revision of this branch to confirm the data loss, and against this one to confirm it is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LskwcbfWuuUTa3DFubRtpE