### PR TITLE
Benchmark the base commit on the same runner as the pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,9 +517,6 @@ jobs:
       - name: Process base commit benchmark total results
         run: npx -p @rubensworks/process-sparql-benchmark-results psbr csv ghbench base/performance/benchmark-watdiv-file/combinations/combination_0/output/ base/performance/benchmark-watdiv-tpf/combinations/combination_0/output/ base/performance/benchmark-bsbm-file/combinations/combination_0/output/ base/performance/benchmark-bsbm-file-10k/combinations/combination_0/output/ base/performance/benchmark-bsbm-tpf/combinations/combination_0/output/ --overrideCombinationLabels WatDiv-File,WatDiv-TPF,BSBM-File,BSBM-File-10k,BSBM-TPF --total true --detailed false --name ghbench-base-total.json
       - name: Wrap the base commit results into baseline data files
-        # These emulate the data file that github-action-benchmark keeps per branch, holding a
-        # single entry: the base commit as measured by the performance job, on the same runner
-        # as the pull request results it is compared against.
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           REPO_URL: ${{ github.event.repository.html_url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,9 +310,6 @@ jobs:
     steps:
       - name: Ensure line endings are consistent
         run: git config --global core.autocrlf input
-      # Both checkouts live in a directory of their own. Nx scans the whole tree below the
-      # monorepo root, so a second copy of the monorepo nested inside the first one makes
-      # every package in it a duplicate project name, and lerna refuses to build.
       - name: Check out repository
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,8 +333,6 @@ jobs:
         if: env.BENCHMARK_BASE == 'true'
         run: yarn install --frozen-lockfile
         working-directory: base
-      # The base runs first, so that the pull request results are the last thing measured,
-      # just like they are on a run without a base.
       - name: Run benchmarks of the base commit
         if: env.BENCHMARK_BASE == 'true'
         run: cd base/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,18 +340,19 @@ jobs:
         if: env.BENCHMARK_BASE == 'true'
         run: yarn install --frozen-lockfile
         working-directory: base
-      # The base runs first, so that the pull request results are the last thing measured,
-      # just like they are on a run without a base.
+      # TEMPORARY, TO BE REVERTED: the run order is swapped, head first and base second, to
+      # measure whether the second-measured version being consistently faster on the TPF
+      # benchmarks is an effect of the order alone.
+      - name: Run benchmarks
+        run: cd head/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
+      - name: Remove containers left behind by the benchmarks
+        # The TPF benchmarks run their LDF server in Docker on fixed ports,
+        # so the benchmarks below must start from the same clean state as the ones above did.
+        if: env.BENCHMARK_BASE == 'true'
+        run: docker ps -aq | xargs -r docker rm -f
       - name: Run benchmarks of the base commit
         if: env.BENCHMARK_BASE == 'true'
         run: cd base/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
-      - name: Remove containers left behind by the base commit benchmarks
-        # The TPF benchmarks run their LDF server in Docker on fixed ports,
-        # so the benchmarks below must start from the same clean state as the base ones did.
-        if: env.BENCHMARK_BASE == 'true'
-        run: docker ps -aq | xargs -r docker rm -f
-      - name: Run benchmarks
-        run: cd head/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
       - uses: actions/upload-artifact@v7
         with:
           name: performance-benchmark-${{ matrix.benchmark }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,19 +340,18 @@ jobs:
         if: env.BENCHMARK_BASE == 'true'
         run: yarn install --frozen-lockfile
         working-directory: base
-      # TEMPORARY, TO BE REVERTED: the run order is swapped, head first and base second, to
-      # measure whether the second-measured version being consistently faster on the TPF
-      # benchmarks is an effect of the order alone.
-      - name: Run benchmarks
-        run: cd head/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
-      - name: Remove containers left behind by the benchmarks
-        # The TPF benchmarks run their LDF server in Docker on fixed ports,
-        # so the benchmarks below must start from the same clean state as the ones above did.
-        if: env.BENCHMARK_BASE == 'true'
-        run: docker ps -aq | xargs -r docker rm -f
+      # The base runs first, so that the pull request results are the last thing measured,
+      # just like they are on a run without a base.
       - name: Run benchmarks of the base commit
         if: env.BENCHMARK_BASE == 'true'
         run: cd base/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
+      - name: Remove containers left behind by the base commit benchmarks
+        # The TPF benchmarks run their LDF server in Docker on fixed ports,
+        # so the benchmarks below must start from the same clean state as the base ones did.
+        if: env.BENCHMARK_BASE == 'true'
+        run: docker ps -aq | xargs -r docker rm -f
+      - name: Run benchmarks
+        run: cd head/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
       - uses: actions/upload-artifact@v7
         with:
           name: performance-benchmark-${{ matrix.benchmark }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,8 +314,13 @@ jobs:
     steps:
       - name: Ensure line endings are consistent
         run: git config --global core.autocrlf input
+      # Both checkouts live in a directory of their own. Nx scans the whole tree below the
+      # monorepo root, so a second copy of the monorepo nested inside the first one makes
+      # every package in it a duplicate project name, and lerna refuses to build.
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          path: head
       - name: Check out the base commit of the pull request
         if: env.BENCHMARK_BASE == 'true'
         uses: actions/checkout@v7
@@ -327,8 +332,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION_HIGHEST }}
           cache: yarn
+          cache-dependency-path: head/yarn.lock
       - name: Install dependencies and build monorepo
         run: yarn install --frozen-lockfile
+        working-directory: head
       - name: Install dependencies and build monorepo of the base commit
         if: env.BENCHMARK_BASE == 'true'
         run: yarn install --frozen-lockfile
@@ -344,18 +351,18 @@ jobs:
         if: env.BENCHMARK_BASE == 'true'
         run: docker ps -aq | xargs -r docker rm -f
       - name: Run benchmarks
-        run: cd performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
+        run: cd head/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
       - uses: actions/upload-artifact@v7
         with:
           name: performance-benchmark-${{ matrix.benchmark }}
-          path: performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/
+          path: head/performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/
       - uses: actions/upload-artifact@v7
         if: env.BENCHMARK_BASE == 'true'
         with:
           name: performance-benchmark-base-${{ matrix.benchmark }}
           path: base/performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/
       - name: Print raw output
-        run: cat performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/query-times.csv
+        run: cat head/performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/query-times.csv
       - name: Print raw output of the base commit
         if: env.BENCHMARK_BASE == 'true'
         run: cat base/performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/query-times.csv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,11 +305,23 @@ jobs:
         # The web benchmark is omitted on pull requests, as its query set varies across runs,
         # which makes its totals incomparable between two runs.
         benchmark: ${{ github.event_name == 'pull_request' && fromJSON('["watdiv-file", "watdiv-tpf", "bsbm-file", "bsbm-tpf"]') || fromJSON('["watdiv-file", "watdiv-tpf", "bsbm-file", "bsbm-tpf", "web"]') }}
+    env:
+      # Pull requests benchmark their base commit on this same runner, so that the comparison
+      # in performance-compare measures the code difference rather than the hardware difference
+      # between two runners, which is the dominant source of variance on hosted runners.
+      # Forks are excluded, as performance-compare can not post their comparison anyway.
+      BENCHMARK_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Ensure line endings are consistent
         run: git config --global core.autocrlf input
       - name: Check out repository
         uses: actions/checkout@v7
+      - name: Check out the base commit of the pull request
+        if: env.BENCHMARK_BASE == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
       - name: Use Node.js ${{ env.NODE_VERSION_HIGHEST }}
         uses: actions/setup-node@v7
         with:
@@ -317,14 +329,36 @@ jobs:
           cache: yarn
       - name: Install dependencies and build monorepo
         run: yarn install --frozen-lockfile
+      - name: Install dependencies and build monorepo of the base commit
+        if: env.BENCHMARK_BASE == 'true'
+        run: yarn install --frozen-lockfile
+        working-directory: base
+      # The base runs first, so that the pull request results are the last thing measured,
+      # just like they are on a run without a base.
+      - name: Run benchmarks of the base commit
+        if: env.BENCHMARK_BASE == 'true'
+        run: cd base/performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
+      - name: Remove containers left behind by the base commit benchmarks
+        # The TPF benchmarks run their LDF server in Docker on fixed ports,
+        # so the benchmarks below must start from the same clean state as the base ones did.
+        if: env.BENCHMARK_BASE == 'true'
+        run: docker ps -aq | xargs -r docker rm -f
       - name: Run benchmarks
         run: cd performance/benchmark-${{ matrix.benchmark }}/ && yarn run performance:ci
       - uses: actions/upload-artifact@v7
         with:
           name: performance-benchmark-${{ matrix.benchmark }}
           path: performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/
+      - uses: actions/upload-artifact@v7
+        if: env.BENCHMARK_BASE == 'true'
+        with:
+          name: performance-benchmark-base-${{ matrix.benchmark }}
+          path: base/performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/
       - name: Print raw output
         run: cat performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/query-times.csv
+      - name: Print raw output of the base commit
+        if: env.BENCHMARK_BASE == 'true'
+        run: cat base/performance/benchmark-${{ matrix.benchmark }}/combinations/combination_0/output/query-times.csv
 
   performance-consolidate:
     name: Performance analysis
@@ -448,26 +482,69 @@ jobs:
         with:
           name: performance-benchmark-bsbm-tpf
           path: performance/benchmark-bsbm-tpf/combinations/combination_0/output/
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-base-watdiv-file
+          path: base/performance/benchmark-watdiv-file/combinations/combination_0/output/
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-base-watdiv-tpf
+          path: base/performance/benchmark-watdiv-tpf/combinations/combination_0/output/
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-base-bsbm-file
+          path: base/performance/benchmark-bsbm-file/combinations/combination_0/output/
+      - uses: actions/download-artifact@v8
+        with:
+          name: performance-benchmark-base-bsbm-tpf
+          path: base/performance/benchmark-bsbm-tpf/combinations/combination_0/output/
       - name: Process benchmark detailed results
         run: npx -p @rubensworks/process-sparql-benchmark-results psbr csv ghbench performance/benchmark-watdiv-file/combinations/combination_0/output/ performance/benchmark-watdiv-tpf/combinations/combination_0/output/ performance/benchmark-bsbm-file/combinations/combination_0/output/ performance/benchmark-bsbm-tpf/combinations/combination_0/output/ --overrideCombinationLabels WatDiv-File,WatDiv-TPF,BSBM-File,BSBM-TPF --total false --detailed true --name ghbench-detail.json
       - name: Process benchmark total results
         run: npx -p @rubensworks/process-sparql-benchmark-results psbr csv ghbench performance/benchmark-watdiv-file/combinations/combination_0/output/ performance/benchmark-watdiv-tpf/combinations/combination_0/output/ performance/benchmark-bsbm-file/combinations/combination_0/output/ performance/benchmark-bsbm-tpf/combinations/combination_0/output/ --overrideCombinationLabels WatDiv-File,WatDiv-TPF,BSBM-File,BSBM-TPF --total true --detailed false --name ghbench-total.json
-      - name: Fetch the benchmark results of the base branch
-        # These are read over raw.githubusercontent.com rather than the GitHub Pages site,
-        # because the latter is served from a CDN that can lag behind by several minutes.
-        # A missing baseline yields an empty data file, upon which the comparison is skipped.
+      - name: Process base commit benchmark detailed results
+        run: npx -p @rubensworks/process-sparql-benchmark-results psbr csv ghbench base/performance/benchmark-watdiv-file/combinations/combination_0/output/ base/performance/benchmark-watdiv-tpf/combinations/combination_0/output/ base/performance/benchmark-bsbm-file/combinations/combination_0/output/ base/performance/benchmark-bsbm-tpf/combinations/combination_0/output/ --overrideCombinationLabels WatDiv-File,WatDiv-TPF,BSBM-File,BSBM-TPF --total false --detailed true --name ghbench-base-detail.json
+      - name: Process base commit benchmark total results
+        run: npx -p @rubensworks/process-sparql-benchmark-results psbr csv ghbench base/performance/benchmark-watdiv-file/combinations/combination_0/output/ base/performance/benchmark-watdiv-tpf/combinations/combination_0/output/ base/performance/benchmark-bsbm-file/combinations/combination_0/output/ base/performance/benchmark-bsbm-tpf/combinations/combination_0/output/ --overrideCombinationLabels WatDiv-File,WatDiv-TPF,BSBM-File,BSBM-TPF --total true --detailed false --name ghbench-base-total.json
+      - name: Wrap the base commit results into baseline data files
+        # These emulate the data file that github-action-benchmark keeps per branch, holding a
+        # single entry: the base commit as measured by the performance job, on the same runner
+        # as the pull request results it is compared against.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          REPO_URL: ${{ github.event.repository.html_url }}
         run: |
-          set -o pipefail
-          BASE_URL="https://raw.githubusercontent.com/comunica/comunica-performance-results/master/comunica/${GITHUB_BASE_REF}"
-          for KIND in detail total; do
-            if curl -fsSL "${BASE_URL}/benchmarks-${KIND}/data.js" | sed '1s/^window.BENCHMARK_DATA = //' > "baseline-${KIND}.json"; then
-              echo "Fetched ${KIND} baseline of ${GITHUB_BASE_REF}"
-            else
-              echo "No ${KIND} baseline found for ${GITHUB_BASE_REF}"
-              echo '{"lastUpdate":0,"repoUrl":"","entries":{}}' > "baseline-${KIND}.json"
-            fi
-          done
-      # The two comparison steps below read the last entry of the base branch as their baseline,
+          set -eu
+          wrap () {
+            jq -n \
+              --slurpfile benches "ghbench-base-$1.json" \
+              --arg name "$2" \
+              --arg sha "$BASE_SHA" \
+              --arg repo "$REPO_URL" \
+              --argjson date "$(date +%s000)" \
+              '{
+                lastUpdate: $date,
+                repoUrl: $repo,
+                entries: {
+                  ($name): [{
+                    commit: {
+                      author: { name: "", username: "", email: "" },
+                      committer: { name: "", username: "", email: "" },
+                      id: $sha,
+                      message: "Base commit of the pull request",
+                      timestamp: ($date / 1000 | todate),
+                      url: "\($repo)/commit/\($sha)"
+                    },
+                    date: $date,
+                    tool: "customSmallerIsBetter",
+                    benches: $benches[0]
+                  }]
+                }
+              }' > "baseline-$1.json"
+          }
+          wrap detail 'Benchmarks detailed results'
+          wrap total 'Benchmarks total results'
+      # The two comparison steps below read the single entry of the base commit as their baseline,
       # and leave a self-updating comment on the pull request. Passing save-data-file disables
       # the only write these perform, so pull request measurements are never stored.
       - name: Compare benchmark detailed results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,10 +306,6 @@ jobs:
         # which makes its totals incomparable between two runs.
         benchmark: ${{ github.event_name == 'pull_request' && fromJSON('["watdiv-file", "watdiv-tpf", "bsbm-file", "bsbm-file-10k", "bsbm-tpf"]') || fromJSON('["watdiv-file", "watdiv-tpf", "bsbm-file", "bsbm-file-10k", "bsbm-tpf", "web"]') }}
     env:
-      # Pull requests benchmark their base commit on this same runner, so that the comparison
-      # in performance-compare measures the code difference rather than the hardware difference
-      # between two runners, which is the dominant source of variance on hosted runners.
-      # Forks are excluded, as performance-compare can not post their comparison anyway.
       BENCHMARK_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Ensure line endings are consistent

--- a/performance/benchmark-bsbm-file/combinations/combination_0/jbr-experiment.json
+++ b/performance/benchmark-bsbm-file/combinations/combination_0/jbr-experiment.json
@@ -12,6 +12,6 @@
   "endpointUrl": "http://host.docker.internal:3001/sparql",
   "endpointUrlExternal": "http://localhost:3001/sparql",
   "warmupRuns": 5,
-  "runs": 10,
+  "runs": 15,
   "hookSparqlEndpoint": {"@id": "urn:jbr:benchmark-watdiv-file:combination_0:hookSparqlEndpoint","@type": "HookCli","entrypoint": [  "node",  "../../engines/query-sparql-file/bin/http.js",  "file@generated/dataset.nt",  "-p",  "3001"],"statsFilePath": "output/stats.csv"  }
 }

--- a/performance/benchmark-bsbm-file/combinations/combination_1/jbr-experiment.json
+++ b/performance/benchmark-bsbm-file/combinations/combination_1/jbr-experiment.json
@@ -12,6 +12,6 @@
   "endpointUrl": "http://host.docker.internal:3001/sparql",
   "endpointUrlExternal": "http://localhost:3001/sparql",
   "warmupRuns": 5,
-  "runs": 10,
+  "runs": 15,
   "hookSparqlEndpoint": {"@id": "urn:jbr:benchmark-watdiv-file:combination_1:hookSparqlEndpoint",  "@type": "HookSparqlEndpointComunica",  "dockerfileClient": "input/dockerfiles/Dockerfile-client",  "resourceConstraints": {"@type": "StaticDockerResourceConstraints","cpu_percentage": 100  },  "configClient": "input/config-client.json",  "contextClient": "input/context-client.json",  "additionalBinds": ["../../generated/dataset.nt:/tmp/dataset.nt"],  "clientPort": 3001,  "clientLogLevel": "info",  "queryTimeout": 500,  "maxMemory": 8192}
 }

--- a/performance/benchmark-bsbm-file/jbr-experiment.json.template
+++ b/performance/benchmark-bsbm-file/jbr-experiment.json.template
@@ -12,6 +12,6 @@
   "endpointUrl": "http://host.docker.internal:3001/sparql",
   "endpointUrlExternal": "http://localhost:3001/sparql",
   "warmupRuns": 5,
-  "runs": 10,
+  "runs": 15,
   "hookSparqlEndpoint": %FACTOR-hookSparqlEndpoint%
 }

--- a/performance/benchmark-bsbm-tpf/combinations/combination_0/jbr-experiment.json
+++ b/performance/benchmark-bsbm-tpf/combinations/combination_0/jbr-experiment.json
@@ -13,7 +13,7 @@
   "endpointUrl": "http://host.docker.internal:3001/sparql",
   "endpointUrlExternal": "http://localhost:3001/sparql",
   "warmupRuns": 5,
-  "runs": 10,
+  "runs": 15,
   "hookSparqlEndpoint": {
     "@id": "urn:jbr:tmp:hookSparqlEndpoint",
     "@type": "HookSparqlEndpointLdf",

--- a/performance/benchmark-bsbm-tpf/combinations/combination_1/jbr-experiment.json
+++ b/performance/benchmark-bsbm-tpf/combinations/combination_1/jbr-experiment.json
@@ -13,7 +13,7 @@
   "endpointUrl": "http://host.docker.internal:3001/sparql",
   "endpointUrlExternal": "http://localhost:3001/sparql",
   "warmupRuns": 5,
-  "runs": 10,
+  "runs": 15,
   "hookSparqlEndpoint": {
     "@id": "urn:jbr:tmp:hookSparqlEndpoint",
     "@type": "HookSparqlEndpointLdf",

--- a/performance/benchmark-bsbm-tpf/jbr-experiment.json.template
+++ b/performance/benchmark-bsbm-tpf/jbr-experiment.json.template
@@ -13,7 +13,7 @@
   "endpointUrl": "http://host.docker.internal:3001/sparql",
   "endpointUrlExternal": "http://localhost:3001/sparql",
   "warmupRuns": 5,
-  "runs": 10,
+  "runs": 15,
   "hookSparqlEndpoint": {
     "@id": "urn:jbr:tmp:hookSparqlEndpoint",
     "@type": "HookSparqlEndpointLdf",

--- a/performance/benchmark-watdiv-file/combinations/combination_0/jbr-experiment.json
+++ b/performance/benchmark-watdiv-file/combinations/combination_0/jbr-experiment.json
@@ -12,7 +12,7 @@
   "queryRecurrence": 1,
   "generateHdt": false,
   "endpointUrl": "http://localhost:3001/sparql",
-  "queryRunnerReplication": 3,
+  "queryRunnerReplication": 5,
   "queryRunnerWarmupRounds": 1,
   "queryRunnerRequestDelay": 0,
   "queryRunnerEndpointAvailabilityCheckTimeout": 1000,

--- a/performance/benchmark-watdiv-file/combinations/combination_1/jbr-experiment.json
+++ b/performance/benchmark-watdiv-file/combinations/combination_1/jbr-experiment.json
@@ -12,7 +12,7 @@
   "queryRecurrence": 1,
   "generateHdt": false,
   "endpointUrl": "http://localhost:3001/sparql",
-  "queryRunnerReplication": 3,
+  "queryRunnerReplication": 5,
   "queryRunnerWarmupRounds": 1,
   "queryRunnerRequestDelay": 0,
   "queryRunnerEndpointAvailabilityCheckTimeout": 1000,

--- a/performance/benchmark-watdiv-file/jbr-experiment.json.template
+++ b/performance/benchmark-watdiv-file/jbr-experiment.json.template
@@ -12,7 +12,7 @@
   "queryRecurrence": 1,
   "generateHdt": false,
   "endpointUrl": "http://localhost:3001/sparql",
-  "queryRunnerReplication": 3,
+  "queryRunnerReplication": 5,
   "queryRunnerWarmupRounds": 1,
   "queryRunnerRequestDelay": 0,
   "queryRunnerEndpointAvailabilityCheckTimeout": 1000,

--- a/performance/benchmark-watdiv-tpf/combinations/combination_0/jbr-experiment.json
+++ b/performance/benchmark-watdiv-tpf/combinations/combination_0/jbr-experiment.json
@@ -13,7 +13,7 @@
   "queryRecurrence": 1,
   "generateHdt": true,
   "endpointUrl": "http://localhost:3001/sparql",
-  "queryRunnerReplication": 1,
+  "queryRunnerReplication": 3,
   "queryRunnerWarmupRounds": 1,
   "queryRunnerRequestDelay": 0,
   "queryRunnerEndpointAvailabilityCheckTimeout": 1000,

--- a/performance/benchmark-watdiv-tpf/combinations/combination_1/jbr-experiment.json
+++ b/performance/benchmark-watdiv-tpf/combinations/combination_1/jbr-experiment.json
@@ -13,7 +13,7 @@
   "queryRecurrence": 1,
   "generateHdt": true,
   "endpointUrl": "http://localhost:3001/sparql",
-  "queryRunnerReplication": 1,
+  "queryRunnerReplication": 3,
   "queryRunnerWarmupRounds": 1,
   "queryRunnerRequestDelay": 0,
   "queryRunnerEndpointAvailabilityCheckTimeout": 1000,

--- a/performance/benchmark-watdiv-tpf/jbr-experiment.json.template
+++ b/performance/benchmark-watdiv-tpf/jbr-experiment.json.template
@@ -13,7 +13,7 @@
   "queryRecurrence": 1,
   "generateHdt": true,
   "endpointUrl": "http://localhost:3001/sparql",
-  "queryRunnerReplication": 1,
+  "queryRunnerReplication": 3,
   "queryRunnerWarmupRounds": 1,
   "queryRunnerRequestDelay": 0,
   "queryRunnerEndpointAvailabilityCheckTimeout": 1000,


### PR DESCRIPTION
The pull request comparison added in #1802 measures the head of the pull request on a freshly assigned hosted runner, and compares it against the stored results of the base branch, which were measured on a different runner at a different time. Hosted runners differ in CPU model and in how much of the host they share, so that difference between machines dominates the difference between the two versions of the code.

That premise is now measured rather than assumed, and so is the improvement. This pull request changes no engine code, so every ratio it reports should be exactly 1.00, which makes each of its own CI runs a direct measurement of the error. Over seven runs the WatDiv-File total ranged from 1319 ms to 2327 ms on identical code, a factor of 1.8 that is entirely the machine.

## What changes

**`performance`**: on a pull request, the job now also checks the base commit (`github.event.pull_request.base.sha`) out into `base/`, builds it, and benchmarks it on the same runner as the head. Both measurements come from the same CPU under the same conditions, so only the code differs between them. The base results are uploaded as `performance-benchmark-base-*` artifacts.

Both checkouts live in a directory of their own, `head/` and `base/`. Nx resolves the workspace root by walking up from the working directory and then scans the whole tree below it, so nesting one checkout inside the other makes every package a duplicate project name and lerna refuses to build.

Between the two runs, leftover containers are removed, so the second run starts from the same clean Docker state the first one did. The TPF benchmarks run their LDF server in Docker on fixed ports, which could not previously collide, as each benchmark used to run only once per job.

**`performance-compare`**: no longer fetches a baseline from `comunica-performance-results`. It downloads the base artifacts, processes them with the same `psbr` invocation as the head artifacts, and wraps them into the data file layout that `github-action-benchmark` reads through `external-data-json-path`. `save-data-file` stays disabled, so pull request measurements are still never stored.

Dropping the fetch also removes two failure modes: a pull request against a branch with no stored history no longer silently skips its comparison, and the baseline no longer depends on whichever commit last happened to publish results.

**Benchmark replication**: `benchmark-watdiv-tpf` had `queryRunnerReplication: 1`, so every query time it reported came from a single execution with nothing to average, and it was the noisiest of the four. It now uses 3, matching what `benchmark-watdiv-file` used. `benchmark-watdiv-file` goes from 3 to 5, and `benchmark-bsbm-file` and `benchmark-bsbm-tpf` from 10 runs to 15, keeping their 5 warmup runs. Combination configs were regenerated with `jbr generate-combinations` rather than edited by hand.

`benchmark-bsbm-file-10k`, added to master in #1801 after this branch was cut, is deliberately left at 10 runs. Its noise has not been measured here, and at ten times the data of `benchmark-bsbm-file` the extra repetitions would cost the most on the benchmark least likely to need them, since longer queries suffer less from the millisecond quantisation that the repetitions are there to average away. It is otherwise fully covered by this change: the `performance` job benchmarks it on both the base and the head like the rest, and `performance-compare` compares it.

## Measured effect

Seven CI runs of this pull request provide the measurement. All of them compare byte-identical engine code, so the true ratio is 1.00 everywhere and every deviation is error. Each run also measures the base commit, which gives both baselines from one dataset:

- **same runner**, this pull request's method: the head over the base measured beside it.
- **across runners**, the previous method: the head of one run over the base of *another* run. Same code, different machine, different time, which is what comparing against a stored master result did. Every ordered pair of distinct runs is one sample.

Pairing on the same head measurement means the head's own noise cancels and only the choice of baseline varies:

| Benchmark | Same runner | Across runners | Same runner closer |
| --- | --- | --- | --- |
| WatDiv-File | 4.8% | 16.3% | 7/7 |
| WatDiv-TPF | 2.8% | 14.2% | 7/7 |
| BSBM-File | 2.0% | 8.7% | 6/7 |
| BSBM-TPF | 3.8% | 6.7% | 6/7 |
| **All** | **3.3%** | **11.5%** | **26/28** |

Mean absolute error falls 3.5x. A sign test over the 28 paired observations gives p = 3e-06.

The practical form of the same number, the share of measurements wrong by more than a given amount:

| Error exceeds | Same runner | Across runners |
| --- | --- | --- |
| 5% | 21% | 93% |
| 10% | 7% | 57% |
| 20% | 0% | 4% |

Under the previous method more than half of all readings were off by over 10% on code that had not changed, which is the scale of a typical optimisation. That is now 7%.

## Cost and scope

Job wall time, covering both versions and both installs, before and after the added repetitions:

| Job | Before | After |
| --- | --- | --- |
| `bsbm-tpf` | 6:22 | 6:25 |
| `bsbm-file` | 3:48 | 4:01 |
| `watdiv-file` | 5:04 | 5:19 |
| `watdiv-tpf` | 12:13 | 17:14 |

`watdiv-tpf` is the only one that grows materially, and it is not the critical path: the run it came from finished five minutes later on another job. `bsbm-file-10k` is not in the table because it postdates those measurements; its cost roughly doubles, like every other benchmark, from being run on the base as well as the head.

Fork pull requests skip the base run entirely, since `performance-compare` cannot post their comparison with a read-only token and the extra run would be wasted work. Pushes to `master`, tags, `feature/*` and `next` are unaffected: they still run a single measurement and store it through `performance-consolidate`.

`benchmark-web` is unchanged and stays excluded from pull requests. Its variance comes from querying live web sources rather than from the runner, and at roughly 28 minutes it is by far the slowest experiment, so paying more there buys nothing for this comparison.

## What this does not fix

A runner can drift over one job's lifetime, which shifts a whole benchmark rather than individual queries, and no amount of repetition inside a version's own run cancels that. It is what the residual 3.3% is made of. Every ratio below should read 1.00:

| Run | Settings | Order | WatDiv-File | WatDiv-TPF | BSBM-File | BSBM-TPF |
| --- | --- | --- | --- | --- | --- | --- |
| `6caeb74` | old | base first | 1.00 | 0.94 | 0.98 | 0.93 |
| `1e6ffd4` | old | head first | 0.87 | 0.99 | 0.98 | 0.97 |
| `763914f` | old | base first | 0.99 | 1.04 | 1.01 | 0.95 |
| `3947ead` | new | base first | 0.88 | 1.02 | 1.00 | 0.99 |
| `3947ead` re-run | new | base first | 0.96 | 1.00 | 1.00 | 0.98 |
| `3947ead` re-run | new | base first | 1.01 | 1.05 | 0.94 | 0.94 |
| `166bcce` | new | base first | 0.99 | 1.02 | 1.02 | 0.97 |

Two things are visible in it. Runs 1 and 3 are the same configuration in the same order, and WatDiv-TPF reads 0.94 in one and 1.04 in the other, so the drift is variance rather than a bias that a chosen run order could correct: run 2 deliberately swapped the order and did not invert the pattern. And run 4's WatDiv-File is a whole-benchmark shift, with nearly every one of its queries between 0.82 and 0.92, which is what job drift looks like as distinct from per-query noise.

So one reading in five is more than 5% out and one in fourteen more than 10%, the worst observed being 12.5%. A single run supports a claim of "this changed something" only above roughly 10%; anything smaller needs repetition. Averaging an interleaved ABBA ordering would cut the residual further, at the cost of running both versions twice.

Two caveats on the figures above. The across-runner numbers are reconstructed from these runs rather than produced by re-executing the old workflow; if anything they flatter it, since the real one compared against whatever result was last stored, possibly days older and on a different runner image. And all seven runs fall within about a day on `ubuntu-latest`, whose runner population shifts over time. `benchmark-bsbm-file-10k` has only one run and is excluded from the statistics.

## Verification

`actionlint` passes on the workflow. The nested-checkout failure was reproduced locally and the sibling layout confirmed to resolve all 336 packages. The `jq` baseline construction was run against a sample `psbr` output and its result diffed field for field against a real `data.js` from `comunica-performance-results`. `addBenchmarkEntry` in `github-action-benchmark` selects the last entry whose commit id differs from the current one, which the single wrapped base entry satisfies. The four changed experiments pass `jbr validate`. After merging #1801, a run confirmed the comparison reports all five benchmarks with both a head and a base value, `BSBM-File-10k` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMqRTuUgVLAWN5Xmbc2d5T

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMqRTuUgVLAWN5Xmbc2d5T)_