### PR TITLE
feat(service): allow custom SERVICE executor injection via context (#1660)

### DIFF
--- a/packages/actor-context-preprocess-convert-shortcuts/lib/ActorContextPreprocessConvertShortcuts.ts
+++ b/packages/actor-context-preprocess-convert-shortcuts/lib/ActorContextPreprocessConvertShortcuts.ts
@@ -77,6 +77,7 @@ export interface IActorContextPreprocessConvertShortcutsArgs extends IActorConte
    *   "extensionFunctions": "@comunica/actor-init-query:extensionFunctions",
    *   "extensionFunctionsAlwaysPushdown": "@comunica/actor-init-query:extensionFunctionsAlwaysPushdown",
    *   "extensionFunctionCreator": "@comunica/actor-init-query:extensionFunctionCreator",
+   *   "serviceExecutors": "@comunica/actor-init-query:serviceExecutors",
    *   "functionArgumentsCache": "@comunica/actor-init-query:functionArgumentsCache",
    *   "explain": "@comunica/actor-init-query:explain",
    *   "unionDefaultGraph": "@comunica/bus-query-operation:unionDefaultGraph",

--- a/packages/actor-optimize-query-operation-assign-sources-exhaustive/lib/ActorOptimizeQueryOperationAssignSourcesExhaustive.ts
+++ b/packages/actor-optimize-query-operation-assign-sources-exhaustive/lib/ActorOptimizeQueryOperationAssignSourcesExhaustive.ts
@@ -7,7 +7,14 @@ import { ActorOptimizeQueryOperation } from '@comunica/bus-optimize-query-operat
 import { KeysInitQuery, KeysQueryOperation } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { ActionContext, passTestVoid } from '@comunica/core';
-import type { ComunicaDataFactory, IQuerySourceWrapper } from '@comunica/types';
+import type {
+  ComunicaDataFactory,
+  IActionContext,
+  IQueryBindingsOptions,
+  IQuerySource,
+  IQuerySourceWrapper,
+  ServiceExecutorCallback,
+} from '@comunica/types';
 import { Algebra, AlgebraFactory, algebraUtils } from '@comunica/utils-algebra';
 import {
   assignOperationSource,
@@ -32,7 +39,9 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
 
     const sources = action.context.get(KeysQueryOperation.querySources) ?? [];
     const serviceSources = action.context.get(KeysQueryOperation.serviceSources) ?? {};
-    if (sources.length === 0 && Object.keys(serviceSources).length === 0) {
+    const serviceExecutors = action.context.get(KeysQueryOperation.serviceExecutors) ??
+      action.context.get(KeysInitQuery.serviceExecutors) ?? {};
+    if (sources.length === 0 && Object.keys(serviceSources).length === 0 && Object.keys(serviceExecutors).length === 0) {
       return { operation: action.operation, context: action.context };
     }
     if (await passFullOperationToSource(action.operation, sources, action.context)) {
@@ -42,7 +51,7 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
       };
     }
     return {
-      operation: this.assignExhaustive(algebraFactory, action.operation, sources, serviceSources),
+      operation: this.assignExhaustive(algebraFactory, action.operation, sources, serviceSources, serviceExecutors),
       // We only keep queryString in the context if we only have a single source that accepts the full operation.
       // In that case, the queryString can be sent to the source as-is.
       context: action.context
@@ -58,12 +67,14 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
    * @param operation The input operation.
    * @param sources The sources to assign.
    * @param serviceSources Mapping of SERVICE names to sources.
+   * @param serviceExecutors Mapping of SERVICE names to custom executors.
    */
   public assignExhaustive(
     factory: AlgebraFactory,
     operation: Algebra.Operation,
     sources: IQuerySourceWrapper[],
     serviceSources: Record<string, IQuerySourceWrapper>,
+    serviceExecutors: Record<string, ServiceExecutorCallback> = {},
   ): Algebra.Operation {
     return algebraUtils.mapOperation(operation, {
       [Algebra.Types.PATTERN]: {
@@ -80,7 +91,35 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
         preVisitor: () => ({ continue: false }),
         transform: (serviceOp) => {
           if (serviceOp.name.termType === 'NamedNode') {
-            let source = serviceSources[serviceOp.name.value];
+            const serviceIri = serviceOp.name.value;
+            let source = serviceSources[serviceIri];
+            if (!source && serviceExecutors[serviceIri]) {
+              const executor = serviceExecutors[serviceIri];
+              const customSource: IQuerySource = {
+                referenceValue: serviceIri,
+                getFilterFactor: async() => 1,
+                getSelectorShape: async() => ({
+                  type: 'operation',
+                  operation: {
+                    type: Algebra.Types.SERVICE,
+                  },
+                }),
+                queryBindings: (_op: Algebra.Operation, context: IActionContext, options?: IQueryBindingsOptions) => {
+                  return executor(serviceOp, options?.joinBindings, context) as any;
+                },
+                queryQuads: () => {
+                  throw new Error('SERVICE sources do not support quads queries.');
+                },
+                queryVoid: () => {
+                  throw new Error('SERVICE sources do not support void queries.');
+                },
+                queryBoolean: async() => {
+                  throw new Error('SERVICE sources do not support boolean queries.');
+                },
+                toString: () => `ServiceExecutorSource(${serviceIri})`,
+              };
+              source = { source: customSource };
+            }
             if (source) {
               if (serviceOp.silent) {
                 source = {
@@ -92,7 +131,8 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
                 factory,
                 serviceOp.input,
                 [ source ],
-                // Pass empty serviceSources to ensure nested SERVICE clauses are not transformed.
+                // Pass empty serviceSources and serviceExecutors to ensure nested SERVICE clauses are not transformed.
+                {},
                 {},
               );
             }
@@ -103,7 +143,7 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
       [Algebra.Types.CONSTRUCT]: {
         preVisitor: () => ({ continue: false }),
         transform: constructOp => factory.createConstruct(
-          this.assignExhaustive(factory, constructOp.input, sources, serviceSources),
+          this.assignExhaustive(factory, constructOp.input, sources, serviceSources, serviceExecutors),
           constructOp.template,
         ),
       },
@@ -132,7 +172,7 @@ export class ActorOptimizeQueryOperationAssignSourcesExhaustive extends ActorOpt
         transform: delInsOp => factory.createDeleteInsert(
           delInsOp.delete,
           delInsOp.insert,
-          delInsOp.where ? this.assignExhaustive(factory, delInsOp.where, sources, serviceSources) : undefined,
+          delInsOp.where ? this.assignExhaustive(factory, delInsOp.where, sources, serviceSources, serviceExecutors) : undefined,
         ),
       },
     });

--- a/packages/actor-optimize-query-operation-assign-sources-exhaustive/test/ActorOptimizeQueryOperationAssignSourcesExhaustive-test.ts
+++ b/packages/actor-optimize-query-operation-assign-sources-exhaustive/test/ActorOptimizeQueryOperationAssignSourcesExhaustive-test.ts
@@ -317,6 +317,41 @@ describe('ActorOptimizeQueryOperationAssignSourcesExhaustive', () => {
         expect(getOperationSource(operationOut)).toBeUndefined();
       });
 
+      it('for service with a custom serviceExecutor should assign synthetic source', async() => {
+        const executorMock = jest.fn((op, bindings, ctx) => 'mockStream');
+        const operationIn = AF.createService(
+          AF.createPattern(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+          DF.namedNode('customService1'),
+        );
+        const operationOut = actor.assignExhaustive(AF, operationIn, [], {}, { customService1: executorMock });
+        expect(operationOut.type).toEqual(Algebra.Types.PATTERN);
+        const sourceWrapper = getOperationSource(operationOut);
+        expect(sourceWrapper).toBeDefined();
+        expect(sourceWrapper!.source.referenceValue).toBe('customService1');
+        const customRes = (sourceWrapper!.source as any).queryBindings(operationIn, new ActionContext());
+        expect(executorMock).toHaveBeenCalledTimes(1);
+        expect(customRes).toBe('mockStream');
+      });
+
+      it('for service with a custom serviceExecutor and run context should optimize properly', async() => {
+        const executorMock = jest.fn(() => 'mockStream');
+        const operationIn = AF.createService(
+          AF.createPattern(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),
+          DF.namedNode('customService1'),
+        );
+        const { operation: operationOut } = await actor.run({
+          operation: operationIn,
+          context: new ActionContext({
+            [KeysInitQuery.dataFactory.name]: DF,
+            [KeysInitQuery.serviceExecutors.name]: { customService1: executorMock },
+          }),
+        });
+        expect(operationOut.type).toEqual(Algebra.Types.PATTERN);
+        const sourceWrapper = getOperationSource(operationOut);
+        expect(sourceWrapper).toBeDefined();
+        expect(sourceWrapper!.source.referenceValue).toBe('customService1');
+      });
+
       it('for a construct query', async() => {
         const operationIn = AF.createConstruct(
           AF.createPattern(DF.namedNode('s1'), DF.namedNode('p1'), DF.namedNode('o1')),

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -20,6 +20,7 @@ import type {
   IDiscoverEventData,
   PartialResult,
   ILink,
+  ServiceExecutorCallback,
 } from '@comunica/types';
 import type { Algebra } from '@comunica/utils-algebra';
 import type * as RDF from '@rdfjs/types';
@@ -228,6 +229,13 @@ export const KeysInitQuery = {
     '@comunica/actor-init-query:extensionFunctionsAlwaysPushdown',
   ),
   /**
+   * Dictionary of custom SERVICE executors.
+   * Key is the IRI of the service, and value is the service executor callback.
+   */
+  serviceExecutors: new ActionContextKey<Record<string, ServiceExecutorCallback>>(
+    '@comunica/actor-init-query:serviceExecutors',
+  ),
+  /**
    * Enables manipulation of the CLI arguments and their processing.
    */
   cliArgsHandlers: new ActionContextKey<ICliArgsHandler[]>('@comunica/actor-init-query:cliArgsHandlers'),
@@ -347,6 +355,12 @@ export const KeysQueryOperation = {
    */
   serviceSources: new ActionContextKey<Record<string, IQuerySourceWrapper>>(
     '@comunica/bus-query-operation:serviceSources',
+  ),
+  /**
+   * A mapping of SERVICE targets to custom executors.
+   */
+  serviceExecutors: new ActionContextKey<Record<string, ServiceExecutorCallback>>(
+    '@comunica/bus-query-operation:serviceExecutors',
   ),
 };
 

--- a/packages/types/lib/IQueryContext.ts
+++ b/packages/types/lib/IQueryContext.ts
@@ -60,6 +60,7 @@ export interface IQueryContextCommon {
   extensionFunctionsAlwaysPushdown?: boolean;
   extensionFunctionCreator?: (functionNamedNode: RDF.NamedNode)
   => ((args: RDF.Term[]) => Promise<RDF.Term>) | undefined;
+  serviceExecutors?: Record<string, (operation: any, bindingsStream: any, context: any) => any>;
   functionArgumentsCache?: FunctionArgumentsCache;
   explain?: QueryExplainMode;
   nonLexicalComparison?: boolean;

--- a/packages/types/lib/IServiceExecutor.ts
+++ b/packages/types/lib/IServiceExecutor.ts
@@ -1,0 +1,16 @@
+import type { BindingsStream } from './Bindings';
+import type { IActionContext } from './IActionContext';
+
+/**
+ * A callback function to execute custom SERVICE clauses.
+ *
+ * @param operation The service algebra operation.
+ * @param bindingsStream The input bindings stream to join or process (if available).
+ * @param context The current action context.
+ * @returns A stream of output bindings.
+ */
+export type ServiceExecutorCallback = (
+  operation: any,
+  bindingsStream: BindingsStream | undefined,
+  context: IActionContext,
+) => Promise<BindingsStream> | BindingsStream;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -20,3 +20,4 @@ export * from './ILink';
 export * from './ILinkQueue';
 export * from './Logger';
 export * from './ExpressionEvaluator';
+export * from './IServiceExecutor';


### PR DESCRIPTION
## Description
Resolves #1660

This PR introduces support for custom `SERVICE` executors/handlers injection into Comunica SPARQL query executions via the Query Context, allowing developers to intercept `SERVICE <iri>` clauses and handle bindings processing without requiring a remote physical HTTP SPARQL endpoint.

### Summary of Changes:
- **`@comunica/types`**: Added `ServiceExecutorCallback` interface and exposed `serviceExecutors` under `IQueryContextCommon`.
- **`@comunica/context-entries`**: Added `KeysInitQuery.serviceExecutors` and `KeysQueryOperation.serviceExecutors`.
- **`@comunica/actor-context-preprocess-convert-shortcuts`**: Added `"serviceExecutors"` shortcut mapping to `@comunica/actor-init-query:serviceExecutors`.
- **`@comunica/actor-optimize-query-operation-assign-sources-exhaustive`**: Extended `assignExhaustive` to bind matching custom service executors to a synthetic query source during query optimization.
- **Unit Tests**: Added test cases for custom `serviceExecutors` optimization and execution.
