### PR TITLE
Disallow SERVICE clauses from targeting local files by default

### DIFF
--- a/engines/query-sparql-file/README.md
+++ b/engines/query-sparql-file/README.md
@@ -6,6 +6,16 @@ Comunica SPARQL is a SPARQL query engine for JavaScript for querying local and r
 
 This module is part of the [Comunica framework](https://comunica.dev/).
 
+Since this engine can read local files,
+`SERVICE` clauses are not allowed to target local files by default,
+as queries from untrusted parties could otherwise read arbitrary files from the local file system.
+If all queries originate from trusted parties,
+this can be enabled via the `serviceAllowFileTargets` context entry:
+
+```bash
+$ comunica-sparql-file path/to/my/file.ttl -c '{ "serviceAllowFileTargets": true }' "SELECT * WHERE { ... }"
+```
+
 ## Install
 
 ```bash

--- a/engines/query-sparql-file/test/QuerySparqlFile-test.ts
+++ b/engines/query-sparql-file/test/QuerySparqlFile-test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment setup-polly-jest/jest-environment-node */
 
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { QueryStringContext } from '@comunica/types';
 import 'jest-rdf';
 import { BindingsFactory } from '@comunica/utils-bindings-factory';
@@ -55,6 +56,35 @@ WHERE {
 
         const result = await arrayifyStream(await engine.queryBindings(query, context));
         expect(result).toEqualBindingsArray(expectedResult);
+      });
+    });
+
+    describe('SERVICE clauses targeting files', () => {
+      let source: string;
+      let serviceTarget: string;
+      let query: string;
+
+      beforeEach(() => {
+        source = path.join(path.relative(process.cwd(), __dirname), 'assets/dummy.ttl');
+        serviceTarget = pathToFileURL(path.join(__dirname, 'assets/dummy.jsonld')).href;
+        query = `SELECT * WHERE { SERVICE <${serviceTarget}> { ?s ?p ?o. } }`;
+      });
+
+      it('should not be allowed by default', async() => {
+        const context: QueryStringContext = { sources: [{ value: source }]};
+        await expect(async() => arrayifyStream(await engine.queryBindings(query, context))).rejects
+          .toThrow(`Dereferencing the local file '${serviceTarget}' is not allowed within this scope.`);
+      });
+
+      it('should produce no results by default when silent', async() => {
+        const querySilent = `SELECT * WHERE { SERVICE SILENT <${serviceTarget}> { ?s ?p ?o. } }`;
+        const context: QueryStringContext = { sources: [{ value: source }]};
+        await expect(arrayifyStream(await engine.queryBindings(querySilent, context))).resolves.toHaveLength(0);
+      });
+
+      it('should be allowed with serviceAllowFileTargets', async() => {
+        const context: QueryStringContext = { sources: [{ value: source }], serviceAllowFileTargets: true };
+        await expect(arrayifyStream(await engine.queryBindings(query, context))).resolves.toHaveLength(2);
       });
     });
   });

--- a/engines/query-sparql-file/test/QuerySparqlFile-test.ts
+++ b/engines/query-sparql-file/test/QuerySparqlFile-test.ts
@@ -86,6 +86,15 @@ WHERE {
         const context: QueryStringContext = { sources: [{ value: source }], serviceAllowFileTargets: true };
         await expect(arrayifyStream(await engine.queryBindings(query, context))).resolves.toHaveLength(2);
       });
+
+      it('should not block file sources that are passed as query sources', async() => {
+        const queryCombined = `SELECT * WHERE {
+          ?s ?p ?o.
+          OPTIONAL { SERVICE SILENT <${serviceTarget}> { ?s2 ?p2 ?o2. } }
+        }`;
+        const context: QueryStringContext = { sources: [{ value: source }]};
+        await expect(arrayifyStream(await engine.queryBindings(queryCombined, context))).resolves.toHaveLength(5);
+      });
     });
   });
 });

--- a/packages/actor-context-preprocess-convert-shortcuts/lib/ActorContextPreprocessConvertShortcuts.ts
+++ b/packages/actor-context-preprocess-convert-shortcuts/lib/ActorContextPreprocessConvertShortcuts.ts
@@ -56,6 +56,7 @@ export interface IActorContextPreprocessConvertShortcutsArgs extends IActorConte
    *   "queryTimestampHighResolution": "@comunica/actor-init-query:queryTimestampHighResolution",
    *   "httpProxyHandler": "@comunica/actor-http-proxy:httpProxyHandler",
    *   "lenient": "@comunica/actor-init-query:lenient",
+   *   "serviceAllowFileTargets": "@comunica/actor-init-query:serviceAllowFileTargets",
    *   "parseUnsupportedVersions": "@comunica/actor-init-query:parseUnsupportedVersions",
    *   "httpIncludeCredentials": "@comunica/bus-http:include-credentials",
    *   "httpAuth": "@comunica/bus-http:auth",

--- a/packages/actor-dereference-file/README.md
+++ b/packages/actor-dereference-file/README.md
@@ -7,6 +7,10 @@ A comunica File Dereference Actor.
 An [Dereference](https://github.com/comunica/comunica/tree/master/packages/bus-dereference) actor that
 resolves an URL to a local file (optionally starting with `file://`).
 
+This actor refuses to dereference files if the `@comunica/bus-dereference:blockFileAccess` context entry is enabled.
+This is for example set for SERVICE targets,
+so that queries from untrusted parties can not read arbitrary local files.
+
 [Click here if you just want to query with Comunica](https://comunica.dev/docs/query/).
 
 ## Install

--- a/packages/actor-dereference-file/lib/ActorDereferenceFile.ts
+++ b/packages/actor-dereference-file/lib/ActorDereferenceFile.ts
@@ -35,8 +35,7 @@ export class ActorDereferenceFile extends ActorDereference {
     // Dereferencing local files can be blocked within certain scopes, such as SERVICE targets.
     if (context.get(KeysDereference.blockFileAccess)) {
       return this.handleDereferenceErrors(action, new Error(
-        `Dereferencing the local file '${url}' is not allowed within this scope. ` +
-        `Within SERVICE clauses, this can be allowed via the 'serviceAllowFileTargets' context entry.`,
+        `Dereferencing the local file '${url}' is not allowed within this scope. `,
       ));
     }
 

--- a/packages/actor-dereference-file/lib/ActorDereferenceFile.ts
+++ b/packages/actor-dereference-file/lib/ActorDereferenceFile.ts
@@ -2,7 +2,7 @@ import { accessSync, createReadStream, constants } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { IActionDereference, IActorDereferenceArgs, IActorDereferenceOutput } from '@comunica/bus-dereference';
 import { ActorDereference } from '@comunica/bus-dereference';
-import { KeysInitQuery } from '@comunica/context-entries';
+import { KeysDereference, KeysInitQuery } from '@comunica/context-entries';
 import type { IActorTest, TestResult } from '@comunica/core';
 import { failTest, passTestVoid } from '@comunica/core';
 
@@ -29,7 +29,17 @@ export class ActorDereferenceFile extends ActorDereference {
     return URIRegex.exec(str) !== null;
   }
 
-  public async run({ url, context }: IActionDereference): Promise<IActorDereferenceOutput> {
+  public async run(action: IActionDereference): Promise<IActorDereferenceOutput> {
+    const { url, context } = action;
+
+    // Dereferencing local files can be blocked within certain scopes, such as SERVICE targets.
+    if (context.get(KeysDereference.blockFileAccess)) {
+      return this.handleDereferenceErrors(action, new Error(
+        `Dereferencing the local file '${url}' is not allowed within this scope. ` +
+        `Within SERVICE clauses, this can be allowed via the 'serviceAllowFileTargets' context entry.`,
+      ));
+    }
+
     const requestTimeStart = Date.now();
     return {
       data: createReadStream(getPath(url)),

--- a/packages/actor-dereference-file/test/ActorDereferenceFile-test.ts
+++ b/packages/actor-dereference-file/test/ActorDereferenceFile-test.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { IActorDereferenceOutput } from '@comunica/bus-dereference';
 import { ActorDereference } from '@comunica/bus-dereference';
+import { KeysDereference, KeysInitQuery } from '@comunica/context-entries';
 import { ActionContext, Bus } from '@comunica/core';
 import type { IActionContext } from '@comunica/types';
 import { stringify as streamToString } from '@jeswr/stream-to-string';
@@ -91,6 +92,23 @@ describe('ActorDereferenceFile', () => {
           url: pathToFileURL(p).href,
         },
       );
+    });
+
+    it('should not run when file access is blocked', async() => {
+      const p = path.join(__dirname, 'dummy.ttl');
+      context = context.set(KeysDereference.blockFileAccess, true);
+      await expect(actor.run({ url: p, context })).rejects
+        .toThrow(`Dereferencing the local file '${p}' is not allowed within this scope.`);
+    });
+
+    it('should run with an empty stream when file access is blocked in lenient mode', async() => {
+      const p = path.join(__dirname, 'dummy.ttl');
+      context = context
+        .set(KeysDereference.blockFileAccess, true)
+        .set(KeysInitQuery.lenient, true);
+      const result = await actor.run({ url: p, context });
+      await expect(streamToString(result.data)).resolves.toBe('');
+      expect(result).toMatchObject<Partial<IActorDereferenceOutput>>({ exists: false, status: 404 });
     });
 
     it('should run for file:/// paths', async() => {

--- a/packages/actor-optimize-query-operation-query-source-identify/README.md
+++ b/packages/actor-optimize-query-operation-query-source-identify/README.md
@@ -9,6 +9,9 @@ It will store all query sources in the context using `KeysQueryOperation.querySo
 and sources corresponding to the SERVICE clauses within the query will be stored
 using `KeysQueryOperation.serviceSources`.
 
+Sources of SERVICE clauses are not allowed to be dereferenced from the local file system,
+unless the `serviceAllowFileTargets` context entry is enabled.
+
 This actor also contains a cache so that identical sources will be reused across multiple query executions.
 This cache can be invalidated via `engine.invalidateHttpCache()`.
 
@@ -43,6 +46,12 @@ After installing, this package can be added to your engine's configuration as fo
   ]
 }
 ```
+
+### Context Parameters
+
+* `serviceAllowFileTargets`: Optional flag indicating if SERVICE clauses may target local files, defaults to `false`.
+  Enabling this allows queries to read arbitrary local files,
+  which should only be done if all queries originate from trusted parties.
 
 ### Config Parameters
 

--- a/packages/actor-optimize-query-operation-query-source-identify/lib/ActorOptimizeQueryOperationQuerySourceIdentify.ts
+++ b/packages/actor-optimize-query-operation-query-source-identify/lib/ActorOptimizeQueryOperationQuerySourceIdentify.ts
@@ -7,7 +7,7 @@ import type {
 } from '@comunica/bus-optimize-query-operation';
 import { ActorOptimizeQueryOperation } from '@comunica/bus-optimize-query-operation';
 import type { MediatorQuerySourceIdentify } from '@comunica/bus-query-source-identify';
-import { KeysInitQuery, KeysQueryOperation, KeysStatistics } from '@comunica/context-entries';
+import { KeysDereference, KeysInitQuery, KeysQueryOperation, KeysStatistics } from '@comunica/context-entries';
 import type { TestResult, IActorTest } from '@comunica/core';
 import { passTestVoid, ActionContext } from '@comunica/core';
 import type {
@@ -22,6 +22,10 @@ import type {
 import { Algebra, algebraUtils } from '@comunica/utils-algebra';
 import { passFullOperationToSource } from '@comunica/utils-query-operation';
 import { LRUCache } from 'lru-cache';
+
+// Cache key prefix for sources that are identified as SERVICE targets,
+// as these are identified with a different source context than regular sources.
+const KEY_PREFIX_SERVICE = 'service:';
 
 /**
  * A comunica Query Source Identify Optimize Query Operation Actor.
@@ -45,7 +49,14 @@ export class ActorOptimizeQueryOperationQuerySourceIdentify extends ActorOptimiz
     const cache = this.cache;
     if (cache) {
       this.httpInvalidator.addInvalidateListener(
-        ({ url }: IActionHttpInvalidate) => url ? cache.delete(url) : cache.clear(),
+        ({ url }: IActionHttpInvalidate) => {
+          if (url) {
+            cache.delete(url);
+            cache.delete(KEY_PREFIX_SERVICE + url);
+          } else {
+            cache.clear();
+          }
+        },
       );
     }
   }
@@ -99,11 +110,17 @@ export class ActorOptimizeQueryOperationQuerySourceIdentify extends ActorOptimiz
           },
         },
       });
+      // Unless explicitly allowed, SERVICE targets may not be dereferenced from the local file system,
+      // as queries from untrusted parties could otherwise read arbitrary local files.
+      const serviceContext = context.get(KeysInitQuery.serviceAllowFileTargets) ?
+        undefined :
+        new ActionContext().set(KeysDereference.blockFileAccess, true);
       const serviceSources: Record<string, IQuerySourceWrapper> = Object.fromEntries(await Promise.all([ ...services ]
         .map(async service => [ service, await this.identifySource({
           type: this.serviceForceSparqlEndpoint ? 'sparql' : undefined,
           value: service,
-        }, context) ])));
+          context: serviceContext,
+        }, context, KEY_PREFIX_SERVICE) ])));
       if (services.size > 0) {
         context = context.set(KeysQueryOperation.serviceSources, serviceSources);
       }
@@ -127,13 +144,17 @@ export class ActorOptimizeQueryOperationQuerySourceIdentify extends ActorOptimiz
   public identifySource(
     querySourceUnidentified: QuerySourceUnidentifiedExpanded,
     context: IActionContext,
+    cacheKeyPrefix = '',
   ): Promise<IQuerySourceWrapper> {
     let sourcePromise: Promise<IQuerySourceWrapper> | undefined;
 
     // Try to read from cache
     // Only sources based on string values (e.g. URLs) are supported!
-    if (typeof querySourceUnidentified.value === 'string' && this.cache) {
-      sourcePromise = this.cache.get(querySourceUnidentified.value)!;
+    const cacheKey = typeof querySourceUnidentified.value === 'string' ?
+      cacheKeyPrefix + querySourceUnidentified.value :
+      undefined;
+    if (cacheKey !== undefined && this.cache) {
+      sourcePromise = this.cache.get(cacheKey)!;
     }
 
     // If not in cache, identify the source
@@ -142,8 +163,8 @@ export class ActorOptimizeQueryOperationQuerySourceIdentify extends ActorOptimiz
         .then(({ querySource }) => querySource);
 
       // Set in cache
-      if (typeof querySourceUnidentified.value === 'string' && this.cache) {
-        this.cache.set(querySourceUnidentified.value, sourcePromise);
+      if (cacheKey !== undefined && this.cache) {
+        this.cache.set(cacheKey, sourcePromise);
       }
     }
 

--- a/packages/actor-optimize-query-operation-query-source-identify/test/ActorOptimizeQueryOperationQuerySourceIdentify-test.ts
+++ b/packages/actor-optimize-query-operation-query-source-identify/test/ActorOptimizeQueryOperationQuerySourceIdentify-test.ts
@@ -1,7 +1,7 @@
 import type { ActorHttpInvalidateListenable } from '@comunica/bus-http-invalidate';
 import type { MediatorOptimizeQueryOperation } from '@comunica/bus-optimize-query-operation';
 import type { IActionQuerySourceIdentify, MediatorQuerySourceIdentify } from '@comunica/bus-query-source-identify';
-import { KeysInitQuery, KeysQueryOperation, KeysStatistics }
+import { KeysDereference, KeysInitQuery, KeysQueryOperation, KeysStatistics }
   from '@comunica/context-entries';
 import type { IAction } from '@comunica/core';
 import { ActionContext, ActionContextKey, Bus } from '@comunica/core';
@@ -16,6 +16,9 @@ import '@comunica/utils-jest';
 
 const AF = new AlgebraFactory();
 const DF = new DataFactory();
+
+// The source context that SERVICE targets are identified with by default
+const serviceContextBlocked = new ActionContext().set(KeysDereference.blockFileAccess, true);
 
 describe('ActorOptimizeQueryOperationQuerySourceIdentify', () => {
   let bus: any;
@@ -123,10 +126,54 @@ describe('ActorOptimizeQueryOperationQuerySourceIdentify', () => {
           source2: { ofUnidentified: expect.objectContaining({ value: 'source2' }) },
         });
         expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledTimes(2);
-        expect(mediatorQuerySourceIdentify.mediate)
-          .toHaveBeenCalledWith({ querySourceUnidentified: { value: 'source1' }, context: expect.anything() });
-        expect(mediatorQuerySourceIdentify.mediate)
-          .toHaveBeenCalledWith({ querySourceUnidentified: { value: 'source2' }, context: expect.anything() });
+        expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledWith({
+          querySourceUnidentified: { value: 'source1', context: serviceContextBlocked },
+          context: expect.anything(),
+        });
+        expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledWith({
+          querySourceUnidentified: { value: 'source2', context: serviceContextBlocked },
+          context: expect.anything(),
+        });
+      });
+
+      it('with SERVICE clauses and allowed file targets', async() => {
+        contextIn = contextIn.set(KeysInitQuery.serviceAllowFileTargets, true);
+        await actor.run({ context: contextIn, operation: operationService });
+        expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledTimes(2);
+        expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledWith({
+          querySourceUnidentified: { value: 'source1', context: undefined },
+          context: expect.anything(),
+        });
+        expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledWith({
+          querySourceUnidentified: { value: 'source2', context: undefined },
+          context: expect.anything(),
+        });
+      });
+
+      it('should not reuse cache entries of SERVICE targets for regular sources', async() => {
+        const { context: contextOutService } = await actor.run({
+          context: contextIn,
+          operation: operationService,
+        });
+        const { context: contextOutSource } = await actor.run({
+          context: contextIn.set(KeysInitQuery.querySourcesUnidentified, [ 'source1' ]),
+          operation,
+        });
+        expect(contextOutService.get<Record<string, IQuerySourceWrapper>>(KeysQueryOperation.serviceSources)!.source1)
+          .not.toBe(contextOutSource.get<IQuerySourceWrapper[]>(KeysQueryOperation.querySources)![0]);
+      });
+
+      it('should allow cache invalidation of SERVICE targets for a specific url', async() => {
+        const { context: contextOut1 } = await actor.run({ context: contextIn, operation: operationService });
+
+        listener({ url: 'source1' });
+
+        const { context: contextOut2 } = await actor.run({ context: contextIn, operation: operationService });
+
+        const services1 = contextOut1.get<Record<string, IQuerySourceWrapper>>(KeysQueryOperation.serviceSources)!;
+        const services2 = contextOut2.get<Record<string, IQuerySourceWrapper>>(KeysQueryOperation.serviceSources)!;
+        expect(services1.source1).not.toBe(services2.source1);
+        expect(services1.source2).toBe(services2.source2);
       });
 
       it('with SERVICE clauses but the single source accepts the full query', async() => {
@@ -431,11 +478,11 @@ describe('ActorOptimizeQueryOperationQuerySourceIdentify', () => {
       });
       expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledTimes(2);
       expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledWith({
-        querySourceUnidentified: { type: 'sparql', value: 'source1' },
+        querySourceUnidentified: { type: 'sparql', value: 'source1', context: serviceContextBlocked },
         context: expect.anything(),
       });
       expect(mediatorQuerySourceIdentify.mediate).toHaveBeenCalledWith({
-        querySourceUnidentified: { type: 'sparql', value: 'source2' },
+        querySourceUnidentified: { type: 'sparql', value: 'source2', context: serviceContextBlocked },
         context: expect.anything(),
       });
     });

--- a/packages/context-entries/lib/Keys.ts
+++ b/packages/context-entries/lib/Keys.ts
@@ -160,6 +160,12 @@ export const KeysInitQuery = {
    */
   lenient: new ActionContextKey<boolean>('@comunica/actor-init-query:lenient'),
   /**
+   * If SERVICE clauses are allowed to target local files.
+   * This is disabled by default, as queries could otherwise read arbitrary local files,
+   * which is problematic when queries originate from untrusted parties.
+   */
+  serviceAllowFileTargets: new ActionContextKey<boolean>('@comunica/actor-init-query:serviceAllowFileTargets'),
+  /**
    * By default, errors will be emitted if parsers encounter unsupported versions.
    * Setting this flag to true will silence those checks.
    * Errors may still be emitted if unsupported grammar is encountered.
@@ -397,6 +403,15 @@ export const KeysQuerySourceIdentify = {
    * This means that sources annotated with this flag are considered incomplete until all links have been traversed.
    */
   traverse: new ActionContextKey<boolean>('@comunica/bus-query-source-identify:traverse'),
+};
+
+export const KeysDereference = {
+  /**
+   * If local files may not be dereferenced within the current scope.
+   * This is for example set when dereferencing SERVICE targets,
+   * to avoid exposing local files to queries from untrusted parties.
+   */
+  blockFileAccess: new ActionContextKey<boolean>('@comunica/bus-dereference:blockFileAccess'),
 };
 
 export const KeysRdfUpdateQuads = {

--- a/packages/types/lib/IQueryContext.ts
+++ b/packages/types/lib/IQueryContext.ts
@@ -38,6 +38,7 @@ export interface IQueryContextCommon {
   queryTimestampHighResolution?: DOMHighResTimeStamp;
   httpProxyHandler?: IProxyHandler;
   lenient?: boolean;
+  serviceAllowFileTargets?: boolean;
   parseUnsupportedVersions?: boolean;
   httpIncludeCredentials?: boolean;
   httpAuth?: string;


### PR DESCRIPTION
Before this change, any engine that can dereference local files would happily resolve a `SERVICE <file:///...>` target from the local file system. For `comunica-sparql-file` (the only engine bundling `@comunica/actor-dereference-file`), and especially for `comunica-sparql-file-http`, this means that a query from an untrusted party can read arbitrary local files:

```sparql
SELECT * WHERE { SERVICE <file:///etc/some-secret.ttl> { ?s ?p ?o } }
```

## Approach

Rather than pattern-matching on the SERVICE IRI, the restriction is enforced at the place that actually grants local file access:

* `ActorOptimizeQueryOperationQuerySourceIdentify` now identifies SERVICE targets with a source context in which the new `@comunica/bus-dereference:blockFileAccess` entry is enabled. This context follows the source into query execution, so it also covers any links that are traversed from the SERVICE target.
* `ActorDereferenceFile` refuses to dereference within such a scope, via `handleDereferenceErrors`, so `SERVICE SILENT` and lenient mode keep their usual semantics (a warning and an empty result, instead of a hard error).
* The new `serviceAllowFileTargets` context entry (`@comunica/actor-init-query:serviceAllowFileTargets`) turns it back on for those who need it:

  ```bash
  $ comunica-sparql-file file.ttl -c '{ "serviceAllowFileTargets": true }' "SELECT * WHERE { ... }"
  ```

Engines without a file dereference actor are unaffected, as blocking only applies to local file dereferencing.

Since SERVICE sources are now identified with a different source context than regular sources, they are cached under a separate cache key, so that a blocked SERVICE source can never be reused for a source that the user explicitly passed (and vice versa). Cache invalidation covers both keys.

## Notes

* This is a behavioural break for anyone relying on `SERVICE <file://...>` in `comunica-sparql-file`.
* `LOAD <file:///...>` is a comparable vector, but it is only reachable when updates are explicitly enabled (`comunica-sparql-file-http -u`), so it is left out of scope here.

## Tests

* Unit tests for the blocked and lenient paths in `ActorDereferenceFile`, and for the SERVICE source context, the `serviceAllowFileTargets` entry, and the separate cache keys in `ActorOptimizeQueryOperationQuerySourceIdentify`.
* System tests in `query-sparql-file` covering the denied, silent, and explicitly allowed cases.
* Full test suite passes (6879 tests), both changed source files remain at 100% coverage, and lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SCVUhg7mCAq7CPZZxuCvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019SCVUhg7mCAq7CPZZxuCvQ)_