### PR TITLE
Compare pull request benchmarks against the base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,17 +297,14 @@ jobs:
 
   performance:
     name: Performance benchmarks
-    if: startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/feature') || startsWith(github.ref, 'refs/heads/next')
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/master') || startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/feature') || startsWith(github.ref, 'refs/heads/next')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        benchmark:
-          - watdiv-file
-          - watdiv-tpf
-          - bsbm-file
-          - bsbm-tpf
-          - web
+        # The web benchmark is omitted on pull requests, as its query set varies across runs,
+        # which makes its totals incomparable between two runs.
+        benchmark: ${{ github.event_name == 'pull_request' && fromJSON('["watdiv-file", "watdiv-tpf", "bsbm-file", "bsbm-tpf"]') || fromJSON('["watdiv-file", "watdiv-tpf", "bsbm-file", "bsbm-tpf", "web"]') }}
     steps:
       - name: Ensure line endings are consistent
         run: git config --global core.autocrlf input
@@ -331,6 +328,8 @@ jobs:
 
   performance-consolidate:
     name: Performance analysis
+    # Pull request results are compared in performance-compare instead, and are never stored.
+    if: github.event_name != 'pull_request'
     needs:
       - misc
       - test
@@ -413,6 +412,85 @@ jobs:
         uses: peter-evans/commit-comment@v4
         with:
           body-path: ./commit-comment-body.txt
+
+  performance-compare:
+    name: Performance comparison
+    # Forks receive a read-only GITHUB_TOKEN, which can not post the comparison onto the pull request.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - performance
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Ensure line endings are consistent
+        run: git config --global core.autocrlf input
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Use Node.js ${{ env.NODE_VERSION_HIGHEST }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION_HIGHEST }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-watdiv-file
+          path: performance/benchmark-watdiv-file/combinations/combination_0/output/
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-watdiv-tpf
+          path: performance/benchmark-watdiv-tpf/combinations/combination_0/output/
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-bsbm-file
+          path: performance/benchmark-bsbm-file/combinations/combination_0/output/
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-bsbm-tpf
+          path: performance/benchmark-bsbm-tpf/combinations/combination_0/output/
+      - name: Process benchmark detailed results
+        run: npx -p @rubensworks/process-sparql-benchmark-results psbr csv ghbench performance/benchmark-watdiv-file/combinations/combination_0/output/ performance/benchmark-watdiv-tpf/combinations/combination_0/output/ performance/benchmark-bsbm-file/combinations/combination_0/output/ performance/benchmark-bsbm-tpf/combinations/combination_0/output/ --overrideCombinationLabels WatDiv-File,WatDiv-TPF,BSBM-File,BSBM-TPF --total false --detailed true --name ghbench-detail.json
+      - name: Process benchmark total results
+        run: npx -p @rubensworks/process-sparql-benchmark-results psbr csv ghbench performance/benchmark-watdiv-file/combinations/combination_0/output/ performance/benchmark-watdiv-tpf/combinations/combination_0/output/ performance/benchmark-bsbm-file/combinations/combination_0/output/ performance/benchmark-bsbm-tpf/combinations/combination_0/output/ --overrideCombinationLabels WatDiv-File,WatDiv-TPF,BSBM-File,BSBM-TPF --total true --detailed false --name ghbench-total.json
+      - name: Fetch the benchmark results of the base branch
+        # These are read over raw.githubusercontent.com rather than the GitHub Pages site,
+        # because the latter is served from a CDN that can lag behind by several minutes.
+        # A missing baseline yields an empty data file, upon which the comparison is skipped.
+        run: |
+          set -o pipefail
+          BASE_URL="https://raw.githubusercontent.com/comunica/comunica-performance-results/master/comunica/${GITHUB_BASE_REF}"
+          for KIND in detail total; do
+            if curl -fsSL "${BASE_URL}/benchmarks-${KIND}/data.js" | sed '1s/^window.BENCHMARK_DATA = //' > "baseline-${KIND}.json"; then
+              echo "Fetched ${KIND} baseline of ${GITHUB_BASE_REF}"
+            else
+              echo "No ${KIND} baseline found for ${GITHUB_BASE_REF}"
+              echo '{"lastUpdate":0,"repoUrl":"","entries":{}}' > "baseline-${KIND}.json"
+            fi
+          done
+      # The two comparison steps below read the last entry of the base branch as their baseline,
+      # and leave a self-updating comment on the pull request. Passing save-data-file disables
+      # the only write these perform, so pull request measurements are never stored.
+      - name: Compare benchmark detailed results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Benchmarks detailed results
+          tool: customSmallerIsBetter
+          output-file-path: ghbench-detail.json
+          external-data-json-path: baseline-detail.json
+          save-data-file: false
+          comment-always: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compare benchmark total results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Benchmarks total results
+          tool: customSmallerIsBetter
+          output-file-path: ghbench-total.json
+          external-data-json-path: baseline-total.json
+          save-data-file: false
+          comment-always: true
+          summary-always: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   documentation:
     name: Prepare documentation


### PR DESCRIPTION
The `performance` job was gated on master, tags, `feature*` and `next`, so pull requests were never benchmarked. It now also runs on pull requests, and a new `performance-compare` job reports the results against the base branch as a self-updating review comment.

### How the comparison works

`performance-consolidate` uses the action's gh-pages mode, which clones the results repository and pushes to it. That mode is wrong for pull requests: it needs the PAT, and it writes.

`performance-compare` uses `external-data-json-path` instead, pointed at the base branch's published data:

```
curl -fsSL ".../comunica/${GITHUB_BASE_REF}/benchmarks-total/data.js" \
  | sed '1s/^window.BENCHMARK_DATA = //' > baseline-total.json
```

with `save-data-file: false`. In `src/write.ts`, `writeBenchmarkToExternalJson` computes `prevBench` via `addBenchmarkToDataJson` and only afterwards hits the `if (!saveDataFile) return { prevBench, ... }` early return, so the comparison happens and the write does not. On a `pull_request` event `write.ts` routes to `leavePRComment`, which tags the review body with `${name} Summary` and calls `pulls.updateReview` on later pushes rather than adding a new comment each time.

Consequences worth noting:

- **Nothing is persisted.** The results repository is only ever read.
- **No PAT.** The baseline is public, so `GITHUB_TOKEN` with `pull-requests: write` is all the job needs.
- **`raw.githubusercontent.com`, not the Pages site.** Pages is served from a CDN that can lag several minutes behind, which would hand back a stale master.
- **A missing baseline is not an error.** An absent base branch yields an empty data file, upon which the action logs that the previous result was not found and skips the comparison.

### Metrics

Unchanged. The job reuses the same two `psbr csv ghbench` invocations as `performance-consolidate`, so both the per-query timings and the totals reported on a pull request are exactly the ones tracked on master, and the bench names line up with the stored series.

### The web benchmark is omitted on pull requests

It still runs and is still tracked on master. Its query set is not stable across runs: over the last thirty master runs the stored bench counts are 30 (x14), 32 (x10), 31 (x2), 40, 38 and 33. Since `--total` sums the median of whichever queries produced a value, two runs of it measure different query sets and are not comparable.

### `performance-consolidate` needed an explicit guard

It has no `if` of its own and was skipped on pull requests only as a consequence of `needs: performance` being skipped. Now that `performance` runs on pull requests, without `if: github.event_name != 'pull_request'` it would start pushing pull request measurements onto the master history.

### Forks

A fork's `GITHUB_TOKEN` is read-only for pull requests, so `pulls.createReview` would 403. `performance-compare` is therefore limited to branches in this repository. Fork pull requests still run the benchmarks and still upload their raw output, they just get no comment. Covering them needs the `workflow_run` split, which is deliberately not in this change.

### Verification

`actionlint` (with shellcheck) passes on the workflow.

The mechanism was exercised end to end locally: the real master `data.js` converted through the `sed` above parses as valid JSON with the entry key `Benchmarks total results` and bench names matching `--overrideCombinationLabels`. Running the action against it on a synthetic `pull_request` payload, with a result set built by scaling WatDiv-File to 0.8x and BSBM-File to 1.4x and dropping Web, produced:

| Benchmark suite | Current | Previous | Ratio |
|-|-|-|-|
| `WatDiv-File` | `1686` ms | `2108` ms | `0.80` |
| `WatDiv-TPF` | `23953` ms | `23953` ms | `1` |
| `BSBM-File` | `273` ms | `195` ms | `1.40` |
| `BSBM-TPF` | `1513` ms | `1513` ms | `1` |

compared against `7616661`, the current master tip, with the baseline file's checksum unchanged afterwards. Web being absent from the current results caused no error, it is simply left out of the table.

That local run had one side effect that needs an apology: it posted its table as a review on #1801. The token passed to it was a placeholder, but the request was authenticated anyway on its way out. Those numbers were synthetic and unrelated to that pull request. Submitted reviews cannot be deleted through the API, so it needs to be removed by hand.

### Expected timing

The four remaining benchmarks run in parallel, the slowest being watdiv-tpf at about 6m40s on recent master runs, so the comment should land roughly 10 to 15 minutes in. `performance-compare` deliberately depends only on `performance`, unlike `performance-consolidate`, so it does not wait on the Jest matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7fJyYyxnUuavdeJoP8qCu

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7fJyYyxnUuavdeJoP8qCu)_